### PR TITLE
Simplifie l'impression de mandat en cours de création

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import AbstractUser

--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -6,6 +6,7 @@
   display: flex;
   flex-direction: column;
   justify-content: center;
+  max-width: none;
 }
 
 @media (max-width: 749px) {

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -72,6 +72,14 @@ h1.brand, h2.brand, h3.brand, h4.brand, h5.brand, h6.brand {
   width: 170px;
 }
 
+.margin-left-100 {
+  margin-left: 100px;
+}
+
+.margin-bottom-50 {
+  margin-bottom: 50px;
+}
+
 @media (max-width: 699px) {
   form {
     padding: 0 1em;

--- a/aidants_connect_web/static/css/mandat_print.css
+++ b/aidants_connect_web/static/css/mandat_print.css
@@ -3,13 +3,10 @@ main {
   }
 
 .container {
-    font-size: .70em;
+    font-size: .75em;
+    line-height: 1.5em;
     border: 1px solid gray;
     padding: 30px;
-}
-
-.column {
-    flex: 50%;
 }
 
 @media print {

--- a/aidants_connect_web/static/css/mandat_print.css
+++ b/aidants_connect_web/static/css/mandat_print.css
@@ -1,0 +1,28 @@
+main {
+    margin: 20px;
+  }
+
+.container {
+    font-size: .70em;
+    border: 1px solid gray;
+    padding: 30px;
+}
+
+.column {
+    flex: 50%;
+}
+
+@media print {
+    @page {
+        size: auto; /* auto is the initial value */
+        margin: 0; /* this affects the margin in the printer settings */
+    }
+    .no-print,
+    .no-print * {
+        display: none !important;
+    }
+    .container {
+        border: 0;
+        padding: 0;
+    }
+}

--- a/aidants_connect_web/templates/aidants_connect_web/dashboard.html
+++ b/aidants_connect_web/templates/aidants_connect_web/dashboard.html
@@ -1,6 +1,7 @@
 {% extends 'layouts/main.html' %}
 
 {% load static %}
+
 {% block extracss %}
 <link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/home_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/home_page.html
@@ -2,12 +2,11 @@
 
 {% load static %}
 
-{% block content %}
-
 {% block extracss %}
 <link href="{% static 'css/home.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
+{% block content %}
 <div class="hero">
   <div class="hero__container">
     <div class="row">
@@ -18,7 +17,7 @@
         </p>
         <p>Ce service sécurise et facilite le « faire pour le compte de ».</p>
       </div>
-      <img src="{% static "images/aidantsconnect-illustration.svg" %}" alt="" />
+      <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="" />
     </div>
   </div>
 </div>
@@ -65,5 +64,4 @@
     <h2 class="text-center">Aidants Connect est un service qui utilise <img class="logo__fc" src="{% static 'images/fc_logo_v2.png'%}" /></h2>
   </div>
 </section>
-
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -18,19 +18,19 @@
       <fieldset>
         <legend>Choisissez l'usager que vous souhaitez FranceConnecter.</legend>
         <div id="usagers" class="grid">
-        {% for usager in usagers %}
-          <div id="usager" class="tile">
-          <input id="button-{{ usager.id }}" type="submit" value="{{ usager.id }}" name="chosen_usager"/>
-          <label id="label-usager" for="button-{{ usager.id }}">
-            <h3>{{ usager.family_name }} {{ usager.given_name }}</h3>
-          </label>
-        </div>
-        {% endfor %}
+          {% for usager in usagers %}
+            <div id="usager" class="tile">
+              <input id="button-{{ usager.id }}" type="submit" value="{{ usager.id }}" name="chosen_usager" />
+              <label id="label-usager" for="button-{{ usager.id }}">
+                <h3>{{ usager.family_name }} {{ usager.given_name }}</h3>
+              </label>
             </div>
-          {% csrf_token %}
-          <input type="hidden" name="state" value="{{state}}" />
-          </fieldset>
-      </form>
-    <div>
+          {% endfor %}
+        </div>
+        {% csrf_token %}
+        <input type="hidden" name="state" value="{{ state }}" />
+      </fieldset>
+    </form>
+  <div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
@@ -14,22 +14,22 @@
       <h2 id="welcome_aidant">Sélectionnez le type de démarche que vous allez effectuer</h2>
       <p id="instructions">En selectionnant une démarche, vous allez FranceConnecter [Nom de l'usager] (Changer d'usager)</p>
       {% csrf_token %}
-        <input type="hidden" name="state" value="{{state}}" />
-        <div id="demarches_list" class="grid">
-            {% for demarche, demarche_info in demarches.items %}
-            <div id="{{ demarche }}" class="tile">
-                <input id="button-{{ demarche }}" type="submit" value="{{ demarche }}" name="chosen_demarche"/>
-                <label id="label_demarche" for="button-{{ demarche }}">
-                    <img src="{{ demarche_info.icon }}">
-                    <h3>{{ demarche_info.titre }}</h3>
-                    <p>{{ demarche_info.description }}</p>
-                </label>
-            </div>
-            {% endfor %}
-        </div>
+      <input type="hidden" name="state" value="{{ state }}" />
+      <div id="demarches_list" class="grid">
+        {% for demarche, demarche_info in demarches.items %}
+          <div id="{{ demarche }}" class="tile">
+            <input id="button-{{ demarche }}" type="submit" value="{{ demarche }}" name="chosen_demarche" />
+            <label id="label_demarche" for="button-{{ demarche }}">
+              <img src="{{ demarche_info.icon }}">
+              <h3>{{ demarche_info.titre }}</h3>
+              <p>{{ demarche_info.description }}</p>
+            </label>
+          </div>
+        {% endfor %}
+      </div>
     </form>
     <p>Si vous ne trouvez pas le type de démarche que vous souhaitez effectuer, il se peut que vous n'ayez pas de mandat ou que le mandat a expiré.
     Pour créer un nouveau mandat, rendez-vous sur <a href="aidantsconnect.beta.gouv.fr">aidantsconnect.beta.gouv.fr</a></p>
-    </div>
+  </div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandats.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandats.html
@@ -3,7 +3,7 @@
 {% load static %}
 
 {% block extracss %}
-  <link href="{% static 'css/mandats.css' %}" rel="stylesheet">
+<link href="{% static 'css/mandats.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
 {% block content %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -32,15 +32,15 @@
       <div id="demarches" class="tiles">
         <h2>Étape 1 : Sélectionnez la ou les démarche(s)</h2>
         {% if form.errors %}
-        <div class="notification">
-        {{ form.errors }}
-        </div>
+          <div class="notification">
+          {{ form.errors }}
+          </div>
         {% endif %}
         {% csrf_token %}
         <div id="demarches_list" class="grid">
           {% for value, label in form.demarche.field.choices %}
             <div id="{{ value }}" class="tile">
-              <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
+              <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" />
               <label class="label-demarche" for="button-{{ value }}">
                 <img src={{ label.icon }} alt="">
                 <h3 class="brand">{{ label.titre }}</h3>
@@ -55,7 +55,7 @@
         <div id="duree_list" class="grid">
           {% for value, label in form.duree.field.choices %}
             <div id="{{ value }}" class="tile">
-              <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree"/>
+              <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree" />
               <label class="label-duree" for="button-{{ value }}">
                 <h3>{{ label.title }}</h3>
                 <span>{{ label.description }}</span>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
@@ -10,7 +10,6 @@
 {% endblock nav %}
 
 {% block content %}
-
 <section class="no-print text-center">
   <p><i>
     🖨 Pour imprimer, sélectionnez dans le menu de votre navigateur 'Fichier', puis 'Imprimer'.

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
@@ -12,14 +12,9 @@
 {% block content %}
 
 <section class="no-print text-center">
-  <!-- <p>
-    Ci-dessous l'aperçu du Mandat.
-  </p> -->
   <p><i>
     🖨 Pour imprimer, sélectionnez dans le menu de votre navigateur 'Fichier', puis 'Imprimer'.
   </i></p>
-    <!-- <button onclick="window.print();">cliquez ici</button> -->
-    <!-- <a href="javascript:window.print()">cliquez ici</a> -->
   </div>
   <br>
 </section>
@@ -102,13 +97,6 @@
     Fait à <strong>{{ lieu }}</strong>, le <strong>{{ date }}</strong>
   </p>
 
-  <!-- <p>
-    Le mandant Le mandataire
-  </p> -->
-  <!-- <div class="row">
-    <div class="column">Le mandant</div>
-    <div class="column">Le mandataire</div>
-  </div> -->
   <p class="margin-bottom-50">
     <span>Le mandant</span>
     <span class="margin-left-100">Le mandataire</span>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -14,7 +14,7 @@
 </div>
 <section class="section section-grey">
   <div class="container container-small">
-    <a class="button" href="{% url 'generate_mandat_preview'%}" target="_blank">🖨 Imprimer le mandat</a>
+    <a class="button" href="{% url 'new_mandat_preview' %}" target="_blank">🖨 Imprimer le mandat</a>
     <form method="post" class="panel">
       {% if error %}
         <div class="notification warning">{{ error }}</div>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/pdf_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/pdf_mandat.html
@@ -1,71 +1,120 @@
-<html>
-<head>
-  <title>Test</title>
-  <style>
-    body {
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-      font-size: .75em;
-    }
-    h1 {
-        font-size: 1.5em;
-        font-weight: bold;
-    }
+{% extends 'layouts/main.html' %}
 
-  </style>
-</head>
-<body>
-<h1>Mandat type d’un aidant réalisant des démarches administratives en ligne au bénéfice d’un usager via le service « Aidants Connect »</h1>
+{% load static %}
 
-<p>Je soussigné(e), <strong>{{usager}}</strong> autorise <strong>{{aidant}}</strong>, exerçant  la profession de <strong>{{profession}}</strong> au sein de <strong>{{organisation}}</strong> à
-    réaliser en mon nom conformément aux dispositions des articles 1984 et suivants du Code civil, les démarches administratives en ligne suivantes:</p>
+{% block extracss %}
+<link href="{% static 'css/mandat_print.css' %}" rel="stylesheet">
+{% endblock extracss %}
 
-{% for demarche in demarches %}
+{% block nav %}
+{% endblock nav %}
+
+{% block content %}
+
+<section class="no-print text-center">
+  <!-- <p>
+    Ci-dessous l'aperçu du Mandat.
+  </p> -->
+  <p><i>
+    🖨 Pour imprimer, sélectionnez dans le menu de votre navigateur 'Fichier', puis 'Imprimer'.
+  </i></p>
+    <!-- <button onclick="window.print();">cliquez ici</button> -->
+    <!-- <a href="javascript:window.print()">cliquez ici</a> -->
+  </div>
+  <br>
+</section>
+
+<section class="container">
+  <div class="navbar__home text-center">
+    <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}"
+      alt="aidantsconnect.beta.gouv.fr" /><img src="{% static 'images/aidants-connect_logo.png' %}" class="navbar__gouvfr" alt="aidantsconnect.beta.gouv.fr" />
+  </div>
+  
+  <h1>Mandat type d’un aidant réalisant des démarches administratives en ligne au bénéfice d’un usager via le service
+    « Aidants Connect »</h1>
+
+  <p>Je soussigné(e), <strong>{{ usager }}</strong> autorise <strong>{{ aidant }}</strong>, exerçant la profession de
+    <strong>{{profession}}</strong> au sein de <strong>{{ organisation }}</strong> à
+    réaliser en mon nom conformément aux dispositions des articles 1984 et suivants du Code civil, les démarches
+    administratives en ligne suivantes:</p>
+
+  <ul>
+    {% for demarche in demarches %}
+      <li><strong>{{ demarche }}</strong></li>
+    {% endfor %}
+  </ul>
+
+  <p>
+    pour une durée de <strong>{{ duree }}</strong>.
+  </p>
+
+  <p>
+    À cette fin :
     <ul>
-        <li><strong>{{ demarche }}</strong></li>
+      <li><strong>{{ usager }}</strong> autorise <strong>{{ aidant }}</strong> à utiliser ses données à caractère personnel.
+      </li>
+      <li><strong>{{ aidant }}</strong> a rappelé à <strong>{{ usager }}</strong> l’objet de l’intervention, la raison pour
+        laquelle ses informations sont collectées et leur utilité ; l’existence de droits
+        sur ses données (accès, rectification, suppression, etc.) et la possibilité pour le mandant de retirer à tout
+        moment son consentement.</li>
     </ul>
-{% endfor %}
+  </p>
 
-<p> pour une durée de <strong>{{duree}}</strong></p>
-
- <p>À cette fin :
-     <ul>
-    <li><strong>{{usager}}</strong> autorise <strong>{{aidant}}</strong> à utiliser ses données à caractère personnel.</li>
-    <li><strong>{{aidant}}</strong> a rappelé à <strong>{{usager}}</strong> l’objet de l’intervention, la raison pour laquelle ses informations sont collectées et leur utilité ; l’existence de droits
-        sur ses données (accès, rectification, suppression, etc.) et la possibilité pour le mandant de retirer à tout moment son consentement.</li>
-</ul>
- </p>
-<p>
-Le mandataire s’engage à :
+  <p>
+    Le mandataire s’engage à :
     <ol>
-        <li>ne collecter et enregistrer que les seules informations strictement nécessaires au regard  des démarches susvisées ;</li>
-        <li>n’utiliser les informations concernant le mandant que pour les seules démarches susvisées. S’il a besoin de les utiliser pour d’autres démarches, il doit au préalable en informer le mandant et en demander l’autorisation ;</li>
-        <li>mettre à jour puis à supprimer l’ensemble des informations relatives au mandant lorsqu’elles ne sont plus nécessaires à la réalisation des démarches lui incombant au titre du mandat ;</li>
-        <li>informer le mandant de toutes les actions qu’il/elle effectue à sa place ;</li>
-        <li>conserver les données à caractère personnel strictement nécessaires à ces démarches le  seul temps strictement nécessaire à leur réalisation.</li>
+      <li>ne collecter et enregistrer que les seules informations strictement nécessaires au regard des démarches
+        susvisées ;</li>
+      <li>n’utiliser les informations concernant le mandant que pour les seules démarches susvisées. S’il a besoin de
+        les utiliser pour d’autres démarches, il doit au préalable en informer le mandant et en demander
+        l’autorisation ;</li>
+      <li>mettre à jour puis à supprimer l’ensemble des informations relatives au mandant lorsqu’elles ne sont plus
+        nécessaires à la réalisation des démarches lui incombant au titre du mandat ;</li>
+      <li>informer le mandant de toutes les actions qu’il/elle effectue à sa place ;</li>
+      <li>conserver les données à caractère personnel strictement nécessaires à ces démarches le seul temps strictement
+        nécessaire à leur réalisation.</li>
     </ol>
-</p>
+  </p>
 
-
-<p>
+  <p>
     Le mandataire est soumis à une obligation de confidentialité.
     Il ne doit en aucun cas divulguer les informations du mandant à des tiers lorsque cette divulgation n’est
     pas nécessaire à l’accomplissement des démarches dont il est responsable (ex. : il ne doit pas
     communiquer des informations concernant le mandant à son collègue de travail). Le mandataire enregistre les
     informations du mandant de manière sécurisée et notamment prend toutes précautions pour assurer la sécurité physique
     et logique de ces données.
-</p>
+  </p>
 
-<p>Le présent mandat est accepté et consenti pour la durée nécessaire à l’accomplissement des missions de <strong>{{aidant}}</strong>.
+  <p>
+    Le présent mandat est accepté et consenti pour la durée nécessaire à l’accomplissement des missions de
+    <strong>{{ aidant }}</strong>.
     Le mandat prend fin lorsque la réalisation des démarches susvisées a été accomplie, ou à tout moment si le mandant
-    ou le mandataire décide de révoquer le mandat.</p>
+    ou le mandataire décide de révoquer le mandat.
+  </p>
 
-<p><strong>{{aidant}}</strong> est tenu(e) d’accomplir le mandat tant qu’il en demeure chargé, et répond des dommages et intérêts qui
-    pourraient résulter de son inexécution conformément à l’article 1991 du Code civil.</p>
+  <p>
+    <strong>{{ aidant }}</strong> est tenu(e) d’accomplir le mandat tant qu’il en demeure chargé, et répond des dommages
+    et intérêts qui
+    pourraient résulter de son inexécution conformément à l’article 1991 du Code civil.
+  </p>
 
-<p>Fait à <strong>{{lieu}}</strong>, le <strong>{{date}}</strong></p>
+  <p>
+    Fait à <strong>{{ lieu }}</strong>, le <strong>{{ date }}</strong>
+  </p>
 
-<p>Le mandant Le mandataire</p>
+  <!-- <p>
+    Le mandant Le mandataire
+  </p> -->
+  <!-- <div class="row">
+    <div class="column">Le mandant</div>
+    <div class="column">Le mandataire</div>
+  </div> -->
+  <p class="margin-bottom-50">
+    <span>Le mandant</span>
+    <span class="margin-left-100">Le mandataire</span>
+  </p>
+</section>
+{% endblock content %}
 
-
-</body>
-</html>
+{% block footer %}
+{% endblock footer %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/recap.html
@@ -14,7 +14,7 @@
 </div>
 <section class="section section-grey">
   <div class="container container-small">
-    <a class="button" href="{% url 'generate_mandat_pdf'%}">🖨 Imprimer le mandat</a>
+    <a class="button" href="{% url 'generate_mandat_pdf'%}" target="_blank">🖨 Imprimer le mandat</a>
     <form method="post" class="panel">
       {% if error %}
         <div class="notification warning">{{ error }}</div>
@@ -24,7 +24,7 @@
         <p id="recap_text"><strong>{{ usager }}</strong> autorise <strong>{{ aidant }}</strong>,  <em>aidant·e numérique</em> au sein de <em>{{ aidant.organisation.name }}</em>  à réaliser en mon nom conformément aux dispositions des articles 1984 et suivants du Code civil, la ou les démarches administratives en ligne suivantes :</p>
         <ul>
           {% for demarche in demarches %}
-          <li>{{ demarche }}</li>
+            <li>{{ demarche }}</li>
           {% endfor %}
         </ul>
         pour une durée de : <strong>{{ duree }}</strong>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/recap.html
@@ -14,7 +14,7 @@
 </div>
 <section class="section section-grey">
   <div class="container container-small">
-    <a class="button" href="{% url 'generate_mandat_pdf'%}" target="_blank">🖨 Imprimer le mandat</a>
+    <a class="button" href="{% url 'generate_mandat_preview'%}" target="_blank">🖨 Imprimer le mandat</a>
     <form method="post" class="panel">
       {% if error %}
         <div class="notification warning">{{ error }}</div>

--- a/aidants_connect_web/templates/aidants_connect_web/resource_list.html
+++ b/aidants_connect_web/templates/aidants_connect_web/resource_list.html
@@ -1,43 +1,47 @@
 {% load static %}
 
 <div class="row">
-    <div class="card">
-      <div class="card__cover">
-         <img src="{% static "images/ressources/kitinterventionrimage.png" %}"  alt="Écran montrant le site du kit d'intervention rapide">
-      </div>
+  <div class="card">
+    <div class="card__cover">
+      <img src="{% static 'images/ressources/kitinterventionrimage.png' %}" alt="Écran montrant le site du kit d'intervention rapide">
+    </div>
+    <div class="card__content">
+      <h3 class="brand">Kit d'intervention rapide</h3>
+      <div class="card__meta"><span>Mission Société Numérique</span></div>
+      <p>
+        Ce site a pour objectif de permettre à toute personne, en particulier les non professionnels
+        de la médiation numérique, d’aborder rapidement les principaux enjeux de l’accompagnement
+        des individus en difficulté sur les outils numériques.
+      </p>
+    </div>
+    <div class="card__extra">
+      <div class="label"><a href="https://kit-inclusion.societenumerique.gouv.fr">https://kit-inclusion.societenumerique.gouv.fr</a></div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card__cover">
+        <img src="{% static 'images/ressources/maquetteimpotsimage.png' %}" alt="Écran montrant le site de démonstration des impôts">
+    </div>
+    <div class="card__content">
+      <h3 class="brand">Site de démonstration des impôts</h3>
+      <div class="card__meta"><span>Direction Générale des Finances Publiques</span></div>
+      <p>
+        Ce site est une copie du site des impôts permettant de simuler les déclarations en ligne
+        sans manipuler les données personnelles de la personne accompagnée.
+      </p>
+    </div>
+    <div class="card__extra">
+      <div class="label"><a href="https://impots.societenumerique.gouv.fr/">https://impots.societenumerique.gouv.fr/</a></div>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card__cover">
+      <img src="{% static 'images/ressources/forumimage.png' %}" alt="Écran montrant le forum des aidants">
+    </div>
       <div class="card__content">
-        <h3 class="brand">Kit d'intervention rapide</h3>
-        <div class="card__meta"><span>Mission Société Numérique</span></div>
-        <p>Ce site a pour objectif de permettre à toute personne, en particulier les non professionnels
-            de la médiation numérique, d’aborder rapidement les principaux enjeux de l’accompagnement
-            des individus en difficulté sur les outils numériques.</p>
+        <h3 class="brand">Forum des aidants</h3>
+        <div class="card__meta"><span>Équipe Aidants Connect</span></div>
+        <p>Bientôt disponible</p>
       </div>
-      <div class="card__extra">
-          <div class="label"><a href="https://kit-inclusion.societenumerique.gouv.fr">https://kit-inclusion.societenumerique.gouv.fr</a></div>
-      </div>
-    </div>
-    <div class="card">
-      <div class="card__cover">
-         <img src="{% static "images/ressources/maquetteimpotsimage.png" %}" alt="Écran montrant le site de démonstration des impôts">
-      </div>
-      <div class="card__content">
-        <h3 class="brand">Site de démonstration des impôts</h3>
-        <div class="card__meta"><span>Direction Générale des Finances Publiques</span></div>
-        <p>Ce site est une copie du site des impôts permettant de simuler les déclarations en ligne
-            sans manipuler les données personnelles de la personne accompagnée.</p>
-      </div>
-      <div class="card__extra">
-          <div class="label"><a href="https://impots.societenumerique.gouv.fr/">https://impots.societenumerique.gouv.fr/</a></div>
-      </div>
-    </div>
-    <div class="card">
-      <div class="card__cover">
-         <img src="{% static "images/ressources/forumimage.png" %}" alt="Écran montrant le forum des aidants">
-      </div>
-        <div class="card__content">
-          <h3 class="brand">Forum des aidants</h3>
-          <div class="card__meta"><span>Équipe Aidants Connect</span></div>
-          <p>Bientôt disponible</p>
-        </div>
-    </div>
+  </div>
 </div>

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -78,19 +78,24 @@
     </defs>
   </svg>
 
-  {% include 'layouts/nav.html' %}
+  <!-- {% block nav %} -->
+    {% include 'layouts/nav.html' %}
+  <!-- {% endblock nav %} -->
 
-  {% block hero %}{% endblock %}
+  {% block hero %}
+  {% endblock %}
 
   <main>
-  {% block content %}{% endblock %}
+  {% block content %}
+  {% endblock %}
   </main>
 
-  {% include 'layouts/footer.html' %}
+  <!-- {% block footer %} -->
+    {% include 'layouts/footer.html' %}
+  <!-- {% endblock footer %} -->
 
   {% block extrajs %}
   {% endblock %}
-
 </body>
 
 </html>

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -78,9 +78,9 @@
     </defs>
   </svg>
 
-  <!-- {% block nav %} -->
+  {% block nav %}
     {% include 'layouts/nav.html' %}
-  <!-- {% endblock nav %} -->
+  {% endblock nav %}
 
   {% block hero %}
   {% endblock %}
@@ -90,9 +90,9 @@
   {% endblock %}
   </main>
 
-  <!-- {% block footer %} -->
+  {% block footer %}
     {% include 'layouts/footer.html' %}
-  <!-- {% endblock footer %} -->
+  {% endblock footer %}
 
   {% block extrajs %}
   {% endblock %}

--- a/aidants_connect_web/templates/login/email_sent.html
+++ b/aidants_connect_web/templates/login/email_sent.html
@@ -1,18 +1,22 @@
 {% extends 'layouts/main.html' %}
+
 {% load static %}
+
 {% block extracss %}
 <link href="{% static 'css/login.css' %}" rel="stylesheet">
 {% endblock extracss %}
+
 {% block content %}
-  <div class="page">
-    <div class="main-page">
-      <section class="section section-white">
-        <div class="container">
-          <h1>Un email vous a été envoyé pour vous connecter.</h1>
-        </div>
-        <div class="container">
-           Si vous ne le recevez pas, vous pouvez <a href="{% url 'magicauth-login' %}" class="btn btn-secondary">réessayer</a>.
-        </div>
-      </section>
-    </div>
+<div class="page">
+  <div class="main-page">
+    <section class="section section-white">
+      <div class="container">
+        <h1>Un email vous a été envoyé pour vous connecter.</h1>
+      </div>
+      <div class="container">
+          Si vous ne le recevez pas, vous pouvez <a href="{% url 'magicauth-login' %}" class="btn btn-secondary">réessayer</a>.
+      </div>
+    </section>
+  </div>
+</div>
 {% endblock content %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -1,15 +1,18 @@
 {% extends 'layouts/main.html' %}
+
 {% load static %}
+
 {% block extracss %}
 <link href="{% static 'css/login.css' %}" rel="stylesheet">
 {% endblock extracss %}
+
 {% block content %}
 <div class="page">
   <div class="main-page">
     <section class="section section-white">
-    <div class="container">
-      <form class="" method="post">
-        {% csrf_token %}
+      <div class="container">
+        <form class="" method="post">
+          {% csrf_token %}
           {% if user.is_authenticated %}
             <div class="alert alert-info text-center" role="alert">
               Vous êtes déjà connecté
@@ -31,19 +34,31 @@
                 <p><strong>Aidants Connect est disponible dans un nombre limité de structures d'accompagnement.</strong></p>
                 <p>Si vous faites partie d'une de ces structures, vous pouvez vous connecter :</p>
               <input type="email" name="email" class="form-control {% if form.errors %}state-invalid {% endif %}"
-                               id="id_email" aria-describedby="emailHelp" placeholder="Votre email" required/>
+                                id="id_email" aria-describedby="emailHelp" placeholder="Votre email" required/>
               {% for error in form.email.errors %}
                 <div class="alet alert-danger text-center">{{ error }}</div>
               {% endfor %}
             </div>
             <button type="submit" class="button">Valider</button>
           {% endif %}
-          <p>Ce service est reservé aux aidants professionnels salariés d'une structure habilitée Aidants Connect. Pour en savoir plus,  <a href="mailto:aidantsconnect@beta.gouv.fr?subject=[site Aidants Connect - login] Demande d'informations">contactez-nous</a>.</p>
-          <p>Vous êtes habilité Aidants Connect et vous rencontrez des difficultés pour vous connecter?</p>
-        <a href="mailto:aidantsconnect@beta.gouv.frsubject=[site Aidants Connect - login] Demande d'aide au login">Demandez de l'aide</a>
-      </form>
-    </div>
-  </section>
+        </form>
+        <div class="text-center text-muted">
+          <p>
+            <strong>Aidants Connect est actuellement en test dans un nombre limité de structures d'accompagnement.</strong>
+          </p>
+          <p>
+            Ce service est reservé aux aidants professionnels salariés d'une structure habilitée Aidants Connect.
+          </p>
+          <p>
+            Pour en savoir plus, <a href="mailto:aidantsconnect@beta.gouv.fr?subject=[site Aidants Connect - login] Demande d'informations">contactez-nous</a>.
+          </p>
+          <p>
+            Vous êtes habilités Aidants Connect et vous rencontrez des difficultés pour vous connecter?
+          </p>
+          <a href="mailto:aidantsconnect@beta.gouv.frsubject=[site Aidants Connect - login] Demande d'aide au login">Demandez de l'aide</a>
+        </div>
+      </div>
+    </section>
   </div>
 </div>
 {% endblock content %}

--- a/aidants_connect_web/templates/registration/login.html
+++ b/aidants_connect_web/templates/registration/login.html
@@ -1,4 +1,5 @@
 {% extends 'layouts/main.html' %}
+
 {% load static %}
 
 {% block extracss %}

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -49,7 +49,7 @@ class NewMandatTests(TestCase):
 
 
 @tag("new_mandat")
-class RecapTests(TestCase):
+class NewMandatRecapTests(TestCase):
     def setUp(self):
         self.client = Client()
         self.aidant_thierry = factories.UserFactory()
@@ -71,8 +71,8 @@ class RecapTests(TestCase):
         )
 
     def test_recap_url_triggers_the_recap_view(self):
-        found = resolve("/recap/")
-        self.assertEqual(found.func, new_mandat.recap)
+        found = resolve("/new_mandat_recap/")
+        self.assertEqual(found.func, new_mandat.new_mandat_recap)
 
     def test_recap_url_triggers_the_recap_template(self):
         self.client.force_login(self.aidant_thierry)
@@ -81,9 +81,11 @@ class RecapTests(TestCase):
         session["connection"] = self.mandat_builder.id
         session.save()
 
-        response = self.client.get("/recap/")
+        response = self.client.get("/new_mandat_recap/")
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "aidants_connect_web/new_mandat/recap.html")
+        self.assertTemplateUsed(
+            response, "aidants_connect_web/new_mandat/new_mandat_recap.html"
+        )
 
     def test_post_to_recap_with_correct_data_redirects_to_dashboard(self):
         self.client.force_login(self.aidant_thierry)
@@ -93,7 +95,7 @@ class RecapTests(TestCase):
         session.save()
 
         response = self.client.post(
-            "/recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
         )
         self.assertEqual(Usager.objects.all().count(), 1)
         usager = Usager.objects.get(given_name="Fabrice")
@@ -117,7 +119,7 @@ class RecapTests(TestCase):
         session["connection"] = mandat_builder.id
         session.save()
         response = self.client.post(
-            "/recap/", data={"personal_data": True, "brief": True}
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
         )
         messages = list(get_messages(response.wsgi_request))
         self.assertEqual(len(messages), 1)
@@ -133,7 +135,9 @@ class RecapTests(TestCase):
         session["connection"] = mandat_builder_1.id
         session.save()
         # trigger the mandat creation/update
-        self.client.post("/recap/", data={"personal_data": True, "brief": True})
+        self.client.post(
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+        )
 
         self.assertEqual(Mandat.objects.count(), 1)
         last_journal_entry = Journal.objects.last()
@@ -148,7 +152,9 @@ class RecapTests(TestCase):
         session["connection"] = mandat_builder_2.id
         session.save()
         # trigger the mandat creation/update
-        self.client.post("/recap/", data={"personal_data": True, "brief": True})
+        self.client.post(
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+        )
 
         self.assertEqual(Mandat.objects.count(), 1)
         updated_mandat = Mandat.objects.get(
@@ -172,7 +178,9 @@ class RecapTests(TestCase):
         session["connection"] = mandat_builder_1.id
         session.save()
         # trigger the mandat creation/update
-        self.client.post("/recap/", data={"personal_data": True, "brief": True})
+        self.client.post(
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+        )
         self.client.logout()
 
         # second session : Create same mandat with other aidant
@@ -185,7 +193,9 @@ class RecapTests(TestCase):
         session.save()
 
         # trigger the mandat creation/update
-        self.client.post("/recap/", data={"personal_data": True, "brief": True})
+        self.client.post(
+            "/new_mandat_recap/", data={"personal_data": True, "brief": True}
+        )
 
         self.assertEqual(Mandat.objects.count(), 2)
         first_mandat = Mandat.objects.get(
@@ -233,16 +243,19 @@ class GenerateMandatPreview(TestCase):
             usager=self.test_usager,
         )
 
-    def test_generate_mandat_html_triggers_the_generate_mandat_preview_view(self):
-        found = resolve("/generate_mandat_preview/")
-        self.assertEqual(found.func, new_mandat.generate_mandat_preview)
+    def test_generate_mandat_html_triggers_the_new_mandat_preview_view(self):
+        found = resolve("/new_mandat_preview/")
+        self.assertEqual(found.func, new_mandat.new_mandat_preview)
 
     def test_response_is_the_preview_page(self):
         self.client.force_login(self.aidant_thierry)
+
         session = self.client.session
         session["connection"] = 1
         session.save()
-        response = self.client.get("/generate_mandat_preview/")
+
+        response = self.client.get("/new_mandat_preview/")
+
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(
             response, "aidants_connect_web/new_mandat/new_mandat_preview.html"
@@ -256,11 +269,9 @@ class GenerateMandatPreview(TestCase):
         session["connection"] = 1
         session.save()
 
-        response = self.client.get("/generate_mandat_preview/")
+        response = self.client.get("/new_mandat_preview/")
         response_content = response.content.decode("utf-8")
-        # pdfReader = PyPDF2.PdfFileReader(content)
-        # pageObj = pdfReader.getPage(0)
-        # page = pageObj.extractText()
+
         self.assertIn("mandataire", response_content)
         self.assertIn("Thierry GONEAU", response_content)
         self.assertIn("Fabrice MERCIER", response_content)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -11,12 +11,12 @@ urlpatterns = [
     path("mandats/", service.mandats, name="mandats"),
     # new mandat
     path("new_mandat/", new_mandat.new_mandat, name="new_mandat"),
-    path("recap/", new_mandat.recap, name="recap"),
-    path("logout-callback/", new_mandat.recap, name="recap"),
+    path("new_mandat_recap/", new_mandat.new_mandat_recap, name="new_mandat_recap"),
+    path("logout-callback/", new_mandat.new_mandat_recap, name="new_mandat_recap"),
     path(
-        "generate_mandat_preview/",
-        new_mandat.generate_mandat_preview,
-        name="generate_mandat_preview",
+        "new_mandat_preview/",
+        new_mandat.new_mandat_preview,
+        name="new_mandat_preview",
     ),
     # id_provider
     path("authorize/", id_provider.authorize, name="authorize"),

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -14,9 +14,9 @@ urlpatterns = [
     path("recap/", new_mandat.recap, name="recap"),
     path("logout-callback/", new_mandat.recap, name="recap"),
     path(
-        "generate_mandat_pdf/",
-        new_mandat.generate_mandat_pdf,
-        name="generate_mandat_pdf",
+        "generate_mandat_preview/",
+        new_mandat.generate_mandat_preview,
+        name="generate_mandat_preview",
     ),
     # id_provider
     path("authorize/", id_provider.authorize, name="authorize"),

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -1,26 +1,17 @@
 import logging
-import secrets
-from django.utils import formats
 from datetime import date
-from weasyprint import HTML
+from datetime import timedelta
 
 from django.db import IntegrityError
-
-from django.http import HttpResponse
+from django.utils import formats
+from django.utils import timezone
 from django.shortcuts import render, redirect
-from django.contrib.auth.decorators import login_required
-from django.core.files.storage import FileSystemStorage
-
 from django.contrib import messages
-from django.template.loader import render_to_string
+from django.contrib.auth.decorators import login_required
 
 from aidants_connect_web.models import Mandat, Connection
 from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.views.service import humanize_demarche_names
-
-from datetime import timedelta
-from django.utils import timezone
-
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
@@ -124,7 +115,7 @@ def recap(request):
 
 
 @login_required
-def generate_mandat_pdf(request):
+def generate_mandat_preview(request):
     connection = Connection.objects.get(pk=request.session["connection"])
     aidant = request.user
 
@@ -135,7 +126,7 @@ def generate_mandat_pdf(request):
 
     return render(
         request,
-        "aidants_connect_web/new_mandat/pdf_mandat.html",
+        "aidants_connect_web/new_mandat/new_mandat_preview.html",
         {
             "usager": f"{usager.given_name} {usager.family_name}",
             "aidant": f"{aidant.first_name} {aidant.last_name.upper()}",

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 from django.utils import formats
 from datetime import date
 from weasyprint import HTML
@@ -132,7 +133,8 @@ def generate_mandat_pdf(request):
 
     duree = "1 jour" if connection.duree == 1 else "1 an"
 
-    html_string = render_to_string(
+    return render(
+        request,
         "aidants_connect_web/new_mandat/pdf_mandat.html",
         {
             "usager": f"{usager.given_name} {usager.family_name}",
@@ -145,14 +147,3 @@ def generate_mandat_pdf(request):
             "duree": duree,
         },
     )
-
-    html = HTML(string=html_string)
-    html.write_pdf(target="/tmp/mandat_aidants_connect.pdf")
-
-    fs = FileSystemStorage("/tmp")
-    with fs.open("mandat_aidants_connect.pdf") as pdf:
-        response = HttpResponse(pdf, content_type="application/pdf")
-        response[
-            "Content-Disposition"
-        ] = "inline; filename='mandat_aidants_connect.pdf'"
-        return response

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -50,7 +50,7 @@ def new_mandat(request):
 
 
 @login_required
-def recap(request):
+def new_mandat_recap(request):
 
     connection = Connection.objects.get(pk=request.session["connection"])
     aidant = request.user
@@ -63,7 +63,7 @@ def recap(request):
 
         return render(
             request,
-            "aidants_connect_web/new_mandat/recap.html",
+            "aidants_connect_web/new_mandat/new_mandat_recap.html",
             {
                 "aidant": aidant,
                 "usager": usager,
@@ -103,7 +103,7 @@ def recap(request):
         else:
             return render(
                 request,
-                "aidants_connect_web/new_mandat/recap.html",
+                "aidants_connect_web/new_mandat/new_mandat_recap.html",
                 {
                     "aidant": aidant,
                     "usager": usager,
@@ -115,7 +115,7 @@ def recap(request):
 
 
 @login_required
-def generate_mandat_preview(request):
+def new_mandat_preview(request):
     connection = Connection.objects.get(pk=request.session["connection"])
     aidant = request.user
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,6 @@ selenium==3.141.0
 sqlparse==0.3.0
 whitenoise==5.0.1
 mock==3.0.5
-WeasyPrint==48
-PyPDF2==1.26.0
 git+git://github.com/betagouv/django-magicauth
 django-referrer-policy==1.0
 django-admin-honeypot==1.1.0


### PR DESCRIPTION
## 🌮 Objectif

Remplacer l'export PDF du mandat (en cours de création) par un export HTML (et ensuite impression via le navigateur)

## 🔍 Implémentation

- le template HTML s'appelle maintenant `new_mandat_preview.html`, avec un fichier de style `mandat_print.css` associé
- Utilisation du layout main (mais en cachant les blocks `nav` et `footer`)
- Suppression des packages Python `WeasyPrint` et `PyPDF2`
- Mise à jour des tests

la nouvelle page/template `new_mandat_preview`
![screenshot-localhost_3000-2020 01 15-19_08_10](https://user-images.githubusercontent.com/7147385/72459538-4a244080-37cb-11ea-9f20-12cf884863f9.png)

un exemple de mandat imprimé (pdf)
[AidantConnect - aidantconnect.beta.gouv.fr.pdf](https://github.com/betagouv/Aidants_Connect/files/4066632/AidantConnect.-.aidantconnect.beta.gouv.fr.pdf)

## 🏕 Amélioration continue

- pas mal de typos, strings & indentations
- fix sur la largeur du message d'accueil

## ⚠️ Informations supplémentaires

Le contenu (texte) du mandat n'est pas final (typos, variables manquantes)