### PR TITLE
Authentifier fortement l'aidant à la création d'un mandat

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -74,4 +74,3 @@ admin_site.register(Organisation)
 admin_site.register(MagicToken)
 admin_site.register(StaticDevice, StaticDeviceAdmin)
 admin_site.register(TOTPDevice, TOTPDeviceAdmin)
-

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -74,3 +74,4 @@ admin_site.register(Organisation)
 admin_site.register(MagicToken)
 admin_site.register(StaticDevice, StaticDeviceAdmin)
 admin_site.register(TOTPDevice, TOTPDeviceAdmin)
+

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -113,4 +113,7 @@ form {
   .tile + .tile {
     margin-top: 1em;
   }
+
+#id_otp_token {
+    width:6em;
 }

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -42,37 +42,22 @@
         {% csrf_token %}
     <div class="panel form__group mandat__agreement">
     En cochant les cases, {{ usager }} confirme :
-        {% for field in form %}
-        {% if field.name == "brief" %}
             <div class="checkbox__group">
-                {{ field }}
-                <label class="label-inline" for="{{ field.name }}">Autoriser les aidants habilités de <strong> {{ aidant.organisation.name }}</strong> à utiliser ses données à caractère personnel.</label>
+                <input type="checkbox" name="personal_data" required id="id_personal_data">
+                <label class="label-inline" for="id_personal_data">Avoir reçu, de la part de <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> de <strong>{{ aidant.organisation.name }}</strong> les informations concernant l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression, etc.)</label>
             </div>
-        {% elif field.name == "personal_data" %}
             <div class="checkbox__group">
-            {{ field }}
-            <label class="label-inline" for="{{ field.name }}">Avoir reçu, de la part de <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> de <strong>{{ aidant.organisation.name }}</strong> les informations concernant l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression, etc.)</label>
+                <input type="checkbox" name="brief" required id="id_brief">
+                <label class="label-inline" for="id_brief">Autoriser les aidants habilités de <strong> {{ aidant.organisation.name }}</strong> à utiliser ses données à caractère personnel.</label>
             </div>
-        {% endif %}
-        {% endfor %}
-
     </div>
     <h2>Validation de l'aidant</h2>
         <div class="panel form__group mandat__agreement">
             <fieldset>
-                  {% for field in form %}
-                     {% if field.name == "otp_device" %}
-                        <div class="not_checkbox_group">
-                          <label for="otp_device">Selectionnez</label>
-                          {{ field }}
-                           </div>
-                      {% elif field.name == "otp_token" %}
-                          <div class="not_checkbox_group">
-                          <label for="otp_token">Veuillez indiquer le code à 6 chiffres généré par votre téléphone</label>
-                          {{ field }}
-                           </div>
-                      {% endif %}
-                  {%  endfor %}
+                <div class="not_checkbox_group">
+                    <label for="id_otp_token">Veuillez indiquer le code à 6 chiffres généré par votre téléphone</label>
+                    <input type="text" name="otp_token" maxlength="6" minlength="6" required id="id_otp_token">
+                </div>
             </fieldset>
         <div class="form__group">
             <input type="submit" class="button" value="Enregistrer le mandat" />

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -9,11 +9,12 @@
 {% block content %}
 <div class="hero">
   <div class="container hero__container">
-    <h1>Récapitulatif</h1>
+    <h1>Récapitulatif du mandat</h1>
   </div>
 </div>
 <section class="section section-grey">
   <div class="container container-small">
+  <h2>Éléments du mandat</h2>
     <a class="button" href="{% url 'new_mandat_preview' %}" target="_blank">🖨 Imprimer le mandat</a>
     <form method="post" class="panel">
       {% if error %}
@@ -28,24 +29,58 @@
           {% endfor %}
         </ul>
         pour une durée de : <strong>{{ duree }}</strong>
-      </div>
-      <div class="form__group mandat__agreement">
-        <fieldset>
-          <legend>À cette fin :</legend>
-          <div class="checkbox__group">
-            <input type="checkbox" name="personal_data" id="id_personal_data" />
-            <label class="label-inline" for="id_personal_data">J’autorise <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> à utiliser mes données à caractère personnel.</label>
-          </div>
-          <div class="checkbox__group">
-            <input type="checkbox" name="brief" id="id_brief" />
-            <label class="label-inline" for="id_brief">Je confime que <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> m’a rappelé l’objet de l’intervention, la raison pour laquelle mes informations sont collectées et leur utilité ; les droits sur mes données (accès, rectification, suppression, etc.)</label>
-          </div>
-        </fieldset>
-      </div>
-      <div class="form__group">
-        <input type="submit" class="button" value="J’accepte" />
-      </div>
+    </div>
+
+    <h2>Validation de l'usager</h2>
+
+
+    <form method="post">
+
+        {% if form.non_field_errors %}
+            <div class="notification warning">{{ form.non_field_errors }}</div>
+        {% endif %}
+        {% csrf_token %}
+    <div class="panel form__group mandat__agreement">
+    En cochant les cases, {{ usager }} confirme :
+        {% for field in form %}
+        {% if field.name == "brief" %}
+            <div class="checkbox__group">
+                {{ field }}
+                <label class="label-inline" for="{{ field.name }}">Autoriser les aidants habilités de <strong> {{ aidant.organisation.name }}</strong> à utiliser ses données à caractère personnel.</label>
+            </div>
+        {% elif field.name == "personal_data" %}
+            <div class="checkbox__group">
+            {{ field }}
+            <label class="label-inline" for="{{ field.name }}">Avoir reçu, de la part de <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> de <strong>{{ aidant.organisation.name }}</strong> les informations concernant l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression, etc.)</label>
+            </div>
+        {% endif %}
+        {% endfor %}
+
+    </div>
+    <h2>Validation de l'aidant</h2>
+        <div class="panel form__group mandat__agreement">
+            <fieldset>
+                  {% for field in form %}
+                     {% if field.name == "otp_device" %}
+                        <div class="not_checkbox_group">
+                          <label for="otp_device">Selectionnez</label>
+                          {{ field }}
+                           </div>
+                      {% elif field.name == "otp_token" %}
+                          <div class="not_checkbox_group">
+                          <label for="otp_token">Veuillez indiquer le code à 6 chiffres généré par votre téléphone</label>
+                          {{ field }}
+                           </div>
+                      {% endif %}
+                  {%  endfor %}
+            </fieldset>
+        <div class="form__group">
+            <input type="submit" class="button" value="Enregistrer le mandat" />
+        </div>
+
+        </div>
+
     </form>
-  <div>
+  </div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -7,65 +7,61 @@
 {% endblock extracss %}
 
 {% block content %}
-<div class="hero">
-  <div class="container hero__container">
-    <h1>Récapitulatif du mandat</h1>
-  </div>
-</div>
-<section class="section section-grey">
-  <div class="container container-small">
-  <h2>Éléments du mandat</h2>
-    <a class="button" href="{% url 'new_mandat_preview' %}" target="_blank">🖨 Imprimer le mandat</a>
-    <form method="post" class="panel">
-      {% if error %}
-        <div class="notification warning">{{ error }}</div>
-      {% endif %}
-      {% csrf_token %}
-      <div class="form__group">
-        <p id="recap_text"><strong>{{ usager }}</strong> autorise <strong>{{ aidant }}</strong>,  <em>aidant·e numérique</em> au sein de <em>{{ aidant.organisation.name }}</em>  à réaliser en mon nom conformément aux dispositions des articles 1984 et suivants du Code civil, la ou les démarches administratives en ligne suivantes :</p>
-        <ul>
-          {% for demarche in demarches %}
-            <li>{{ demarche }}</li>
-          {% endfor %}
-        </ul>
-        pour une durée de : <strong>{{ duree }}</strong>
+  <div class="hero">
+    <div class="container hero__container">
+      <h1>Récapitulatif du mandat</h1>
     </div>
-
-    <h2>Validation de l'usager</h2>
-
-
-    <form method="post">
-
-        {% if form.non_field_errors %}
-            <div class="notification warning">{{ form.non_field_errors }}</div>
+  </div>
+  </div>
+  <section class="section section-grey">
+    <div class="container container-small">
+      <h2>Éléments du mandat</h2>
+      <a class="button" href="{% url 'new_mandat_preview' %}" target="_blank">🖨 Imprimer le mandat</a>
+      <form method="post" class="panel">
+        {% if error %}
+          <div class="notification warning">{{ error }}</div>
         {% endif %}
         {% csrf_token %}
-    <div class="panel form__group mandat__agreement">
-    En cochant les cases, {{ usager }} confirme :
-            <div class="checkbox__group">
-                <input type="checkbox" name="personal_data" required id="id_personal_data">
-                <label class="label-inline" for="id_personal_data">Avoir reçu, de la part de <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> de <strong>{{ aidant.organisation.name }}</strong> les informations concernant l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression, etc.)</label>
-            </div>
-            <div class="checkbox__group">
-                <input type="checkbox" name="brief" required id="id_brief">
-                <label class="label-inline" for="id_brief">Autoriser les aidants habilités de <strong> {{ aidant.organisation.name }}</strong> à utiliser ses données à caractère personnel.</label>
-            </div>
-    </div>
-    <h2>Validation de l'aidant</h2>
-        <div class="panel form__group mandat__agreement">
-            <fieldset>
-                <div class="not_checkbox_group">
-                    <label for="id_otp_token">Veuillez indiquer le code à 6 chiffres généré par votre téléphone</label>
-                    <input type="text" name="otp_token" maxlength="6" minlength="6" required id="id_otp_token">
-                </div>
-            </fieldset>
         <div class="form__group">
+          <p id="recap_text"><strong>{{ usager }}</strong> autorise <strong>{{ aidant }}</strong>,  <em>aidant·e numérique</em> au sein de <em>{{ aidant.organisation.name }}</em>  à réaliser en mon nom conformément aux dispositions des articles 1984 et suivants du Code civil, la ou les démarches administratives en ligne suivantes :</p>
+          <ul>
+            {% for demarche in demarches %}
+              <li>{{ demarche }}</li>
+            {% endfor %}
+          </ul>
+          pour une durée de : <strong>{{ duree }}</strong>
+        </div>
+      </form>
+      <h2>Validation de l'usager</h2>
+      <form method="post">
+        {% if form.non_field_errors %}
+          <div class="notification warning">{{ form.non_field_errors }}</div>
+        {% endif %}
+        {% csrf_token %}
+        <div class="panel form__group mandat__agreement">
+          En cochant les cases, {{ usager }} confirme :
+          <div class="checkbox__group">
+            <input type="checkbox" name="personal_data" required id="id_personal_data">
+            <label class="label-inline" for="id_personal_data">Avoir reçu, de la part de <strong>{{ aidant.first_name }} {{ aidant.last_name }}</strong> de <strong>{{ aidant.organisation.name }}</strong> les informations concernant l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression, etc.)</label>
+          </div>
+          <div class="checkbox__group">
+            <input type="checkbox" name="brief" required id="id_brief">
+            <label class="label-inline" for="id_brief">Autoriser les aidants habilités de <strong> {{ aidant.organisation.name }}</strong> à utiliser ses données à caractère personnel.</label>
+          </div>
+        </div>
+        <h2>Validation de l'aidant</h2>
+        <div class="panel form__group mandat__agreement">
+          <fieldset>
+            <div class="not_checkbox_group">
+              <label for="id_otp_token">Veuillez indiquer le code à 6 chiffres généré par votre téléphone</label>
+              <input type="text" name="otp_token" maxlength="6" minlength="6" required id="id_otp_token">
+            </div>
+          </fieldset>
+          <div class="form__group">
             <input type="submit" class="button" value="Enregistrer le mandat" />
+          </div>
         </div>
-
-        </div>
-
-    </form>
-  </div>
-</section>
+      </form>
+    </div>
+  </section>
 {% endblock content %}

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -16,6 +16,8 @@ class CreateNewMandat(StaticLiveServerTestCase):
         # FC only calls back on specific port
         cls.port = settings.FC_AS_FS_TEST_PORT
         cls.aidant = UserFactory()
+        device = cls.aidant.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
         super().setUpClass()
         cls.selenium = WebDriver()
         cls.selenium.implicitly_wait(10)
@@ -88,16 +90,19 @@ class CreateNewMandat(StaticLiveServerTestCase):
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(recap_title, "Récapitulatif")
+        self.assertEqual(recap_title, "Récapitulatif du mandat")
         recap_text = self.selenium.find_element_by_id("recap_text").text
         self.assertIn("Angela Claire Louise DUBOIS ", recap_text)
         checkboxes = self.selenium.find_elements_by_tag_name("input")
-        id_personal_data = checkboxes[1]
+        id_personal_data = checkboxes[2]
         self.assertEqual(id_personal_data.get_attribute("id"), "id_personal_data")
         id_personal_data.click()
-        id_brief = checkboxes[2]
+        id_brief = checkboxes[3]
         self.assertEqual(id_brief.get_attribute("id"), "id_brief")
         id_brief.click()
+        id_otp_token = checkboxes[4]
+        self.assertEqual(id_otp_token.get_attribute("id"), "id_otp_token")
+        id_otp_token.send_keys("123456")
         submit_button = checkboxes[-1]
         self.assertEqual(submit_button.get_attribute("type"), "submit")
         submit_button.click()

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -53,7 +53,13 @@ class NewMandatRecapTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.aidant_thierry = factories.UserFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+        device.token_set.create(token="223456")
+
         self.aidant_monique = factories.UserFactory(username="monique@monique.com")
+        device = self.aidant_monique.staticdevice_set.create(id=2)
+        device.token_set.create(token="323456")
 
         self.test_usager = Usager.objects.create(
             given_name="Fabrice",
@@ -95,7 +101,8 @@ class NewMandatRecapTests(TestCase):
         session.save()
 
         response = self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "123456"},
         )
         self.assertEqual(Usager.objects.all().count(), 1)
         usager = Usager.objects.get(given_name="Fabrice")
@@ -119,7 +126,8 @@ class NewMandatRecapTests(TestCase):
         session["connection"] = mandat_builder.id
         session.save()
         response = self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "123456"},
         )
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
@@ -136,7 +144,8 @@ class NewMandatRecapTests(TestCase):
         session.save()
         # trigger the mandat creation/update
         self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "123456"},
         )
 
         self.assertEqual(Mandat.objects.count(), 1)
@@ -153,7 +162,8 @@ class NewMandatRecapTests(TestCase):
         session.save()
         # trigger the mandat creation/update
         self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "223456"},
         )
 
         self.assertEqual(Mandat.objects.count(), 1)
@@ -179,7 +189,8 @@ class NewMandatRecapTests(TestCase):
         session.save()
         # trigger the mandat creation/update
         self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "123456"},
         )
         self.client.logout()
 
@@ -194,7 +205,8 @@ class NewMandatRecapTests(TestCase):
 
         # trigger the mandat creation/update
         self.client.post(
-            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/",
+            data={"personal_data": True, "brief": True, "otp_token": "323456"},
         )
 
         self.assertEqual(Mandat.objects.count(), 2)

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -10,7 +10,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 
 from aidants_connect_web.models import Mandat, Connection
-from aidants_connect_web.forms import MandatForm
+from aidants_connect_web.forms import MandatForm, RecapMandatForm
 from aidants_connect_web.views.service import humanize_demarche_names
 
 logging.basicConfig(level=logging.INFO)
@@ -60,7 +60,7 @@ def new_mandat_recap(request):
         humanize_demarche_names(demarche) for demarche in connection.demarches
     ]
     if request.method == "GET":
-
+        form = RecapMandatForm(aidant)
         return render(
             request,
             "aidants_connect_web/new_mandat/new_mandat_recap.html",
@@ -69,12 +69,13 @@ def new_mandat_recap(request):
                 "usager": usager,
                 "demarches": demarches_description,
                 "duree": duree,
+                "form": form,
             },
         )
 
     else:
-        form = request.POST
-        if form.get("personal_data") and form.get("brief"):
+        form = RecapMandatForm(aidant=aidant, data=request.POST)
+        if form.is_valid():
             # The loop below creates one Mandat object per Démarche selected in the form
             for demarche in connection.demarches:
                 try:
@@ -109,7 +110,8 @@ def new_mandat_recap(request):
                     "usager": usager,
                     "demarche": demarches_description,
                     "duree": duree,
-                    "error": "Vous devez accepter les conditions du mandat.",
+                    "form": form,
+                    "error": form.errors,
                 },
             )
 


### PR DESCRIPTION
# 🌮 Objectif
Sécuriser la création du mandat tout en restant passwordless et éviter une trop grande dépendance sur nos mailer.

# 🔍 Implémentation
- Demander à l'aidant, à la fin du récapitulatif du mandat, de rentrer un TOTP
- checker la validité de ce mandat dans un "Django form" grâce à la fonction helper "check_token" de Django OTP.

