### PR TITLE
Faciliter l'exécution en local pour les personnes équipées de Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ TEST="Everything is awesome"
 DATABASE_NAME=aidants_connect
 DATABASE_USER=aidants_connect_team
 DATABASE_PASSWORD=''
-DATABASE_URL=''
+DATABASE_HOST=''
 DATABASE_PORT=''
 # Can be replaced by a POSTGRES_URL (from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python AS base
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+RUN pip install honcho
+RUN mkdir /app/staticfiles
+
+FROM base AS service
+WORKDIR /app
+COPY . .

--- a/README.md
+++ b/README.md
@@ -53,10 +53,9 @@ Si la commande précédente déclenche le message d'erreur suivant `ld: library 
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
 ```
 
-Changer le fichier `.env.example` à la racine du projet en .env` et ajoutez vos informations :
+Changer le fichier `.env.example` à la racine du projet en `.env` et ajouter vos informations :
 - Les informations `FC_AS_FS` et `FC_AS_``I``` sont à récupérer via des habilitations FranceConnect
 - Les valeur de sécurité sont issues de https://docs.djangoproject.com/fr/2.2/topics/security/ et de https://www.youtube.com/watch?v=gvQW1vVNohg
-
 
 Créer un repertoire `staticfiles` 
 ```

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -128,7 +128,7 @@ else:
             "NAME": os.getenv("DATABASE_NAME"),
             "USER": os.getenv("DATABASE_USER"),
             "PASSWORD": os.getenv("DATABASE_PASSWORD"),
-            "HOST": os.getenv("DATABASE_URL"),
+            "HOST": os.getenv("DATABASE_HOST"),
             "PORT": os.getenv("DATABASE_PORT"),
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '2'
+
+services:
+  app:
+    build: .
+    ports:
+      - 3000:3000
+    volumes:
+      - ./:/app
+    command: /bin/bash -lc "gunicorn aidants_connect.wsgi --bind 0.0.0.0:3000 --log-file -"
+    working_dir: /app
+    environment:
+      HOST: localhost
+      APP_SECRET: test_secret
+      DATABASE_NAME: aidants_connect
+      DATABASE_USER: aidants_connect_team
+      DATABASE_PASSWORD: test_db_pwd
+      FC_AS_FS_BASE_URL: https://bogus
+      FC_AS_FS_ID: bogus
+      FC_AS_FS_SECRET: bogus
+      FC_AS_FS_CALLBACK_URL: https://bogus
+      FC_AS_FS_TEST_PORT: 3000
+      FC_AS_FI_ID: bogus
+      FC_AS_FI_SECRET: bogus
+      FC_AS_FI_CALLBACK_URL: https://bogus
+      DEBUG: "True"
+    depends_on:
+      - postgres
+  postgres:
+    image: postgres
+    restart: always
+    environment:
+      POSTGRES_DB: aidants_connect
+      POSTGRES_USER: aidants_connect_team
+      POSTGRES_PASSWORD: test_db_pwd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       DATABASE_NAME: aidants_connect
       DATABASE_USER: aidants_connect_team
       DATABASE_PASSWORD: test_db_pwd
+      DATABASE_HOST: postgres
       FC_AS_FS_BASE_URL: https://bogus
       FC_AS_FS_ID: bogus
       FC_AS_FS_SECRET: bogus

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,11 @@ services:
       - 3000:3000
     volumes:
       - ./:/app
-    command: /bin/bash -lc "python manage.py migrate && gunicorn aidants_connect.wsgi --bind 0.0.0.0:3000 --log-file -"
+    command: /bin/bash -lc "python manage.py migrate && PYTHONUNBUFFERED=1 honcho start"
     working_dir: /app
     environment:
       HOST: localhost
+      PORT: 3000
       APP_SECRET: test_secret
       DATABASE_NAME: aidants_connect
       DATABASE_USER: aidants_connect_team

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 3000:3000
     volumes:
       - ./:/app
-    command: /bin/bash -lc "gunicorn aidants_connect.wsgi --bind 0.0.0.0:3000 --log-file -"
+    command: /bin/bash -lc "python manage.py migrate && gunicorn aidants_connect.wsgi --bind 0.0.0.0:3000 --log-file -"
     working_dir: /app
     environment:
       HOST: localhost


### PR DESCRIPTION
Avec cette PR, il est possible d'exécuter rapidement le serveur Aidants Connect en local, à condition d'être déjà à l'aise avec Docker et `docker-compose`. Le fichier YAML définit deux services (`app` et `postgres`) correspondant respectivement au backend Aidants Connect et à la base de données. Le backend expose le port 3000 pour permettre la connexion via `http://localhost:3000`