### PR TITLE
Sécurise les cookies de sessions

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -288,6 +288,7 @@ ADMIN_URL = os.getenv("ADMIN_URL")
 ADMINS = [(os.getenv("ADMIN_NAME"), os.getenv("ADMIN_EMAIL"))]
 
 # Cookie security
+SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = False if os.getenv("SESSION_COOKIE_SECURE") == "False" else True
 CSRF_COOKIE_SECURE = False if os.getenv("CSRF_COOKIE_SECURE") == "False" else True
 


### PR DESCRIPTION
## 🌮 Objectif

Empêche tout code javascript côté client d'accéder au cookie de session.

## 🔍 Implémentation

https://docs.djangoproject.com/fr/3.0/ref/settings/#session-cookie-httponly

> Indique si le drapeau HttpOnly doit être utilisé sur le cookie de session. Si ce paramètre est défini à True, le code JavaScript côté client ne sera pas en mesure d’accéder au cookie de session.
