### PR TITLE
Vérifie l'intégrité des paramètres lors d'appels de France Connect

### DIFF
--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -2,9 +2,9 @@ import time
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.conf import settings
 from django.test import tag
-from django.core import mail
 from selenium.webdriver.firefox.webdriver import WebDriver
 from aidants_connect_web.models import Aidant
+from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 
 @tag("functional", "new_mandat")
@@ -31,7 +31,7 @@ class CreateNewMandat(StaticLiveServerTestCase):
         super().tearDownClass()
 
     def test_create_new_mandat(self):
-        self.login_aidant()
+        login_aidant(self)
 
         welcome_aidant = self.selenium.find_element_by_tag_name("h1").text
         self.assertEqual(welcome_aidant, "Vos mandats")
@@ -110,19 +110,3 @@ class CreateNewMandat(StaticLiveServerTestCase):
 
         # See all mandats page
         self.assertEqual(len(self.selenium.find_elements_by_tag_name("tr")), 3)
-
-    def login_aidant(self):
-        login_field = self.selenium.find_element_by_id("id_email")
-        login_field.send_keys("thierry@thierry.com")
-        submit_button = self.selenium.find_element_by_xpath("//button")
-        submit_button.click()
-        email_sent_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(
-            email_sent_title, "Un email vous a été envoyé pour vous connecter."
-        )
-        self.assertEqual(len(mail.outbox), 1)
-        token_email = mail.outbox[0].body
-        line_containing_magic_link = token_email.split("\n")[2]
-        magic_link_https = line_containing_magic_link.split()[-1]
-        magic_link_http = magic_link_https.replace("https", "http")
-        self.selenium.get(magic_link_http)

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
 from django.core import mail
 from django.test import tag
@@ -82,7 +83,18 @@ class UseNewMandat(StaticLiveServerTestCase):
     def test_mandataires(self):
         browser = self.selenium
 
-        browser.get(f"{self.live_server_url}/authorize/?state=34&nonce=45")
+        parameters = (
+            f"state=34"
+            f"&nonce=45"
+            f"&response_type=code"
+            f"&client_id={settings.FC_AS_FI_ID}"
+            f"&redirect_uri={settings.FC_AS_FI_CALLBACK_URL}"
+            f"&scope=openid profile email address phone birth"
+            f"&acr_values=eidas1"
+        )
+
+        url = f"{self.live_server_url}/authorize/?{parameters}"
+        browser.get(url)
 
         # Login
         self.login_aidant()

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -73,7 +73,7 @@ class UseNewMandat(StaticLiveServerTestCase):
 
         super().setUpClass()
         cls.selenium = WebDriver()
-        cls.selenium.implicitly_wait(10)
+        cls.selenium.implicitly_wait(3)
 
     @classmethod
     def tearDownClass(cls):

--- a/aidants_connect_web/tests/test_functional/test_view_mandats.py
+++ b/aidants_connect_web/tests/test_functional/test_view_mandats.py
@@ -1,9 +1,10 @@
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
-from django.core import mail
 
 from django.test import tag
 from selenium.webdriver.firefox.webdriver import WebDriver
 from aidants_connect_web.models import Aidant, Usager, Mandat
+from aidants_connect_web.tests.test_functional.utilities import login_aidant
+
 from datetime import date
 
 
@@ -72,7 +73,7 @@ class ViewMandats(StaticLiveServerTestCase):
         self.selenium.get(f"{self.live_server_url}/dashboard/")
 
         # Login
-        self.login_aidant()
+        login_aidant(self)
 
         # Dashboard
         self.selenium.find_element_by_id("view_mandats").click()
@@ -83,19 +84,3 @@ class ViewMandats(StaticLiveServerTestCase):
         # The first row is the title row
         mandats = rows[1:]
         self.assertEqual(len(mandats), 3)
-
-    def login_aidant(self):
-        login_field = self.selenium.find_element_by_id("id_email")
-        login_field.send_keys("thierry@thierry.com")
-        submit_button = self.selenium.find_element_by_xpath("//button")
-        submit_button.click()
-        email_sent_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(
-            email_sent_title, "Un email vous a été envoyé pour vous connecter."
-        )
-        self.assertEqual(len(mail.outbox), 1)
-        token_email = mail.outbox[0].body
-        line_containing_magic_link = token_email.split("\n")[2]
-        magic_link_https = line_containing_magic_link.split()[-1]
-        magic_link_http = magic_link_https.replace("https", "http")
-        self.selenium.get(magic_link_http)

--- a/aidants_connect_web/tests/test_functional/utilities.py
+++ b/aidants_connect_web/tests/test_functional/utilities.py
@@ -1,0 +1,18 @@
+from django.core import mail
+
+
+def login_aidant(self):
+    login_field = self.selenium.find_element_by_id("id_email")
+    login_field.send_keys("thierry@thierry.com")
+    submit_button = self.selenium.find_element_by_xpath("//button")
+    submit_button.click()
+    email_sent_title = self.selenium.find_element_by_tag_name("h1").text
+    self.assertEqual(
+        email_sent_title, "Un email vous a été envoyé pour vous connecter."
+    )
+    self.assertEqual(len(mail.outbox), 1)
+    token_email = mail.outbox[0].body
+    line_containing_magic_link = token_email.split("\n")[2]
+    magic_link_https = line_containing_magic_link.split()[-1]
+    magic_link_http = magic_link_https.replace("https", "http", 1)
+    self.selenium.get(magic_link_http)

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -337,6 +337,12 @@ class TokenTests(TestCase):
         fc_request["code"] = "wrong_code"
         response = self.client.post("/token/", fc_request)
         self.assertEqual(response.status_code, 403)
+    def test_missing_parameters_triggers_bad_request(self):
+        for parameter in self.fc_request:
+            bad_request = dict(self.fc_request)
+            del bad_request[parameter]
+            response = self.client.post("/token/", bad_request)
+            self.assertEqual(response.status_code, 400)
 
     date_expired = date + timedelta(minutes=CONNECTION_EXPIRATION_TIME + 20)
 

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -140,7 +140,16 @@ class AuthorizeTests(TestCase):
         fc_call_state = token_urlsafe(4)
 
         response = self.client.get(
-            "/authorize/", data={"state": fc_call_state, "nonce": "fc_call_nonce"}
+            "/authorize/",
+            data={
+                "state": token_urlsafe(4),
+                "nonce": "fc_call_nonce",
+                "response_type": "code",
+                "client_id": settings.FC_AS_FI_ID,
+                "redirect_uri": settings.FC_AS_FI_CALLBACK_URL,
+                "scope": "openid profile email address phone birth",
+                "acr_values": "eidas1",
+            },
         )
 
         self.assertIsInstance(response.context["state"], str)

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -47,6 +47,7 @@ def fc_authorize(request):
         f"&scope={'openid' + ''.join(['%20' + scope for scope in fc_scopes])}"
         f"&state={connection.state}"
         f"&nonce={connection.nonce}"
+        f"&acr_values=eidas1"
     )
 
     authorize_url = f"{fc_base}/authorize?{parameters}"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 exclude = .git,*migrations*, venv, aidants_connect/settings.py
 max-line-length = 88
-ignore = E203
+ignore = E203, W503


### PR DESCRIPTION
## 🌮 Objectif de la PR
- Augmenter la sécurité de l'application lors de l'utilisation des mandats
- Les appels de FranceConnect à Aidants Connect doivent avoir une forme bien précise, spécifiée dans la [documentation FC](https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-identite)
- Un appel dans lequel l'un des paramètres attendus est manquant renvoie une erreur 400 (bad request).
- Un appel dans lequel l'un des paramètres "statiques" ne contient pas la valeur attendue renvoie une erreur 403 (forbidden)
### Autres modifications :
- La connexion à France Connect, en tant que FS contient le niveau eidas visé.
- Certains tests utilisent maintenant la `factory` d'aidants

## 🔍 Implémentation
Dans `aidants_connect_web/views/id_provider.py`, pour les vues `authorize` et `token` deux objects sont créés : 
- `parameters` contient les valeurs des paramètres attendus, contenus dans la requète, ou `None` si le périmètre n'était pas présent.
- `expected_static_parameters` est un sous-set de paramètres, et de leurs valeurs attendues.
- Une nouvelle fonction, `check_request_parameter`, prends les deux éléments ci-dessus en paramètres pour : 
    1. Vérifier que les paramètres attendues sont présents
    2. Vérifier que les valeurs attendues sont correct
    Si ce n'est pas la cas, la méthode renvoie une erreur avec un message en fonction du cas.
- Les vues `authorize` et `token` appellent cette fonction puis vérifient si une erreur a été repérée. Si oui, elle répondent en fonction du cas d'erreur.

## :speech_balloon: Mystère [[SOLVED](https://github.com/betagouv/Aidants_Connect/pull/92#issuecomment-552985070)]
Lors des tests d'intégration, `aidants_connect_web.tests.test_functional.test_create_mandat.CreateNewMandat` on envoie dans la requête à `/authorize` un paramètre `redirect_uri`. Si ce paramètre est en HTTPS dans la requête, il arrive dans le view en ayant été reformulé en HTTP. Idem si l'on ajoute un `/` à la fin de l'URL dans le paramètre, il disparait une fois arrivé dans la `view`.


