### PR TITLE
add tooltips to fields

### DIFF
--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -8,3 +8,41 @@ body {
 main {
   flex-grow: 1;
 }
+
+.has-tooltip label {
+    display: inline-block;
+}
+
+.has-tooltip {
+    position: relative;
+}
+
+.tooltip-info {
+    display: inline-block;
+    background-color: #8393a7;
+    border-radius: 50%;
+    width: 1.5em;
+    height: 1.5em;
+    color: #fff;
+    text-align: center;
+    font-weight: 700;
+    position: absolute;
+    margin: 0.1em 0.5em;
+    transform: scale(0.75);
+}
+
+.tooltip-info:hover::after {
+    color: #ffffff;
+    padding: 0.25em 0.75em;
+    border-radius: 3px;
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 3em;
+    top: 0.75em;
+    transform: translateY(-50%);
+    background-color: #8393a7;
+    z-index: 2;
+    width: auto;
+    min-width: 25em;
+    text-align: left;
+}

--- a/aidants_connect_web/templates/aidants_connect_web/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/authorize.html
@@ -5,18 +5,54 @@
   <div class="container">
     <form method="post" >
       <h2 id="welcome_aidant">Bienvenue, aidant</h2>
+      <p>Vous pouvez entrer ici les informations de l’usager pour qui vous allez faire les démarches.</p>
       {% csrf_token %}
       {% if form.errors %}
       <div class="notification">
           {{ form.errors }}
       </div>
       {% endif %}
-      {% for field in form %}
       <div class="form__group">
-        <label>{{ field.label_tag }}</label>
-        {{ field }}
+        <div class="has-tooltip">
+          <label>{{ form.given_name.label_tag }}</label>
+          <span class="tooltip-info" data-tooltip="Votre ou vos prénoms, séparés par une espace">?️</span>
+        </div>
+        {{ form.given_name }}
       </div>
-      {% endfor %}
+      <div class="form__group">
+        <label>{{ form.family_name.label_tag }}</label>
+        {{ form.family_name }}
+      </div>
+      <div class="form__group">
+        <label>{{ form.preferred_username.label_tag }}</label>
+        {{ form.preferred_username }}
+      </div>
+      <div class="form__group">
+        <label>{{ form.birthdate.label_tag }}</label>
+        {{ form.birthdate }}
+      </div>
+      <div class="form__group">
+        <label>{{ form.gender.label_tag }}</label>
+        {{ form.gender }}
+      </div>
+      <div class="form__group">
+        <div class="has-tooltip">
+          <label>{{ form.birthplace.label_tag }}</label>
+          <span class="tooltip-info" data-tooltip="Code de référence de la commune de naissance à 5 caractères">?</span>
+        </div>
+        {{ form.birthplace }}
+      </div>
+      <div class="form__group">
+        <div class="has-tooltip">
+          <label>{{ form.birthcountry.label_tag }}</label>
+          <span class="tooltip-info" data-tooltip="Code de référence du pays de naissance (99100 pour la France)">?</span>
+        </div>
+        {{ form.birthcountry }}
+      </div>
+      <div class="form__group">
+        <label>{{ form.email.label_tag }}</label>
+        {{ form.email }}
+      </div>
       <div class="form__group">
         <input type="hidden" name="state" value="{{state}}" />
         <input class="button" type="submit" id="submit" value="Envoyer les informations de l'usager" />

--- a/aidants_connect_web/tests/test_functional.py
+++ b/aidants_connect_web/tests/test_functional.py
@@ -46,6 +46,8 @@ class LoginPage(StaticLiveServerTestCase):
         submit_button.click()
         welcome_aidant = self.selenium.find_element_by_id("welcome_aidant").text
         self.assertEqual(welcome_aidant, "Bienvenue, aidant")
+        tooltips = self.selenium.find_elements_by_class_name("tooltip-info")
+        self.assertEqual(len(tooltips), 3)
         # button = self.browser.find_element_by_id("submit")
 
 


### PR DESCRIPTION
Add the possibility to add tooltips to labels for a description of what is needed to fill the field.

![image](https://user-images.githubusercontent.com/1301085/58185016-8510bb80-7cb2-11e9-8378-b623bee493ed.png)
