### PR TITLE
Redemande un TOTP quand l'aidant a eu une période d'inactivité

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@ DEBUG = True # False for prod
 HOST= http://localhost:xxxx
 APP_SECRET=<insert_your_secret>
 TEST="Everything is awesome"
+# number of minutes of inactivity before checking
+ACTIVITY_CHECK_THRESHOLD=0
 
 DATABASE_NAME=aidants_connect
 DATABASE_USER=aidants_connect_team

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 
 import os
 from dotenv import load_dotenv
+from datetime import timedelta
 from aidants_connect.postgres_url import turn_psql_url_into_param
 
 load_dotenv(verbose=True)
@@ -177,6 +178,9 @@ STATIC_URL = "/static/"
 
 LOGIN_REDIRECT_URL = "/"
 LOGOUT_REDIRECT_URL = "home_page"
+ACTIVITY_CHECK_URL = "activity_check"
+ACTIVITY_CHECK_THRESHOLD = int(os.getenv("ACTIVITY_CHECK_THRESHOLD"))
+ACTIVITY_CHECK_DURATION = timedelta(minutes=ACTIVITY_CHECK_THRESHOLD)
 
 AUTH_USER_MODEL = "aidants_connect_web.Aidant"
 

--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -1,0 +1,25 @@
+from django.contrib.auth.decorators import user_passes_test
+from django.conf import settings
+from django.utils import timezone
+
+
+def activity_required(view=None, redirect_field_name="next"):
+    """
+    Similar to :func:`~django.contrib.auth.decorators.login_required`, but
+    requires the user to be :term:`verified`. By default, this redirects users
+    to :setting:`ACTIVITY_CHECK_URL`.
+
+    """
+
+    def test(user):
+        time_since_last_action = timezone.now() - user.get_last_action_timestamp()
+        is_alive = time_since_last_action < settings.ACTIVITY_CHECK_DURATION
+        return is_alive
+
+    decorator = user_passes_test(
+        test,
+        login_url=settings.ACTIVITY_CHECK_URL,
+        redirect_field_name=redirect_field_name,
+    )
+
+    return decorator if (view is None) else decorator(view)

--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -21,5 +21,4 @@ def activity_required(view=None, redirect_field_name="next"):
         login_url=settings.ACTIVITY_CHECK_URL,
         redirect_field_name=redirect_field_name,
     )
-
     return decorator if (view is None) else decorator(view)

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -143,6 +143,7 @@ class OTPForm(forms.Form):
         min_length=6,
         validators=[RegexValidator(r"^\d{6}$")],
         label="Entrez le code à 6 chiffres généré par votre téléphone",
+        widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )
 
     def __init__(self, aidant, *args, **kwargs):

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -137,17 +137,16 @@ class MandatForm(forms.Form):
     duree = forms.ChoiceField(choices=DUREES, required=True, initial=3)
 
 
-class RecapMandatForm(forms.Form):
-    personal_data = forms.BooleanField(
-        label=f"J’autorise mon aidant à utiliser mes données à caractère personnel."
-    )
-    brief = forms.BooleanField(label="brief")
+class OTPForm(forms.Form):
     otp_token = forms.CharField(
-        max_length=6, min_length=6, validators=[RegexValidator(r"^\d{6}$")]
+        max_length=6,
+        min_length=6,
+        validators=[RegexValidator(r"^\d{6}$")],
+        label="Entrez le code à 6 chiffres généré par votre téléphone",
     )
 
     def __init__(self, aidant, *args, **kwargs):
-        super(RecapMandatForm, self).__init__(*args, **kwargs)
+        super(OTPForm, self).__init__(*args, **kwargs)
         self.aidant = aidant
 
     def clean_otp_token(self):
@@ -158,3 +157,10 @@ class RecapMandatForm(forms.Form):
             return otp_token
         else:
             raise ValidationError("Ce code n'est pas valide.")
+
+
+class RecapMandatForm(OTPForm, forms.Form):
+    personal_data = forms.BooleanField(
+        label=f"J’autorise mon aidant à utiliser mes données à caractère personnel."
+    )
+    brief = forms.BooleanField(label="brief")

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -217,6 +217,12 @@ class JournalManager(models.Manager):
         )
         return journal_entry
 
+    def activity_check(self, aidant: Aidant):
+        journal_entry = self.create(
+            initiator=aidant.full_string_identifier, action="activity_check_aidant"
+        )
+        return journal_entry
+
     def mandat_creation(self, mandat: Mandat):
         aidant = mandat.aidant
         usager = mandat.usager
@@ -275,6 +281,7 @@ class JournalManager(models.Manager):
 class Journal(models.Model):
     ACTIONS = (
         ("connect_aidant", "Connexion d'un aidant"),
+        ("activity_check_aidant", "Reprise de connexion d'un aidant"),
         ("create_mandat", "Création d'un mandat"),
         ("use_mandat", "Utilisation d'un mandat"),
         ("update_mandat", "Renouvellement d'un mandat"),

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -95,6 +95,14 @@ class Aidant(AbstractUser):
         active_mandats = Mandat.objects.active().filter(usager=usager, aidant=self)
         return active_mandats.values_list("demarche", flat=True)
 
+    def get_last_action_timestamp(self):
+        a = (
+            Journal.objects.filter(initiator=self.full_string_identifier)
+            .last()
+            .creation_date
+        )
+        return a
+
 
 class UsagerManager(models.Manager):
     def active(self):

--- a/aidants_connect_web/templates/registration/activity_check.html
+++ b/aidants_connect_web/templates/registration/activity_check.html
@@ -11,6 +11,9 @@
   <form method="post">
       <h1>Bonjour {{ aidant.get_full_name }}</h1>
 
+      {% if form.errors %}
+        <div class="notification">Ce code n'est pas valide</div>
+      {% endif %}
       {% csrf_token %}
         <div class="form__group">
         <label>{{ form.otp_token.label_tag }}</label>

--- a/aidants_connect_web/templates/registration/activity_check.html
+++ b/aidants_connect_web/templates/registration/activity_check.html
@@ -1,0 +1,24 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block extracss %}
+  <link href="{% static 'css/login.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <form method="post">
+      <h1>Bonjour {{ aidant.get_full_name }}</h1>
+
+      {% csrf_token %}
+        <div class="form__group">
+        <label>{{ form.otp_token.label_tag }}</label>
+        {{ form.otp_token }}
+      </div>
+      <div class="form__group">
+        <input type="submit" value="Submit">
+      </div>
+  </form>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/registration/activity_check.html
+++ b/aidants_connect_web/templates/registration/activity_check.html
@@ -10,18 +10,16 @@
 <section class="section">
   <form method="post">
       <h1>Bonjour {{ aidant.get_full_name }}</h1>
-
+      <h2>Votre session a expiré</h2>
       {% if form.errors %}
         <div class="notification">Ce code n'est pas valide</div>
       {% endif %}
       {% csrf_token %}
         <div class="form__group">
-        <label>{{ form.otp_token.label_tag }}</label>
-        {{ form.otp_token }}
-      </div>
-      <div class="form__group">
-        <input type="submit" value="Submit">
-      </div>
+          <label>{{ form.otp_token.label_tag }}</label>
+          {{ form.otp_token }}
+          <button type="submit" class="button">Valider</button>
+        </div>
   </form>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/tests/test_decorators.py
+++ b/aidants_connect_web/tests/test_decorators.py
@@ -1,0 +1,32 @@
+from django.utils import timezone
+from freezegun import freeze_time
+
+from django.test import TestCase, tag
+from django.conf import settings
+
+from aidants_connect_web.tests.factories import UserFactory
+
+fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
+
+
+@tag("decorators")
+class ActivityRequiredTests(TestCase):
+    def setUp(self):
+        self.aidant_thierry = UserFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+
+    def test_activity_required_decorated_page_loads_if_action_just_happened(self):
+        self.client.force_login(self.aidant_thierry)
+        response = self.client.get("/new_mandat/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_activity_required_decorated_page_redirects_if_action_didnt_just_happened(
+        self,
+    ):
+        self.client.force_login(self.aidant_thierry)
+        with freeze_time(timezone.now() + settings.ACTIVITY_CHECK_DURATION):
+            self.assertEqual(self.aidant_thierry.is_authenticated, True)
+            response = self.client.get("/new_mandat/")
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.url, "/activity_check/?next=/new_mandat/")

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -125,11 +125,3 @@ class UseNewMandat(StaticLiveServerTestCase):
         last_demarche.click()
         time.sleep(2)
         self.assertIn("fcp.integ01.dev-franceconnect.fr", browser.current_url)
-
-        # Check user has been logged out by
-        # checking if they are redirected to the login page
-        self.aidant_is_disconnected(browser)
-
-    def aidant_is_disconnected(self, browser):
-        browser.get(f"{self.live_server_url}/authorize/?state=35")
-        browser.find_element_by_id("id_email")

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -71,7 +71,7 @@ class LogoutPageTests(TestCase):
         self.assertRedirects(response, "/")
 
 
-@tag("service")
+@tag("service", "this")
 class ActivityCheckPageTests(TestCase):
     def setUp(self):
         self.aidant_thierry = UserFactory()
@@ -112,13 +112,13 @@ class ActivityCheckPageTests(TestCase):
         self.client.force_login(self.aidant_thierry)
         self.assertEqual(Journal.objects.count(), 1)
         with freeze_time(timezone.now() + settings.ACTIVITY_CHECK_DURATION):
-            self.client.post(
-                "/activity_check/?next=/new_mandat/", data={"otp_token": "123456"}
+            response = self.client.post(
+                "/activity_check/?next=/usagers/1/?a=test", data={"otp_token": "123456"}
             )
             self.assertEqual(Journal.objects.count(), 2)
             self.assertEqual(Journal.objects.last().action, "activity_check_aidant")
-            response = self.client.get("/new_mandat/")
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 302)
+            self.assertEqual(response.url, "/usagers/1/?a=test")
 
 
 @tag("service")

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -1,5 +1,8 @@
 import os
 
+from django.utils import timezone
+from freezegun import freeze_time
+
 from django.test.client import Client
 from django.test import TestCase, tag
 from django.urls import resolve
@@ -66,6 +69,56 @@ class LogoutPageTests(TestCase):
         self.client.force_login(self.aidant)
         response = self.client.get("/logout/")
         self.assertRedirects(response, "/")
+
+
+@tag("service")
+class ActivityCheckPageTests(TestCase):
+    def setUp(self):
+        self.aidant_thierry = UserFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+
+    def test_totp_url_triggers_totp_view(self):
+        found = resolve("/activity_check/")
+        self.assertEqual(found.func, service.activity_check)
+
+    def test_totp_url_triggers_totp_template(self):
+        self.client.force_login(self.aidant_thierry)
+        response = self.client.get("/activity_check/")
+        self.assertTemplateUsed(response, "registration/activity_check.html")
+
+    def test_totp_page_with_resolvable_next_redirects(self):
+        self.client.force_login(self.aidant_thierry)
+        response = self.client.post(
+            "/activity_check/?next=/new_mandat/", data={"otp_token": "123456"}
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/new_mandat/")
+
+    def test_totp_page_with_non_resolvable_next_triggers_404(self):
+        # test with get
+        self.client.force_login(self.aidant_thierry)
+        response = self.client.get("/activity_check/?next=http://myfishingsite.com")
+        self.assertEqual(response.status_code, 404)
+        # get with post
+        self.client.force_login(self.aidant_thierry)
+        response = self.client.post(
+            "/activity_check/?next=http://myfishingsite.com",
+            data={"otp_token": "123456"},
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_successful_totp_check_creates_journal_entry(self):
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Journal.objects.count(), 1)
+        with freeze_time(timezone.now() + settings.ACTIVITY_CHECK_DURATION):
+            self.client.post(
+                "/activity_check/?next=/new_mandat/", data={"otp_token": "123456"}
+            )
+            self.assertEqual(Journal.objects.count(), 2)
+            self.assertEqual(Journal.objects.last().action, "activity_check_aidant")
+            response = self.client.get("/new_mandat/")
+            self.assertEqual(response.status_code, 200)
 
 
 @tag("service")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -36,6 +36,7 @@ urlpatterns = [
     # misc
     path("ressources/", service.resources, name="resources"),
     path("stats/", service.statistiques, name="statistiques"),
+    path("activity_check/", service.activity_check, name="activity_check"),
 ]
 
 urlpatterns.extend(magicauth_urls)

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -202,7 +202,6 @@ def fi_select_demarche(request):
         connection.save()
 
         fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
-        logout(request)
         return redirect(f"{fc_callback_url}?code={code}&state={this_state}")
 
 

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -19,6 +19,8 @@ from django.utils import timezone
 from django.urls import reverse
 from django.shortcuts import render, redirect
 from django.conf import settings
+
+from aidants_connect_web.decorators import activity_required
 from aidants_connect_web.models import (
     Connection,
     Mandat,
@@ -63,6 +65,7 @@ def check_request_parameters(
 
 
 @login_required
+@activity_required
 def authorize(request):
     if request.method == "GET":
         parameters = {
@@ -138,6 +141,7 @@ def authorize(request):
 
 
 @login_required
+@activity_required()
 def fi_select_demarche(request):
     if request.method == "GET":
         state = request.GET.get("state", False)

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -7,6 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, redirect
 from django.utils import timezone, formats
 
+from aidants_connect_web.decorators import activity_required
 from aidants_connect_web.forms import MandatForm, RecapMandatForm
 from aidants_connect_web.models import Mandat, Connection
 from aidants_connect_web.views.service import humanize_demarche_names
@@ -16,6 +17,7 @@ log = logging.getLogger()
 
 
 @login_required
+@activity_required
 def new_mandat(request):
     aidant = request.user
     form = MandatForm()

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -50,6 +50,7 @@ def new_mandat(request):
 
 
 @login_required
+@activity_required
 def new_mandat_recap(request):
 
     connection = Connection.objects.get(pk=request.session["connection"])
@@ -117,6 +118,7 @@ def new_mandat_recap(request):
 
 
 @login_required
+@activity_required
 def new_mandat_preview(request):
     connection = Connection.objects.get(pk=request.session["connection"])
     aidant = request.user

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -132,12 +132,8 @@ def statistiques(request):
 
 @login_required()
 def activity_check(request):
-    next_parameter = request.GET.get("next")
-    next_page = (
-        resolve(next_parameter).url_name
-        if next_parameter
-        else settings.LOGIN_REDIRECT_URL
-    )
+    next_parameter = request.GET.get("next", settings.LOGIN_REDIRECT_URL)
+    next_page = resolve(next_parameter).url_name
     aidant = request.user
     if request.method == "POST":
         form = OTPForm(aidant=aidant, data=request.POST)

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -4,6 +4,7 @@ from django.shortcuts import render
 from django.contrib.auth.decorators import login_required
 from django.contrib.messages import get_messages
 
+from aidants_connect_web.decorators import activity_required
 from aidants_connect_web.models import Usager
 
 
@@ -12,6 +13,7 @@ log = logging.getLogger()
 
 
 @login_required
+@activity_required
 def usagers_index(request):
     messages = get_messages(request)
     aidant = request.user
@@ -26,6 +28,7 @@ def usagers_index(request):
 
 
 @login_required
+@activity_required
 def usagers_details(request, usager_id):
     messages = get_messages(request)
     aidant = request.user


### PR DESCRIPTION
## 🌮 Objectif

Cette PR permet de protéger des vues de l'application en déclenchant un "activity check" si nous n'avons pas vu d'activité de cet aidant pendant une période pré-définie.

Pour protéger une page, il faut ajouter le décorateur `@activity_required`(voir la vue new_mandat)

## 🔍 Implémentation
- Création du décorateur @activity_required : ce décorateur vérifie que la dernière entrée de Journal concernant cet aidant a moins de X minutes.
- Création d'un helper de l'aidant qui récupère le datetime de la dernière entrée du Journal que l'aidant a initiée : `Aidant.get_last_action_timestamp`.
- Si l'aidant a été inactif trop longtemps, il est redirigé vers la nouvelle view `activity_check`, via l'url du même nom.
- La vue `activity_check` propose un check du TOTP dans un template du même nom.
- Si le check réussi, une nouvelle entrée de Journal est créée. A cette occasion, une nouvelle fonction du journal_manager apparait `activity_check", ce qui met à jour `Aidant.get_last_action_timestamp`

## ⚠️ Informations supplémentaires

1. Cette PR est basée sur la PR Housekeeping #123 
2. Il faut ajouter à l'environnement une nouvelle variable : ACTIVITY_CHECK_THRESHOLD