### PR TITLE
Ajoute une fonctionnalité d'OTP à l'admin métier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,13 @@
 venv/*
-aidants_connect/tmp_email_as_file/**
 .idea/*
 **/__pycache__/**
 db.sqlite3
 geckodriver.log
 
+aidants_connect/tmp_email_as_file/**
 .env
 staticfiles
 .DS_Store
 
 */fixtures/*
+local_db.json

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -65,6 +65,9 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "aidants_connect_web",
     "admin_honeypot",
+    "django_otp",
+    "django_otp.plugins.otp_static",
+    "django_otp.plugins.otp_totp",
 ]
 
 MIDDLEWARE = [
@@ -79,6 +82,7 @@ MIDDLEWARE = [
     "django.contrib.sites.middleware.CurrentSiteMiddleware",
     "django_referrer_policy.middleware.ReferrerPolicyMiddleware",
     "csp.middleware.CSPMiddleware",
+    "django_otp.middleware.OTPMiddleware",
 ]
 
 ROOT_URLCONF = "aidants_connect.urls"

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,9 +1,10 @@
-from django.contrib import admin
 from django.conf import settings
 from django.urls import path, include
 
+from aidants_connect_web.admin import admin_site
+
 urlpatterns = [
-    path(settings.ADMIN_URL, admin.site.urls),
+    path(settings.ADMIN_URL, admin_site.urls),
     path("admin/", include("admin_honeypot.urls", namespace="admin_honeypot")),
     path("", include("aidants_connect_web.urls")),
 ]

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -1,8 +1,21 @@
-from django.contrib import admin
 from aidants_connect_web.forms import AidantChangeForm, AidantCreationForm
-from django.contrib.auth.models import Group
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
-from aidants_connect_web.models import Aidant, Usager, Mandat, Journal, Connection
+
+from magicauth.models import MagicToken
+from django_otp.plugins.otp_static.models import StaticToken
+from django_otp.plugins.otp_totp.models import TOTPDevice
+from django_otp.admin import OTPAdminSite
+from aidants_connect_web.models import (
+    Aidant,
+    Usager,
+    Mandat,
+    Journal,
+    Connection,
+    Organisation,
+)
+
+
+admin_site = OTPAdminSite(OTPAdminSite.name)
 
 
 class AidantAdmin(DjangoUserAdmin):
@@ -48,13 +61,14 @@ class AidantAdmin(DjangoUserAdmin):
     ordering = ("email",)
 
 
-# Now register the new AidantAdmin...
-admin.site.register(Aidant, AidantAdmin)
-admin.site.register(Usager)
-admin.site.register(Mandat)
-admin.site.register(Journal)
-admin.site.register(Connection)
+# Display the following tables in the admin
+admin_site.register(Aidant, AidantAdmin)
+admin_site.register(Usager)
+admin_site.register(Mandat)
+admin_site.register(Journal)
+admin_site.register(Connection)
+admin_site.register(Organisation)
 
-# ... and, since we're not using Django's built-in permissions,
-# unregister the Group model from admin.
-admin.site.unregister(Group)
+admin_site.register(MagicToken)
+admin_site.register(StaticToken)
+admin_site.register(TOTPDevice)

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -2,8 +2,10 @@ from aidants_connect_web.forms import AidantChangeForm, AidantCreationForm
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 
 from magicauth.models import MagicToken
-from django_otp.plugins.otp_static.models import StaticToken
+from django_otp.plugins.otp_static.models import StaticDevice
+from django_otp.plugins.otp_static.admin import StaticDeviceAdmin
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from django_otp.plugins.otp_totp.admin import TOTPDeviceAdmin
 from django_otp.admin import OTPAdminSite
 from aidants_connect_web.models import (
     Aidant,
@@ -70,5 +72,5 @@ admin_site.register(Connection)
 admin_site.register(Organisation)
 
 admin_site.register(MagicToken)
-admin_site.register(StaticToken)
-admin_site.register(TOTPDevice)
+admin_site.register(StaticDevice, StaticDeviceAdmin)
+admin_site.register(TOTPDevice, TOTPDeviceAdmin)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,6 @@ django-referrer-policy==1.0
 django-admin-honeypot==1.1.0
 django-csp==3.5
 factory-boy==2.12.0
-django-otp
+django-otp==0.7.4
+qrcode==6.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ django-referrer-policy==1.0
 django-admin-honeypot==1.1.0
 django-csp==3.5
 factory-boy==2.12.0
+django-otp
+


### PR DESCRIPTION
## 🌮 Objectif
Sécuriser la connexion des administrateur·ices métier en ajoutant un "One Time Password".

## 🔍 Implementation
- Installation de la bibliothèque Django-otp (https://django-otp-official.readthedocs.io/) ainsi que deux plugins : un pour le TOTP (time base one-time password) et Static (qui permet de créer des recovery codes) (settings.py, requirements.txt)
- Utiliser le site d'admin proposé par Django-otp, et afficher dans le site d'admin les bases de token
(`urls.py`, `admin.py`)

## 🏕 Amélioration continue
- Ajouter au `.gitignore` un nom générique d'export de base de données

⚠️ lors de l'installation, il peut être nécessaire de bootstraper un accès. Dans ce cas, on peut utiliser : https://django-otp-official.readthedocs.io/en/stable/overview.html#addstatictoken