### PR TITLE
Correction faute frappe bloc coconstruction

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/home_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/home_page.html
@@ -43,7 +43,7 @@
       </div>
       <div class="tile tile-colored text-center">
         <img class="tile__icon" src="{% static 'images/build.svg' %}" />
-        <h3>Aidants Connect a été co-construits avec des aidants</h3>
+        <h3>Aidants Connect a été co-construit avec des aidants</h3>
         <p>Des ateliers utilisateurs ont eu lieu dans une dizaine de territoires</p>
       </div>
       <div class="tile tile-colored text-center">


### PR DESCRIPTION
Enlever le "s" à "coconstruit"