### PR TITLE
Remplace l'authentification login/password par un envoi d'email avec un lien contenant un token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 venv/*
+aidants_connect/tmp_email_as_file/**
 .idea/*
 **/__pycache__/**
 db.sqlite3
 geckodriver.log
 
 .env
-.integ.env
 staticfiles
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ FC_AS_FI_ID=<insert_your_data>
 FC_AS_FI_SECRET=<insert_your_data>
 FC_AS_FI_CALLBACK_URL=<insert_your_data>
 
+# if you are debugging, and want to use the file based email backend
+EMAIL_BACKEND = django.core.mail.backends.filebased.EmailBackend
+
+# If you want to use the default smtp backend
+EMAIL_HOST = <insert_your_data>
+EMAIL_PORT = <insert_your_data>
+EMAIL_HOST_USER = <insert_your_data>
+EMAIL_HOST_PASSWORD = <insert_your_data>
+
+# email address the connexion email is sent from
+MAGICAUTH_FROM_EMAIL = "test@domain.user"
+
 # Optional
 DATABASE_SSL
 DEBUG

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -239,12 +239,21 @@ DEMARCHES = {
 
 # Magic Auth
 MAGICAUTH_EMAIL_FIELD = "email"
-MAGICAUTH_FROM_EMAIL = "test@domain.user"
+MAGICAUTH_FROM_EMAIL = os.getenv("MAGICAUTH_FROM_EMAIL")
 MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME = "dashboard"
 MAGICAUTH_LOGIN_VIEW_TEMPLATE = "login/login.html"
 MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE = "login/email_sent.html"
 
-EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
+# Emails
+EMAIL_BACKEND = os.getenv("EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend")
+## if file based email backend is used (debug)
 EMAIL_FILE_PATH = (
-    os.path.dirname(os.path.abspath(__file__)) + "/tmp/app-messages"
-)  # change this to a proper location
+    os.path.dirname(os.path.abspath(__file__)) + "/tmp_email_as_file"
+)
+## if smtp backend is used
+EMAIL_HOST = os.getenv("EMAIL_HOST", None)
+EMAIL_PORT = os.getenv("EMAIL_PORT", None)
+EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", None)
+EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", None)
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
+EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -57,6 +57,7 @@ ALLOWED_HOSTS = [os.environ["HOST"]]
 
 INSTALLED_APPS = [
     "django.contrib.admin",
+    "magicauth",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
@@ -74,6 +75,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django.contrib.sites.middleware.CurrentSiteMiddleware",
 ]
 
 ROOT_URLCONF = "aidants_connect.urls"
@@ -234,3 +236,10 @@ DEMARCHES = {
         "/loisirs.png",
     },
 }
+
+# Magic Auth
+MAGICAUTH_EMAIL_FIELD = "email"
+MAGICAUTH_FROM_EMAIL = "test@domain.user"
+MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME = "dashboard"
+MAGICAUTH_LOGIN_VIEW_TEMPLATE = "login/login.html"
+MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE = "login/email_sent.html"

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -243,3 +243,8 @@ MAGICAUTH_FROM_EMAIL = "test@domain.user"
 MAGICAUTH_LOGGED_IN_REDIRECT_URL_NAME = "dashboard"
 MAGICAUTH_LOGIN_VIEW_TEMPLATE = "login/login.html"
 MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE = "login/email_sent.html"
+
+EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
+EMAIL_FILE_PATH = (
+    os.path.dirname(os.path.abspath(__file__)) + "/tmp/app-messages"
+)  # change this to a proper location

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,13 +1,7 @@
 from django.contrib import admin
 from django.urls import path, include
-from django.contrib.auth import views
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path(
-        "accounts/login/",
-        views.LoginView.as_view(template_name="registration/login.html"),
-        name="login",
-    ),
     path("", include("aidants_connect_web.urls")),
 ]

--- a/aidants_connect_web/static/css/login.css
+++ b/aidants_connect_web/static/css/login.css
@@ -1,3 +1,4 @@
-input.button {
+button.button {
   margin-top: 2em;
+  margin-bottom: 2em;
 }

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -19,7 +19,7 @@
           </li>
           {% else %}
           <li class="nav__item">
-            <a href="{% url 'dashboard' %}">
+            <a href="{% url 'login' %}">
               Se connecter
             </a>
           {% endif %}

--- a/aidants_connect_web/templates/login/email_sent.html
+++ b/aidants_connect_web/templates/login/email_sent.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/main.html' %}
+{% load static %}
+{% block extracss %}
+<link href="{% static 'css/login.css' %}" rel="stylesheet">
+{% endblock extracss %}
+{% block content %}
+  <div class="page">
+    <div class="main-page">
+      <section class="section section-white">
+        <div class="container">
+          <h1>Un email vous a été envoyé pour vous connecter.</h1>
+        </div>
+        <div class="container">
+           Si vous ne le recevez pas, vous pouvez <a href="{% url 'magicauth-login' %}" class="btn btn-secondary">réessayer</a>.
+        </div>
+      </section>
+    </div>
+{% endblock content %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -1,0 +1,48 @@
+{% extends 'layouts/main.html' %}
+{% load static %}
+{% block extracss %}
+<link href="{% static 'css/login.css' %}" rel="stylesheet">
+{% endblock extracss %}
+{% block content %}
+<div class="page">
+  <div class="main-page">
+    <section class="section section-white">
+    <div class="container">
+      <form class="" method="post">
+        {% csrf_token %}
+          {% if user.is_authenticated %}
+            <div class="alert alert-info text-center" role="alert">
+              Vous êtes déjà connecté
+            </div>
+            <div class="text-center">
+              <a href="{% url LOGGED_IN_REDIRECT_URL_NAME %}" class="btn btn-success">Accédez à l'accueil</a>
+              <a href="{% url LOGOUT_URL_NAME %}" class="btn btn-warning">Déconnectez-vous</a>
+            </div>
+          {% else %}
+            {% if messages %}
+              <div class="text-center" role="alert">
+                {% for message in messages %}
+                  <p {% if message.tags %} class="alert alert-{{ message.tags }}"{% endif %}>{{ message }}</p>
+                {% endfor %}
+              </div>
+            {% endif %}
+            <div class="form__group">
+              <h1>Se connecter</h1>
+              <input type="email" name="email" class="form-control {% if form.errors %}state-invalid {% endif %}"
+                               id="id_email" aria-describedby="emailHelp" placeholder="Votre email" required/>
+              {% for error in form.email.errors %}
+                <div class="alet alert-danger text-center">{{ error }}</div>
+              {% endfor %}
+            </div>
+            <button type="submit" class="button">Valider</button>
+          {% endif %}
+      </form>
+      <div class="text-center text-muted">
+        Vous rencontrez des difficultés pour vous connecter?
+        <a href="mailto:aidantsconnect@beta.gouv.fr">Demandez de l'aide</a>
+      </div>
+    </div>
+  </section>
+  </div>
+</div>
+{% endblock content %}

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -114,11 +114,12 @@ class CreateNewMandat(StaticLiveServerTestCase):
     def login_aidant(self):
         login_field = self.selenium.find_element_by_id("id_email")
         login_field.send_keys("thierry@thierry.com")
-        submit_button = self.selenium.find_element_by_xpath('//button')
+        submit_button = self.selenium.find_element_by_xpath("//button")
         submit_button.click()
         email_sent_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(email_sent_title,
-                         "Un email vous a été envoyé pour vous connecter.")
+        self.assertEqual(
+            email_sent_title, "Un email vous a été envoyé pour vous connecter."
+        )
         self.assertEqual(len(mail.outbox), 1)
         token_email = mail.outbox[0].body
         line_containing_magic_link = token_email.split("\n")[2]

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -118,11 +118,12 @@ class UseNewMandat(StaticLiveServerTestCase):
     def login_aidant(self):
         login_field = self.selenium.find_element_by_id("id_email")
         login_field.send_keys("thierry@thierry.com")
-        submit_button = self.selenium.find_element_by_xpath('//button')
+        submit_button = self.selenium.find_element_by_xpath("//button")
         submit_button.click()
         email_sent_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(email_sent_title,
-                         "Un email vous a été envoyé pour vous connecter.")
+        self.assertEqual(
+            email_sent_title, "Un email vous a été envoyé pour vous connecter."
+        )
         self.assertEqual(len(mail.outbox), 1)
         token_email = mail.outbox[0].body
         line_containing_magic_link = token_email.split("\n")[2]

--- a/aidants_connect_web/tests/test_functional/test_view_mandats.py
+++ b/aidants_connect_web/tests/test_functional/test_view_mandats.py
@@ -87,15 +87,15 @@ class ViewMandats(StaticLiveServerTestCase):
     def login_aidant(self):
         login_field = self.selenium.find_element_by_id("id_email")
         login_field.send_keys("thierry@thierry.com")
-        submit_button = self.selenium.find_element_by_xpath('//button')
+        submit_button = self.selenium.find_element_by_xpath("//button")
         submit_button.click()
         email_sent_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(email_sent_title,
-                         "Un email vous a été envoyé pour vous connecter.")
+        self.assertEqual(
+            email_sent_title, "Un email vous a été envoyé pour vous connecter."
+        )
         self.assertEqual(len(mail.outbox), 1)
         token_email = mail.outbox[0].body
         line_containing_magic_link = token_email.split("\n")[2]
         magic_link_https = line_containing_magic_link.split()[-1]
         magic_link_http = magic_link_https.replace("https", "http")
         self.selenium.get(magic_link_http)
-

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -196,7 +196,6 @@ class JournalModelTest(TestCase):
             entry.initiator, "Thierry Martin - Commune de Vernon - thierry@thierry.com"
         )
 
-    @tag("this")
     def test_log_mandat_creation_complete(self):
         mandat = Mandat.objects.create(
             aidant=self.aidant_thierry,

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -22,7 +22,7 @@ class HomePageTests(TestCase):
         self.assertTemplateUsed(response, "aidants_connect_web/home_page.html")
 
 
-@tag("service", "this")
+@tag("service")
 class LoginPageTests(TestCase):
     def setUp(self):
         self.client = Client()
@@ -40,7 +40,6 @@ class LoginPageTests(TestCase):
         self.assertEqual(Journal.objects.all()[0].action, "connect_aidant")
         self.client.get("/mandats/")
         self.assertEqual(Journal.objects.count(), 1)
-
 
     def test_login_view_redirects_to_next_if_aidant_is_authenticated(self):
         self.assertEqual(len(Journal.objects.all()), 0)

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -22,7 +22,7 @@ class HomePageTests(TestCase):
         self.assertTemplateUsed(response, "aidants_connect_web/home_page.html")
 
 
-@tag("service")
+@tag("service", "this")
 class LoginPageTests(TestCase):
     def setUp(self):
         self.client = Client()
@@ -40,6 +40,14 @@ class LoginPageTests(TestCase):
         self.assertEqual(Journal.objects.all()[0].action, "connect_aidant")
         self.client.get("/mandats/")
         self.assertEqual(Journal.objects.count(), 1)
+
+
+    def test_login_view_redirects_to_next_if_aidant_is_authenticated(self):
+        self.assertEqual(len(Journal.objects.all()), 0)
+        self.client.login(username="Thierry", password="motdepassedethierry")
+        response = self.client.get("/accounts/login/?next=/dashboard/", follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "aidants_connect_web/dashboard.html")
 
 
 @tag("service")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 from aidants_connect_web.views import service, FC_as_FS, id_provider, new_mandat
-
+from magicauth import views as magicauth_views
+from magicauth.urls import urlpatterns as magicauth_urls
 
 urlpatterns = [
     # service
     path("", service.home_page, name="home_page"),
+    path("accounts/login/", magicauth_views.LoginView.as_view(), name="login"),
     path("dashboard/", service.dashboard, name="dashboard"),
     path("mandats/", service.mandats, name="mandats"),
     # new mandat
@@ -26,3 +28,5 @@ urlpatterns = [
     path("fc_authorize/", FC_as_FS.fc_authorize, name="fc_authorize"),
     path("callback/", FC_as_FS.fc_callback, name="fc_callback"),
 ]
+
+urlpatterns.extend(magicauth_urls)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ whitenoise==4.1.2
 mock==3.0.5
 WeasyPrint==48
 PyPDF2==1.26.0
+git+git://github.com/betagouv/django-magicauth@redirect_to_next


### PR DESCRIPTION
:warning: Depends on changes in betagouv/django-magicauth#4

With this PR, when an Aidant will want to login, they will enter their registered email address.
The app, through a mailer (:warning: that is still to be setup in integration) sends an email to the address containing a link.

The Aidant then clicks the link and is logged in.

:tada: This uses a package started by the betagouv/e-controle team. :tada:
