### PR TITLE
Mettre à jour Django-otp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,6 @@ django-referrer-policy==1.0
 django-admin-honeypot==1.1.0
 django-csp==3.6
 factory-boy==2.12.0
-django-otp==0.7.4
+django-otp==0.7.5
 qrcode==6.1
 pre-commit==1.21.0


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir accéder à l'interface d'admin. 
L'interface d'admin utilise Django OTP et n'était plus disponible une fois le projet passé en Django 3.

## 🔍 Implémentation

- Mise à jour de la librairie Django-OTP 