### PR TITLE
Répare l'interface sur IE11

### DIFF
--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -1,7 +1,3 @@
-.hero .row > * {
-  max-width: none;
-}
-
 .hero .row > img {
   max-width: 40%;
 }
@@ -58,6 +54,11 @@
 .tile h3 {
   font-size: 1.25em;
   line-height: 1.25em;
+}
+
+.tile h3,
+.tile p {
+  max-width: 100;
 }
 
 .tile__icon {

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -1,3 +1,7 @@
+html {
+  height: auto;
+}
+
 body {
   min-height: 100vh;
   display: flex;

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -107,6 +107,16 @@ form {
   align-items: start;
 }
 
+.mandat__agreement .checkbox {
+  width: 100%;
+}
+
 .mandat__agreement .checkbox__group + .checkbox__group {
   margin-top: 1em;
+}
+
+@supports not (display: grid) {
+  .tile + .tile {
+    margin-top: 1em;
+  }
 }


### PR DESCRIPTION
Cette PR corrige les problèmes d'UI liés à IE 11 sur la home et sur la page de récap :
- le conteneur `html` nécessitait qu'on lui force sa hauteur à `auto`
- essentiellement des problèmes de max-width pour forcer les éléments à prendre la largeur de leur parent
 
![image](https://user-images.githubusercontent.com/1301085/68948446-32731080-07b8-11ea-986d-d804b1546eea.png)

![image](https://user-images.githubusercontent.com/1301085/68948524-58001a00-07b8-11ea-8bed-d2499ca20373.png)

![image](https://user-images.githubusercontent.com/1301085/68948329-f2ac2900-07b7-11ea-9487-fd91fa302146.png)
