### PR TITLE
Fix the FI connection

### DIFF
--- a/aidants_connect_web/tests/test_views.py
+++ b/aidants_connect_web/tests/test_views.py
@@ -185,7 +185,7 @@ class TokenTests(TestCase):
         self.connection.save()
         self.fc_request = {
             "grant_type": "authorization_code",
-            "redirect_uri": "test_url.test_url/oidc_callback",
+            "redirect_uri": "test_url.test_url",
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
             "code": "test_code",

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -230,6 +230,8 @@ def token(request):
         request.POST.get("client_secret") == fc_client_secret,
     ]
     if not all(rules):
+        log.info("403: Rules are not all abided")
+        log.info(rules)
         return HttpResponseForbidden()
 
     code = request.POST.get("code")
@@ -237,14 +239,13 @@ def token(request):
     try:
         connection = Connection.objects.get(code=code)
     except ObjectDoesNotExist:
-        log.info("/token No connection corresponds to the code")
+        log.info("403: /token No connection corresponds to the code")
         log.info(code)
         return HttpResponseForbidden()
 
     if connection.expiresOn < timezone.now():
-        log.info("Code expired")
+        log.info("403: Code expired")
         return HttpResponseForbidden()
-
     id_token = {
         # The audience, the Client ID of your Auth0 Application
         "aud": fc_client_id,
@@ -282,7 +283,7 @@ def user_info(request):
     auth_header = request.META.get("HTTP_AUTHORIZATION")
 
     if not auth_header:
-        log.info("missing auth header")
+        log.info("403: Missing auth header")
         return HttpResponseForbidden()
 
     pattern = re.compile(r"^Bearer\s([A-Z-a-z-0-9-_/-]+)$")

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -225,7 +225,7 @@ def token(request):
 
     rules = [
         request.POST.get("grant_type") == "authorization_code",
-        request.POST.get("redirect_uri") == f"{fc_callback_url}/oidc_callback",
+        request.POST.get("redirect_uri") == fc_callback_url,
         request.POST.get("client_id") == fc_client_id,
         request.POST.get("client_secret") == fc_client_secret,
     ]


### PR DESCRIPTION
This PR puts the whole `FC_AS_FI_CALLBACK_URL` in the `envars`.
It also adds explicit error messages before a `403`