### PR TITLE
OIDC - Test grant type on token call

### DIFF
--- a/aidants_connect_web/tests/test_views.py
+++ b/aidants_connect_web/tests/test_views.py
@@ -166,6 +166,28 @@ class TokenTests(TestCase):
 
             self.assertEqual(response_json, awaited_response)
 
+    def test_token_should_respond_403_when_given_wrong_grant_type(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "FC_AS_FS_ID": "test_client_id",
+                "FC_AS_FS_SECRET": "test_client_secret",
+                "FC_CALLBACK_URL": "test_url.test_url",
+                "HOST": "localhost",
+            },
+        ):
+            response = self.client.post(
+                "/token/",
+                {
+                    "grant_type": "not_authorization_code",
+                    "redirect_uri": "test_url.test_url/oidc_callback",
+                    "client_id": "test_client_id",
+                    "client_secret": "test_client_secret",
+                    "code": "test_code",
+                },
+            )
+            self.assertEqual(response.status_code, 403)
+
 
 class UserInfoTests(TestCase):
     def test_token_url_triggers_token_view(self):

--- a/aidants_connect_web/views.py
+++ b/aidants_connect_web/views.py
@@ -71,6 +71,9 @@ def token(request):
         log.info("This method is a get")
         return HttpResponse("You did a GET on a POST only route")
 
+    if request.POST.get("grant_type") != "authorization_code":
+        return HttpResponseForbidden()
+
     code = request.POST.get("code")
     log.info("the code is")
     log.info(code)


### PR DESCRIPTION
This PR add a test if the /token/ call has the wrong grant type