### PR TITLE
Améliore la sécurité de l'application

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+DEBUG = True # False for prod
+HOST= http://localhost:xxxx
+APP_SECRET=<insert_your_secret>
+TEST="Everything is awesome"
+
+DATABASE_NAME=aidants_connect
+DATABASE_USER=aidants_connect_team
+DATABASE_PASSWORD=''
+DATABASE_URL=''
+DATABASE_PORT=''
+# Can be replaced by a POSTGRES_URL (from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
+
+FC_AS_FS_BASE_URL=http://...
+FC_AS_FS_ID=<insert_your_data>
+FC_AS_FS_SECRET=<insert_your_data>
+FC_AS_FS_CALLBACK_URL=http://localhost:xxxx
+FC_AS_FS_TEST_PORT=xxxx
+
+FC_AS_FI_ID=<insert_your_data>
+FC_AS_FI_SECRET=<insert_your_data>
+FC_AS_FI_CALLBACK_URL=https://...
+
+# if you are debugging, and want to use the file based email backend
+EMAIL_BACKEND = django.core.mail.backends.filebased.EmailBackend
+
+# If you want to use the default smtp backend
+# EMAIL_HOST = django.core.mail.backends.filebased.EmailBackend
+# EMAIL_PORT = <insert_your_data>
+# EMAIL_HOST_USER = <insert_your_data>
+# EMAIL_HOST_PASSWORD = <insert_your_data>
+
+# email address the connexion email is sent from
+MAGICAUTH_FROM_EMAIL = "test@domain.user"
+
+ADMIN_URL = mon_url_admin/
+ADMIN_NAME = mon nom
+ADMIN_EMAIL = monnom@domain.user
+
+# Security measures
+SESSION_COOKIE_SECURE = False # True in prod
+CSRF_COOKIE_SECURE = False # True in prod
+
+## be careful with these
+SECURE_HSTS_SECONDS = 0 # should be more than 31556952 (one year) in prod
+SECURE_SSL_REDIRECT = False # True in prod

--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ EMAIL_HOST_PASSWORD = <insert_your_data>
 # email address the connexion email is sent from
 MAGICAUTH_FROM_EMAIL = "test@domain.user"
 
+# Information for the admin page
+ADMIN_URL = site-admin/
+ADMIN_NAME = Cayce Pollard
+ADMIN_EMAIL = cayce.pollard@domain.user
+
 # Optional
 DATABASE_SSL
 DEBUG

--- a/README.md
+++ b/README.md
@@ -53,58 +53,10 @@ Si la commande précédente déclenche le message d'erreur suivant `ld: library 
 export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
 ```
 
-Créer un fichier `.env` à la racine de votre projet et y ajouter les éléments suivants :
- 
+Changer le fichier `.env.example` à la racine du projet en .env` et ajoutez vos informations :
+- Les informations `FC_AS_FS` et `FC_AS_``I``` sont à récupérer via des habilitations FranceConnect
+- Les valeur de sécurité sont issues de https://docs.djangoproject.com/fr/2.2/topics/security/ et de https://www.youtube.com/watch?v=gvQW1vVNohg
 
-```
-HOST= <insert_your_data> #e.g. http://localhost:8000
-APP_SECRET=<insert_your_secret>
-TEST="Everything is awesome"
-
-DATABASE_NAME=aidants_connect
-DATABASE_USER=aidants_connect_team
-DATABASE_PASSWORD='' or <insert_your_data>
-DATABASE_URL='' or <insert_your_data>
-DATABASE_PORT='' or <insert_your_data>
-# Can be replaced by a POSTGRES_URL (from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING)
-
-FC_AS_FS_BASE_URL=<insert_your_data>
-FC_AS_FS_ID=<insert_your_data>
-FC_AS_FS_SECRET=<insert_your_data>
-FC_AS_FS_CALLBACK_URL=<insert_your_data>
-FC_AS_FS_TEST_PORT=<insert_your_data> or ''
-
-FC_AS_FI_ID=<insert_your_data>
-FC_AS_FI_SECRET=<insert_your_data>
-FC_AS_FI_CALLBACK_URL=<insert_your_data>
-
-# if you are debugging, and want to use the file based email backend
-EMAIL_BACKEND = django.core.mail.backends.filebased.EmailBackend
-
-# If you want to use the default smtp backend
-EMAIL_HOST = <insert_your_data>
-EMAIL_PORT = <insert_your_data>
-EMAIL_HOST_USER = <insert_your_data>
-EMAIL_HOST_PASSWORD = <insert_your_data>
-
-# email address the connexion email is sent from
-MAGICAUTH_FROM_EMAIL = "test@domain.user"
-
-# Information for the admin page
-ADMIN_URL = site-admin/
-ADMIN_NAME = Cayce Pollard
-ADMIN_EMAIL = cayce.pollard@domain.user
-
-# Force secure connection (can not work for local development)
-SESSION_COOKIE_SECURE = False when testing, True if using https
-CSRF_COOKIE_SECURE = False when testing, True if using https
-SECURE_HSTS_SECONDS = 0 if using http, production target 1 year
-SECURE_SSL_REDIRECT = False if using http, True if using https
-
-# Optional
-DATABASE_SSL
-DEBUG
-```
 
 Créer un repertoire `staticfiles` 
 ```

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ ADMIN_URL = site-admin/
 ADMIN_NAME = Cayce Pollard
 ADMIN_EMAIL = cayce.pollard@domain.user
 
+# Force secure connection (can not work for local development)
+SESSION_COOKIE_SECURE = False when testing, True if using https
+CSRF_COOKIE_SECURE = False when testing, True if using https
+SECURE_HSTS_SECONDS = 0 if using http, production target 1 year
+SECURE_SSL_REDIRECT = False if using http, True if using https
+
 # Optional
 DATABASE_SSL
 DEBUG

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -76,6 +76,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
+    "django_referrer_policy.middleware.ReferrerPolicyMiddleware",
+    "csp.middleware.CSPMiddleware",
 ]
 
 ROOT_URLCONF = "aidants_connect.urls"
@@ -259,3 +261,20 @@ EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER", None)
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", None)
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)
+
+SECURE_BROWSER_XSS_FILTER = True
+SECURE_CONTENT_TYPE_NOSNIFF = True
+X_FRAME_OPTIONS = "DENY"
+REFERRER_POLICY = "strict-origin"
+
+# Content security policy
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_IMG_SRC = (
+    "'self'",
+    "https://www.service-public.fr/resources/v-5cf79a7acf/web/css/img/png/",
+    "https://societenumerique.gouv.fr/wp-content/uploads/2018/05/mockupkit-1.png",
+)
+CSP_SCRIPT_SRC = ("'self'", "'sha256-dzE1fiHF13yOIlSQf8CYbmucPoYAOHwQ70Y3OO70o+E='")
+CSP_STYLE_SRC = ("'self'",)
+CSP_OBJECT_SRC = ("'none'",)
+

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -64,6 +64,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "aidants_connect_web",
+    "admin_honeypot",
 ]
 
 MIDDLEWARE = [
@@ -170,7 +171,6 @@ USE_TZ = True
 STATIC_ROOT = "staticfiles"
 STATIC_URL = "/static/"
 
-
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "home_page"
 
@@ -262,6 +262,7 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", None)
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)
 
+# Security headers
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
@@ -278,3 +279,6 @@ CSP_SCRIPT_SRC = ("'self'", "'sha256-dzE1fiHF13yOIlSQf8CYbmucPoYAOHwQ70Y3OO70o+E
 CSP_STYLE_SRC = ("'self'",)
 CSP_OBJECT_SRC = ("'none'",)
 
+# Admin Page settings
+ADMIN_URL = os.getenv("ADMIN_URL")
+ADMINS = [(os.getenv("ADMIN_NAME"), os.getenv("ADMIN_EMAIL"))]

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -282,3 +282,11 @@ CSP_OBJECT_SRC = ("'none'",)
 # Admin Page settings
 ADMIN_URL = os.getenv("ADMIN_URL")
 ADMINS = [(os.getenv("ADMIN_NAME"), os.getenv("ADMIN_EMAIL"))]
+
+# Cookie security
+SESSION_COOKIE_SECURE = False if os.getenv("SESSION_COOKIE_SECURE") == "False" else True
+CSRF_COOKIE_SECURE = False if os.getenv("CSRF_COOKIE_SECURE") == "False" else True
+
+# SSL security
+SECURE_SSL_REDIRECT = False if os.getenv("SECURE_SSL_REDIRECT") == "False" else True
+SECURE_HSTS_SECONDS = os.getenv("SECURE_HSTS_SECONDS")

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
+from django.conf import settings
 from django.urls import path, include
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path(settings.ADMIN_URL, admin.site.urls),
+    path("admin/", include("admin_honeypot.urls", namespace="admin_honeypot")),
     path("", include("aidants_connect_web.urls")),
 ]

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -5,6 +5,10 @@ body {
   justify-content: space-between;
 }
 
+.previews {
+    display: none;
+}
+
 .navbar {
   border: 0;
 }

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -56,7 +56,7 @@
 </head>
 
 <body>
-  <svg aria-hidden="true" focusable="false" style="display:none">
+  <svg aria-hidden="true" focusable="false" class="previews">
     <defs>
       <symbol viewBox="0 0 32 32" fill-rule="evenodd" clip-rule="evenodd" stroke-linejoin="round" stroke-miterlimit="1.414" id="copy" xmlns="http://www.w3.org/2000/svg"><path d="M19.75 8.5V1H6.625L1 6.625V23.5h11.25V31H31V8.5H19.75zM6.625 3.651v2.974H3.651l2.974-2.974zm-3.75 17.974V8.5H8.5V2.875h9.375V8.5l-5.625 5.625v7.5H2.875zm15-10.474v2.974h-2.974l2.974-2.974zm11.25 17.974h-15V16h5.625v-5.625h9.375v18.75z" fill-rule="nonzero"/></symbol>
 

--- a/aidants_connect_web/tests/test_functional/test_view_mandats.py
+++ b/aidants_connect_web/tests/test_functional/test_view_mandats.py
@@ -7,7 +7,7 @@ from aidants_connect_web.models import Aidant, Usager, Mandat
 from datetime import date
 
 
-@tag("functional")
+@tag("functional", "this")
 class ViewMandats(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ mock==3.0.5
 WeasyPrint==48
 PyPDF2==1.26.0
 git+git://github.com/betagouv/django-magicauth@redirect_to_next
+django-referrer-policy==1.0
+django-admin-honeypot==1.1.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,5 @@ PyPDF2==1.26.0
 git+git://github.com/betagouv/django-magicauth@redirect_to_next
 django-referrer-policy==1.0
 django-admin-honeypot==1.1.0
+django-csp==3.5
 


### PR DESCRIPTION
Avec cette PR :
- On créé une `Content Security Policy` via les headers, ce qui rends l'injection de code plus compliquée. 
- On ajoute des options via les envars pour activer les fonctionnalités de sécurité de cookies et de connexion SSL forcée en production.
- on bouge la page d'administration de son url django par defaut (`/admin`) et on place un pot de confiture à la place.
