### PR TITLE
Mettre à jour les périmètres de données demandées à FC

### DIFF
--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -30,14 +30,13 @@ def fc_authorize(request):
     fc_id = settings.FC_AS_FS_ID
     fc_callback_uri = f"{settings.FC_AS_FS_CALLBACK_URL}/callback"
     fc_scopes = [
+        "email",
+        "gender",
+        "birthdate",
+        "birthplace",
         "given_name",
         "family_name",
-        "preferred_username",
-        "birthdate",
-        "gender",
-        "birthplace",
         "birthcountry",
-        "email",
     ]
 
     parameters = (


### PR DESCRIPTION
## 🌮 Objectif
Mettre à jour les périmètres de données

## 🔍 Implémentation
- Changer la liste des scopes lors de la création de l'URL pour appeler FC en tant que FS