### PR TITLE
Améliore la sécurité avec FranceConnect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ FC_AS_FS_TEST_PORT=xxxx
 FC_AS_FI_ID=<insert_your_data>
 FC_AS_FI_SECRET=<insert_your_data>
 FC_AS_FI_CALLBACK_URL=https://...
+FC_AS_FI_HASH_SALT=""
+
+CONNECTION_EXPIRATION_TIME_MINUTES = 5
 
 # if you are debugging, and want to use the file based email backend
 EMAIL_BACKEND = django.core.mail.backends.filebased.EmailBackend

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -22,12 +22,17 @@ HOST = os.environ["HOST"]
 FC_AS_FI_CALLBACK_URL = os.environ["FC_AS_FI_CALLBACK_URL"]
 FC_AS_FI_ID = os.environ["FC_AS_FI_ID"]
 FC_AS_FI_SECRET = os.environ["FC_AS_FI_SECRET"]
+FC_AS_FI_HASH_SALT = os.environ["FC_AS_FI_HASH_SALT"]
 
 # FC as FS
 FC_AS_FS_BASE_URL = os.environ["FC_AS_FS_BASE_URL"]
 FC_AS_FS_ID = os.environ["FC_AS_FS_ID"]
 FC_AS_FS_SECRET = os.environ["FC_AS_FS_SECRET"]
 FC_AS_FS_CALLBACK_URL = os.environ["FC_AS_FS_CALLBACK_URL"]
+
+CONNECTION_EXPIRATION_TIME_MINUTES = int(
+    os.environ["CONNECTION_EXPIRATION_TIME_MINUTES"]
+)
 
 if os.environ.get("FC_AS_FS_TEST_PORT"):
     FC_AS_FS_TEST_PORT = int(os.environ["FC_AS_FS_TEST_PORT"])

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -1,17 +1,16 @@
 from datetime import timedelta
 
 from django.db import models
+from django.conf import settings
 from django.utils import timezone
 from django.contrib.auth.models import AbstractUser
 from django.core.validators import MinValueValidator, MaxValueValidator
 from django.contrib.postgres.fields import ArrayField
 
-CONNECTION_EXPIRATION_TIME = 10
-
 
 def default_expiration_date():
     now = timezone.now()
-    return now + timedelta(minutes=CONNECTION_EXPIRATION_TIME)
+    return now + timedelta(minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES)
 
 
 class Organisation(models.Model):

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -28,7 +28,7 @@
           {% endfor %}
         </div>
         {% csrf_token %}
-        <input type="hidden" name="state" value="{{ state }}" />
+        <input type="hidden" name="connection_id" value="{{ connection_id }}" />
       </fieldset>
     </form>
   <div>

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
@@ -10,11 +10,9 @@
 {% block content %}
 <section class="section section-grey">
   <div class="container">
-    <form method="post" >
+    <form method="post">
       <h2 id="welcome_aidant">Sélectionnez le type de démarche que vous allez effectuer</h2>
       <p id="instructions">En selectionnant une démarche, vous allez FranceConnecter [Nom de l'usager] (Changer d'usager)</p>
-      {% csrf_token %}
-      <input type="hidden" name="state" value="{{ state }}" />
       <div id="demarches_list" class="grid">
         {% for demarche, demarche_info in demarches.items %}
           <div id="{{ demarche }}" class="tile">
@@ -26,6 +24,8 @@
             </label>
           </div>
         {% endfor %}
+        {% csrf_token %}
+        <input type="hidden" name="connection_id" value="{{ connection_id }}" />
       </div>
     </form>
     <p>Si vous ne trouvez pas le type de démarche que vous souhaitez effectuer, il se peut que vous n'ayez pas de mandat ou que le mandat a expiré.

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -8,7 +8,7 @@ from django.test import TestCase, tag
 from django.test.client import Client
 from django.conf import settings
 
-from aidants_connect_web.models import Connection, CONNECTION_EXPIRATION_TIME, Usager
+from aidants_connect_web.models import Connection, Usager
 from aidants_connect_web.views.FC_as_FS import get_user_info
 from aidants_connect_web.tests.factories import UserFactory
 
@@ -84,7 +84,9 @@ class FCCallback(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    date_expired = date + timedelta(minutes=CONNECTION_EXPIRATION_TIME + 20)
+    date_expired = date + timedelta(
+        minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES + 20
+    )
 
     @freeze_time(date_expired)
     def test_expired_connection_returns_403(self):

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -87,7 +87,6 @@ def fc_callback(request):
         "client_secret": fc_secret,
         "code": code,
     }
-
     headers = {"Accept": "application/json"}
 
     request_for_token = python_request.post(token_url, data=payload, headers=headers)
@@ -106,17 +105,18 @@ def fc_callback(request):
     except ExpiredSignatureError:
         log.info("403: token signature has expired.")
         return HttpResponseForbidden()
+
     if connection.nonce != decoded_token.get("nonce"):
         log.info("403: The nonce is different than the one expected.")
         return HttpResponseForbidden()
+
     if connection.expiresOn < timezone.now():
         log.info("403: The connection has expired.")
         return HttpResponseForbidden()
+
     try:
         usager = Usager.objects.get(sub=decoded_token["sub"])
-
     except Usager.DoesNotExist:
-
         usager, error = get_user_info(fc_base, connection.access_token)
         if error:
             messages.error(request, error)

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -13,6 +13,7 @@ from django.http import (
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
 from django.contrib.auth import logout
+from django.contrib.auth.hashers import make_password
 from django.contrib.auth.decorators import login_required
 from django.forms.models import model_to_dict
 from django.utils import timezone
@@ -25,7 +26,6 @@ from aidants_connect_web.models import (
     Connection,
     Mandat,
     Usager,
-    CONNECTION_EXPIRATION_TIME,
     Journal,
 )
 
@@ -52,7 +52,17 @@ def check_request_parameters(
             error_message = f"400 Bad request: There is no {parameter} @ {view_name}"
             log.info(error_message)
             return 1, "missing parameter"
-        if (
+        elif (
+            parameter not in expected_static_parameters
+            and parameter in ["state", "nonce"]
+            and not value.isalnum()
+        ):
+            error_message = (
+                f"403 forbidden request: malformed {parameter} @ {view_name}"
+            )
+            log.info(error_message)
+            return 1, "malformed parameter value"
+        elif (
             parameter in expected_static_parameters
             and value != expected_static_parameters[parameter]
         ):
@@ -77,15 +87,16 @@ def authorize(request):
             "scope": request.GET.get("scope"),
             "acr_values": request.GET.get("acr_values"),
         }
-        expected_static_parameters = {
+        EXPECTED_STATIC_PARAMETERS = {
             "response_type": "code",
             "client_id": settings.FC_AS_FI_ID,
             "redirect_uri": settings.FC_AS_FI_CALLBACK_URL,
             "scope": "openid profile email address phone birth",
             "acr_values": "eidas1",
         }
+
         error, message = check_request_parameters(
-            parameters, expected_static_parameters, "authorize"
+            parameters, EXPECTED_STATIC_PARAMETERS, "authorize"
         )
         if error:
             return (
@@ -94,49 +105,52 @@ def authorize(request):
                 else HttpResponseForbidden()
             )
 
-        code = token_urlsafe(64)
-        Connection.objects.create(
-            state=parameters["state"], code=code, nonce=parameters["nonce"]
+        connection = Connection.objects.create(
+            state=parameters["state"], nonce=parameters["nonce"],
         )
         aidant = request.user
+
         return render(
             request,
             "aidants_connect_web/id_provider/authorize.html",
             {
-                "state": parameters["state"],
+                "connection_id": connection.id,
                 "usagers": aidant.get_usagers_with_active_mandat(),
                 "aidant": aidant,
             },
         )
 
     else:
-        state = request.POST.get("state")
+        parameters = {
+            "connection_id": request.POST.get("connection_id"),
+            "chosen_usager": request.POST.get("chosen_usager"),
+        }
 
         try:
-            connection = Connection.objects.get(state=state)
+            connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
                 log.info("Connexion has expired at authorize")
                 return HttpResponseBadRequest()
         except ObjectDoesNotExist:
-            log.info("No connection corresponds to the state:")
-            log.info(state)
+            log.info("No connection corresponds to the connection_id:")
+            log.info(parameters["connection_id"])
             logout(request)
             return HttpResponseForbidden()
-        except Connection.MultipleObjectsReturned:
-            log.info("This connection is not unique. State:")
-            log.info(state)
-            logout(request)
-            return HttpResponseForbidden()
-        chosen_usager = Usager.objects.get(id=request.POST.get("chosen_usager"))
+
+        chosen_usager = Usager.objects.get(pk=parameters["chosen_usager"])
         if chosen_usager not in request.user.get_usagers_with_active_mandat():
             log.info("This usager does not have a valid mandat with the aidant")
             log.info(request.user.id)
             logout(chosen_usager.id)
             logout(request)
             return HttpResponseForbidden()
+
         connection.usager = chosen_usager
         connection.save()
-        select_demarches_url = f"{reverse('fi_select_demarche')}?state={state}"
+
+        select_demarches_url = (
+            f"{reverse('fi_select_demarche')}?connection_id={connection.id}"
+        )
         return redirect(select_demarches_url)
 
 
@@ -144,76 +158,84 @@ def authorize(request):
 @activity_required()
 def fi_select_demarche(request):
     if request.method == "GET":
-        state = request.GET.get("state", False)
-        usager = Connection.objects.get(state=state).usager
-        demarches_rich_text = settings.DEMARCHES
+        parameters = {
+            "connection_id": request.GET.get("connection_id"),
+        }
+
+        try:
+            connection = Connection.objects.get(pk=parameters["connection_id"])
+            if connection.is_expired:
+                log.info("Connexion has expired at select demarche")
+                return HttpResponseBadRequest()
+        except ObjectDoesNotExist:
+            log.info("No connection corresponds to the connection_id:")
+            log.info(parameters["connection_id"])
+            logout(request)
+            return HttpResponseForbidden()
+
         aidant = request.user
-        nom_demarches = aidant.get_active_demarches_for_usager(usager)
+        usager_demarches = aidant.get_active_demarches_for_usager(connection.usager)
 
         demarches = {
-            nom_demarche: demarches_rich_text[nom_demarche]
-            for nom_demarche in nom_demarches
+            nom_demarche: settings.DEMARCHES[nom_demarche]
+            for nom_demarche in usager_demarches
         }
 
         return render(
             request,
             "aidants_connect_web/id_provider/fi_select_demarche.html",
             {
-                "state": state,
+                "connection_id": connection.id,
                 "aidant": request.user.get_full_name(),
                 "demarches": demarches,
             },
         )
+
     else:
-        this_state = request.POST.get("state")
+        parameters = {
+            "connection_id": request.POST.get("connection_id"),
+            "chosen_demarche": request.POST.get("chosen_demarche"),
+        }
+
         try:
-            connection = Connection.objects.get(state=this_state)
+            connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
                 log.info("Connexion has expired at select demarche")
                 return HttpResponseBadRequest()
-            code = connection.code
         except ObjectDoesNotExist:
-            log.info("No connection corresponds to the state:")
-            log.info(this_state)
-            logout(request)
-            return HttpResponseForbidden()
-        except Connection.MultipleObjectsReturned:
-            log.info("This connection is not unique. State:")
-            log.info(this_state)
+            log.info("No connection corresponds to the connection_id:")
+            log.info(parameters["connection_id"])
             logout(request)
             return HttpResponseForbidden()
 
-        chosen_demarche = request.POST.get("chosen_demarche")
         try:
             chosen_mandat = Mandat.objects.get(
                 usager=connection.usager,
                 aidant=request.user,
-                demarche=chosen_demarche,
+                demarche=parameters["chosen_demarche"],
                 expiration_date__gt=timezone.now(),
             )
         except Mandat.DoesNotExist:
             log.info("The mandat asked does not exist")
             return HttpResponseForbidden()
 
-        connection.demarche = chosen_demarche
+        code = token_urlsafe(64)
+        connection.code = make_password(code, settings.FC_AS_FI_HASH_SALT)
+        connection.demarche = parameters["chosen_demarche"]
         connection.mandat = chosen_mandat
         connection.complete = True
         connection.aidant = request.user
         connection.save()
 
-        fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
-        return redirect(f"{fc_callback_url}?code={code}&state={this_state}")
+        return redirect(
+            f"{settings.FC_AS_FI_CALLBACK_URL}?code={code}&state={connection.state}"
+        )
 
 
 # Due to `no_referer` error
 # https://docs.djangoproject.com/en/dev/ref/csrf/#django.views.decorators.csrf.csrf_exempt
 @csrf_exempt
 def token(request):
-    fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
-    fc_client_id = settings.FC_AS_FI_ID
-    fc_client_secret = settings.FC_AS_FI_SECRET
-    host = settings.HOST
-
     if request.method == "GET":
         return HttpResponse("You did a GET on a POST only route")
 
@@ -224,15 +246,15 @@ def token(request):
         "client_id": request.POST.get("client_id"),
         "client_secret": request.POST.get("client_secret"),
     }
-    expected_static_parameters = {
+    EXPECTED_STATIC_PARAMETERS = {
         "grant_type": "authorization_code",
-        "redirect_uri": fc_callback_url,
-        "client_id": fc_client_id,
-        "client_secret": fc_client_secret,
+        "redirect_uri": settings.FC_AS_FI_CALLBACK_URL,
+        "client_id": settings.FC_AS_FI_ID,
+        "client_secret": settings.FC_AS_FI_SECRET,
     }
 
     error, message = check_request_parameters(
-        parameters, expected_static_parameters, "token"
+        parameters, EXPECTED_STATIC_PARAMETERS, "token"
     )
     if error:
         return (
@@ -241,37 +263,37 @@ def token(request):
             else HttpResponseForbidden()
         )
 
-    code = parameters["code"]
+    code_hash = make_password(parameters["code"], settings.FC_AS_FI_HASH_SALT)
     try:
-        connection = Connection.objects.get(code=code)
+        connection = Connection.objects.get(code=code_hash)
+        if connection.is_expired:
+            log.info("Connexion has expired at token")
+            return HttpResponseBadRequest()
     except ObjectDoesNotExist:
         log.info("403: /token No connection corresponds to the code")
-        log.info(code)
-        return HttpResponseForbidden()
-
-    if connection.expiresOn < timezone.now():
-        log.info("403: Code expired")
+        log.info(parameters["code"])
         return HttpResponseForbidden()
 
     id_token = {
         # The audience, the Client ID of your Auth0 Application
-        "aud": fc_client_id,
+        "aud": settings.FC_AS_FI_ID,
         # The expiration time. in the format "seconds since epoch"
         # TODO Check if 10 minutes is not too much
-        "exp": int(time.time()) + CONNECTION_EXPIRATION_TIME * 60,
+        "exp": int(time.time()) + settings.CONNECTION_EXPIRATION_TIME_MINUTES * 60,
         # The issued at time
         "iat": int(time.time()),
         # The issuer,  the URL of your Auth0 tenant
-        "iss": host,
+        "iss": settings.HOST,
         # The unique identifier of the user
         "sub": connection.usager.sub,
         "nonce": connection.nonce,
     }
+    encoded_id_token = jwt.encode(id_token, settings.FC_AS_FI_SECRET, algorithm="HS256")
 
-    encoded_id_token = jwt.encode(id_token, fc_client_secret, algorithm="HS256")
     access_token = token_urlsafe(64)
-    connection.access_token = access_token
+    connection.access_token = make_password(access_token, settings.FC_AS_FI_HASH_SALT)
     connection.save()
+
     response = {
         "access_token": access_token,
         "expires_in": 3600,
@@ -286,7 +308,6 @@ def token(request):
 
 def user_info(request):
     auth_header = request.META.get("HTTP_AUTHORIZATION")
-
     if not auth_header:
         log.info("403: Missing auth header")
         return HttpResponseForbidden()
@@ -297,9 +318,15 @@ def user_info(request):
         return HttpResponseForbidden()
 
     auth_token = auth_header[7:]
-    connection = Connection.objects.get(access_token=auth_token)
-
-    if connection.expiresOn < timezone.now():
+    auth_token_hash = make_password(auth_token, settings.FC_AS_FI_HASH_SALT)
+    try:
+        connection = Connection.objects.get(access_token=auth_token_hash)
+        if connection.is_expired:
+            log.info("Connexion has expired at user_info")
+            return HttpResponseBadRequest()
+    except ObjectDoesNotExist:
+        log.info("403: /user_info No connection corresponds to the access_token")
+        log.info(auth_token)
         return HttpResponseForbidden()
 
     usager = model_to_dict(connection.usager)
@@ -318,4 +345,5 @@ def user_info(request):
         access_token=connection.access_token,
         mandat=connection.mandat,
     )
+
     return JsonResponse(usager, safe=False)


### PR DESCRIPTION
## 🌮 Objectif

Améliore le comportement d'Aidants Connect en tant que Fournisseur d'Identité

## 🔍 Implémentation

- dans les différentes étapes d'id_provider, c'est maintenant le `connection_id` qui est passé d'une page à l'autre
- d'avantage de checks sur la connection en cours
- le Connection `code` est  hashé (avec salt) avant d'être stocké en base
- le Connection `code` est généré sur la page fi_select_demarche
- le Connection `access_token` est hashé (avec salt) avant d'être stocké en base
- On vérifie que `state` et `nonce` sont au bon format
- Mise à jour des tests

## ⚠️ Informations supplémentaires

2 nouvelles variables à mettre dans son .env:
- FC_AS_FI_HASH_SALT
- CONNECTION_EXPIRATION_TIME_MINUTES