### PR TITLE
Allow admin to use a postgres_url as envar

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ DATABASE_USER=aidants_connect_team
 DATABASE_PASSWORD='' or <insert_your_data>
 DATABASE_URL='' or <insert_your_data>
 DATABASE_PORT='' or <insert_your_data>
+# Can be replaced by a POSTGRES_URL (from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
 
 FC_AS_FS_BASE_URL=<insert_your_data>
 FC_AS_FS_ID=<insert_your_data>

--- a/aidants_connect/postgres_url.py
+++ b/aidants_connect/postgres_url.py
@@ -1,0 +1,91 @@
+# from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+def turn_psql_url_into_param(postgres_url: str) -> dict:
+    """
+    >>> turn_psql_url_into_param(
+    ... 'postgres://USERNAME:PASSWORD@URL:PORT/USER?sslmode=SSLMODE') == {
+    ... 'db_user':'USERNAME', 'db_password': 'PASSWORD', 'db_url': 'URL', 'db_port':
+    ... 'PORT', 'db_name': 'USER', 'sslmode': 'SSLMODE'}
+    True
+    >>> turn_psql_url_into_param(
+    ... 'USERNAME:PASSWORD@URL:PORT/USER?sslmode=SSLMODE')
+    Traceback (most recent call last):
+        ...
+    AttributeError: The database URL is not well formated
+
+    >>> turn_psql_url_into_param(
+    ... 'postgres://USERNAME:PASSWORD@URL:PORT/USER') == {
+    ... 'db_user': 'USERNAME', 'db_password': 'PASSWORD', 'db_url': 'URL',
+    ... 'db_port': 'PORT', 'db_name': 'USER'}
+    True
+
+    >>> turn_psql_url_into_param("postgresql://") == {}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://localhost') == {'db_url':
+    ... 'localhost'}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://localhost:5433') == {'db_url':
+    ... 'localhost', 'db_port': '5433'}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://localhost/mydb') == {'db_url':
+    ... 'localhost', 'db_name': 'mydb'}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://user@localhost') == {'db_url':
+    ... 'localhost', 'db_user': 'user'}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://user:secret@localhost') == {
+    ... 'db_url': 'localhost', 'db_user': 'user', 'db_password': 'secret'}
+    True
+
+    >>> turn_psql_url_into_param('postgresql://oto@localhost/ther?'
+    ... 'connect_timeout=10&application_name=myapp') == {
+    ... 'db_url': 'localhost', 'db_user': 'oto', 'db_name': 'ther',
+    ... 'connect_timeout': '10', 'application_name': 'myapp'}
+    True
+    """
+
+    if not postgres_url.startswith(("postgres://", "postgresql://")):
+        raise AttributeError("The database URL is not well formated")
+    response = {}
+
+    # Get parameters
+    params_start = postgres_url.rfind("?")
+    if not params_start == -1:
+        params = postgres_url[params_start + 1:]
+        params = [param.split("=") for param in params.split("&")]
+        for param in params:
+            response[param[0]] = param[1]
+        user_and_db_info = postgres_url[postgres_url.find("://") + 3: params_start]
+    else:
+        user_and_db_info = postgres_url[postgres_url.find("://") + 3:]
+
+    if not user_and_db_info:
+        return response
+
+    # User information
+    if "@" in user_and_db_info:
+        user_info, db_info = tuple(user_and_db_info.split("@"))
+
+        user_info = user_info.split(":")
+        response["db_user"] = user_info[0]
+        if len(user_info) > 1:
+            response["db_password"] = user_info[1]
+    else:
+        db_info = user_and_db_info
+
+    # Database information
+
+    db_info = db_info.split("/")
+    if len(db_info) > 1:
+        response["db_name"] = db_info[1]
+
+    url_and_port = db_info[0]
+    url_and_port = url_and_port.split(":")
+    response["db_url"] = url_and_port[0]
+    if len(url_and_port) > 1:
+        response["db_port"] = url_and_port[1]
+    return response

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 from dotenv import load_dotenv
+from aidants_connect.postgres_url import turn_psql_url_into_param
 
 load_dotenv(verbose=True)
 
@@ -99,19 +100,36 @@ WSGI_APPLICATION = "aidants_connect.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": os.getenv("DATABASE_NAME"),
-        "USER": os.getenv("DATABASE_USER"),
-        "PASSWORD": os.getenv("DATABASE_PASSWORD"),
-        "HOST": os.getenv("DATABASE_URL"),
-        "PORT": os.getenv("DATABASE_PORT"),
+postgres_url = os.getenv("POSTGRESQL_URL")
+if postgres_url:
+    environment_info = turn_psql_url_into_param(postgres_url)
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": environment_info.get("db_name"),
+            "USER": environment_info.get("db_user"),
+            "PASSWORD": environment_info.get("db_password"),
+            "HOST": environment_info.get("db_host"),
+            "PORT": environment_info.get("db_port"),
+        }
     }
-}
 
-ssl_option = os.getenv("DATABASE_SSL")
+    ssl_option = environment_info.get("sslmode")
+
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.getenv("DATABASE_NAME"),
+            "USER": os.getenv("DATABASE_USER"),
+            "PASSWORD": os.getenv("DATABASE_PASSWORD"),
+            "HOST": os.getenv("DATABASE_URL"),
+            "PORT": os.getenv("DATABASE_PORT"),
+        }
+    }
+
+    ssl_option = os.getenv("DATABASE_SSL")
+
 if ssl_option:
     DATABASES["default"]["OPTIONS"] = {"sslmode": ssl_option}
 


### PR DESCRIPTION
Allows admins to use a POSTGRES_URL (from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) to efficiently add database information