### PR TITLE
Déconnecte les aidants après qu'ils utilisent un mandat

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -172,7 +172,6 @@ LOGOUT_REDIRECT_URL = "home_page"
 
 AUTH_USER_MODEL = "aidants_connect_web.Aidant"
 
-
 DEMARCHES = {
     "papiers": {
         "titre": "Papiers - Citoyenneté",

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -79,8 +79,9 @@ class CreateNewMandat(StaticLiveServerTestCase):
         super().tearDownClass()
 
     def test_mandataires(self):
-        self.selenium.get(f"{self.live_server_url}/authorize/?state=34")
         browser = self.selenium
+
+        browser.get(f"{self.live_server_url}/authorize/?state=34")
 
         # Login
         login_field = browser.find_element_by_id("id_username")
@@ -107,3 +108,8 @@ class CreateNewMandat(StaticLiveServerTestCase):
         last_demarche.click()
         time.sleep(2)
         self.assertIn("fcp.integ01.dev-franceconnect.fr", browser.current_url)
+
+        # Check user has been logged out by
+        # checking if they are redirected to the login page
+        browser.get(f"{self.live_server_url}/authorize/?state=35")
+        browser.find_element_by_id("id_username")

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -235,7 +235,6 @@ class FCCallback(TestCase):
 
 @tag("new_mandat", "FC_as_FS")
 class GetUserInfoTests(TestCase):
-
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")
     def test_well_formated_user_info_outputs_usager(self, mock_get):
         mock_response = mock.Mock()

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -165,8 +165,16 @@ class FCCallback(TestCase):
         self.assertEqual(
             connection.access_token, "b337567e-437a-4167-ba51-8f8b6772980b"
         )
-
-        self.assertRedirects(response, "/logout-callback/")
+        url = (
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=b'e"
+            "yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRi"
+            "NDQ4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjox"
+            "NTQ3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29u"
+            "bmVjdC5nb3V2LmZyIiwic3ViIjoxMjMsIm5vbmNlIjoidGVzdF9ub25jZSJ9.vqQoJ3vovqC"
+            "nbXzu7_V7bgsIZH6PPLBkIzeWnSp2sqo'&state=test_state&post_logout_redirect_"
+            "uri=http://localhost:3000/logout-callback"
+        )
+        self.assertRedirects(response, url, fetch_redirect_response=False)
 
     @freeze_time(date)
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.post")
@@ -230,7 +238,16 @@ class FCCallback(TestCase):
         connection = Connection.objects.get(pk=connection_number)
         self.assertEqual(connection.usager.given_name, "Joséphine")
 
-        self.assertRedirects(response, "/logout-callback/")
+        url = (
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=b'ey"
+            "J0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRiND"
+            "Q4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ"
+            "3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmV"
+            "jdC5nb3V2LmZyIiwic3ViIjo0NTYsIm5vbmNlIjoidGVzdF9ub25jZSJ9.tuHulPV1IhyS7UZ"
+            "8q4QWrg8EAeF1vgpFOr-5vV-ags4'&state=test_state&post_logout_redirect_uri="
+            "http://localhost:3000/logout-callback"
+        )
+        self.assertRedirects(response, url, fetch_redirect_response=False)
 
 
 @tag("new_mandat", "FC_as_FS")

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -131,7 +131,6 @@ def fc_callback(request):
     logout_redirect = f"post_logout_redirect_uri={fc_callback_uri_logout}"
     logout_url = f"{logout_base}?{logout_id_token}&{logout_state}&{logout_redirect}"
     return redirect(logout_url)
-    # return redirect("recap")
 
 
 def get_user_info(fc_base: str, access_token: str) -> tuple:

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -18,7 +18,6 @@ logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
 
 
-# TODO add login required ?
 def fc_authorize(request):
     connection = Connection.objects.get(pk=request.session["connection"])
 
@@ -58,7 +57,7 @@ def fc_authorize(request):
 def fc_callback(request):
     fc_base = settings.FC_AS_FS_BASE_URL
     fc_callback_uri = f"{settings.FC_AS_FS_CALLBACK_URL}/callback"
-    # fc_callback_uri_logout = f"{settings.FC_AS_FS_CALLBACK_URL}/logout-callback"
+    fc_callback_uri_logout = f"{settings.FC_AS_FS_CALLBACK_URL}/logout-callback"
     fc_id = settings.FC_AS_FS_ID
     fc_secret = settings.FC_AS_FS_SECRET
 
@@ -126,14 +125,13 @@ def fc_callback(request):
     connection.usager = usager
     connection.save()
 
-    # logout_base = f"{fc_base}/logout"
-    # logout_id_token = f"id_token_hint={fc_id_token}"
-    # logout_state = f"state={state}"
-    # logout_redirect = f"post_logout_redirect_uri={fc_callback_uri_logout}"
-    # logout_url = f"{logout_base}?{logout_id_token}&{logout_state}&{logout_redirect}"
-    # TODO reactivate when FC issue is fixed
-    # return redirect(logout_url)
-    return redirect("recap")
+    logout_base = f"{fc_base}/logout"
+    logout_id_token = f"id_token_hint={fc_id_token}"
+    logout_state = f"state={state}"
+    logout_redirect = f"post_logout_redirect_uri={fc_callback_uri_logout}"
+    logout_url = f"{logout_base}?{logout_id_token}&{logout_state}&{logout_redirect}"
+    return redirect(logout_url)
+    # return redirect("recap")
 
 
 def get_user_info(fc_base: str, access_token: str) -> tuple:


### PR DESCRIPTION
Closes #35

Déconnecter les usagers
Un `usager` est déconnecté de France Connect après avoir créé son `mandat`. cela évite 2 effets de bord de la sessions FC de 30 min.
- L'`aidant` accompagne l'`usager` dans une connection après avoir créé le mandat. Effet de bord : l'`usager est immédiatement "France connecté" et nous perdons le suivi de l'usage du mandat.
- L'aidant voit deux usagers le un à la suite de l'autre pour créer des mandats.  Effet de bord : au moment de valider le mandat, c'est l'usager précédent qui est France connecté.

Déconnecter les aidants
un `aidant` est déconnecté d'Aidants Connect après avoir utilisé un mandat pour diminuer le risque qu'un autre aidant, utilisant le même poste puisse utiliser les mandat du premier