### PR TITLE
Améliore la gestion du sub usager

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -7,8 +7,6 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils import timezone
 
-from aidants_connect_web.utilities import generate_sha256_hash
-
 
 class Organisation(models.Model):
     name = models.TextField(default="No name provided")
@@ -161,14 +159,6 @@ class Usager(models.Model):
 
     def __str__(self):
         return f"{self.given_name} {self.family_name}"
-
-    def save(self, *args, **kwargs):
-        if self._state.adding:
-            if self.sub:
-                self.sub = generate_sha256_hash(self.sub + settings.FC_AS_FI_HASH_SALT)
-            else:
-                raise AttributeError("Cannot add a user without a sub")
-        super(Usager, self).save(*args, **kwargs)
 
     @property
     def full_string_identifier(self):

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -35,7 +35,7 @@ class UsagerFactory(factory.DjangoModelFactory):
     birthplace = 27681
     birthcountry = 99100
     email = "homer@simpson.com"
-    sub = "123"
+    sub = factory.Sequence(lambda n: "avalidsub{0}".format(n))
 
     class Meta:
         model = Usager

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -35,7 +35,7 @@ class UsagerFactory(factory.DjangoModelFactory):
     birthplace = 27681
     birthcountry = 99100
     email = "homer@simpson.com"
-    sub = factory.Sequence(lambda n: "avalidsub{0}".format(n))
+    sub = factory.Sequence(lambda n: f"avalidsub{n}")
 
     class Meta:
         model = Usager

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -24,7 +24,7 @@ class CancelMandat(FunctionalTestCase):
             first_name="Jacqueline",
             last_name="Fremont",
         )
-        cls.usager_josephine = UsagerFactory(given_name="Joséphine", sub="test_sub",)
+        cls.usager_josephine = UsagerFactory(given_name="Joséphine")
         cls.mandat_1 = Mandat.objects.create(
             aidant=cls.aidant_thierry,
             usager=cls.usager_josephine,

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -1,12 +1,12 @@
-from datetime import date, timedelta
+from datetime import timedelta
 import time
 
 from django.conf import settings
 from django.test import tag
 from django.utils import timezone
 
-from aidants_connect_web.models import Aidant, Mandat, Usager
-from aidants_connect_web.tests.factories import AidantFactory
+from aidants_connect_web.models import Mandat
+from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
 from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
@@ -18,7 +18,7 @@ class UseNewMandat(FunctionalTestCase):
         self.aidant = AidantFactory()
         device = self.aidant.staticdevice_set.create(id=self.aidant.id)
         device.token_set.create(token="123456")
-        AidantFactory(
+        self.aidant2 = AidantFactory(
             username="jfremont@domain.user",
             email="jfremont@domain.user",
             password="motdepassedejacqueline",
@@ -26,47 +26,31 @@ class UseNewMandat(FunctionalTestCase):
             last_name="Fremont",
         )
 
-        self.usager = Usager.objects.create(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate=date(1969, 12, 25),
-            gender="female",
-            birthplace=70447,
-            birthcountry=99100,
-            sub="test_sub",
-            email="User@user.domain",
+        self.usager_josephine = UsagerFactory(
+            given_name="Joséphine", family_name="ST-PIERRE"
         )
 
-        Usager.objects.create(
-            given_name="Anne Cécile Gertrude",
-            family_name="EVALOUS",
-            preferred_username="Kasteign",
-            birthdate=date(1945, 2, 14),
-            gender="female",
-            birthplace=27448,
-            birthcountry=99100,
-            sub="test_sub_2",
-            email="akasteing@user.domain",
+        self.usager_anne = UsagerFactory(
+            given_name="Anne Cécile Gertrude", family_name="EVALOUS"
         )
 
         Mandat.objects.create(
-            aidant=Aidant.objects.get(username="thierry@thierry.com"),
-            usager=Usager.objects.get(sub="test_sub"),
+            aidant=self.aidant,
+            usager=self.usager_josephine,
             demarche="argent",
             expiration_date=timezone.now() + timedelta(days=6),
         )
 
         Mandat.objects.create(
-            aidant=Aidant.objects.get(username="thierry@thierry.com"),
-            usager=Usager.objects.get(sub="test_sub"),
+            aidant=self.aidant,
+            usager=self.usager_josephine,
             demarche="famille",
             expiration_date=timezone.now() + timedelta(days=12),
         )
 
         Mandat.objects.create(
-            aidant=Aidant.objects.get(username="jfremont@domain.user"),
-            usager=Usager.objects.get(sub="test_sub"),
+            aidant=self.aidant2,
+            usager=self.usager_josephine,
             demarche="logement",
             expiration_date=timezone.now() + timedelta(days=12),
         )

--- a/aidants_connect_web/tests/test_functional/test_view_mandats.py
+++ b/aidants_connect_web/tests/test_functional/test_view_mandats.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import timedelta
 
 from django.test import tag
 from django.utils import timezone
@@ -16,33 +16,12 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 class ViewMandats(FunctionalTestCase):
     @classmethod
     def setUpClass(cls):
-
         cls.aidant = AidantFactory()
         device = cls.aidant.staticdevice_set.create(id=cls.aidant.id)
         device.token_set.create(token="123456")
 
-        cls.usager = UsagerFactory(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate=date(1969, 12, 25),
-            gender="female",
-            birthplace=70447,
-            birthcountry=99100,
-            sub="test_sub",
-            email="usager@user.domain",
-        )
-        cls.usager2 = UsagerFactory(
-            given_name="Corentin",
-            family_name="DUPUIS",
-            preferred_username="DUPUIS",
-            birthdate=date(1983, 2, 3),
-            gender="male",
-            birthplace=70447,
-            birthcountry=99100,
-            sub="test_sub2",
-            email="usager2@user.domain",
-        )
+        cls.usager = UsagerFactory(given_name="Joséphine")
+        cls.usager2 = UsagerFactory(given_name="Corentin")
         cls.mandat = MandatFactory(
             aidant=cls.aidant,
             usager=cls.usager,

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -102,15 +102,7 @@ class UsagerModelTest(TestCase):
         self.assertEqual(first_saved_item.given_name, "TEST NAME")
         self.assertEqual(str(first_saved_item.birthdate), "1902-06-30")
         self.assertEqual(second_saved_item.family_name, "TEST Family Name éèà")
-        self.assertTrue(first_saved_item.sub)
-        self.assertEqual(len(first_saved_item.sub), 64)
-
-    def test_usager_without_sub_should_raise_error(self):
-        first_usager = Usager()
-        first_usager.given_name = "TEST NAME"
-        first_usager.birthdate = date(1902, 6, 30)
-
-        self.assertRaises(AttributeError, lambda: first_usager.save())
+        self.assertEqual(second_usager.sub, "1234")
 
 
 @tag("models")
@@ -372,10 +364,9 @@ class JournalModelTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.entry1 = Journal.objects.create(action="connect_aidant", initiator="ABC")
-        cls.aidant_thierry = Aidant.objects.create_user(
+        cls.aidant_thierry = AidantFactory(
             username="Thierry",
             email="thierry@thierry.com",
-            password="motdepassedethierry",
             first_name="Thierry",
             last_name="Martin",
             organisation=OrganisationFactory(name="Commune de Vernon"),

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -19,6 +19,7 @@ from aidants_connect_web.tests.factories import (
     AidantFactory,
     OrganisationFactory,
     UsagerFactory,
+    MandatFactory,
 )
 
 
@@ -29,32 +30,12 @@ class ConnectionModelTest(TestCase):
         first_connection.state = "aZeRtY"
         first_connection.code = "ert"
         first_connection.nonce = "varg"
-        first_connection.usager = Usager.objects.create(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate="1969-12-15",
-            gender="female",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="123",
-            email="User@user.domain",
-        )
+        first_connection.usager = UsagerFactory(given_name="Joséphine")
         first_connection.save()
 
         second_connection = Connection()
         second_connection.state = "QsDfG"
-        second_connection.usager = Usager.objects.create(
-            given_name="Fabrice",
-            family_name="MERCIER",
-            preferred_username="TROIS",
-            birthdate="1981-07-27",
-            gender="male",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="124",
-            email="User@user.domain",
-        )
+        second_connection.usager = UsagerFactory(given_name="Fabrice")
         second_connection.save()
 
         saved_items = Connection.objects.all()
@@ -121,6 +102,15 @@ class UsagerModelTest(TestCase):
         self.assertEqual(first_saved_item.given_name, "TEST NAME")
         self.assertEqual(str(first_saved_item.birthdate), "1902-06-30")
         self.assertEqual(second_saved_item.family_name, "TEST Family Name éèà")
+        self.assertTrue(first_saved_item.sub)
+        self.assertEqual(len(first_saved_item.sub), 64)
+
+    def test_usager_without_sub_should_raise_error(self):
+        first_usager = Usager()
+        first_usager.given_name = "TEST NAME"
+        first_usager.birthdate = date(1902, 6, 30)
+
+        self.assertRaises(AttributeError, lambda: first_usager.save())
 
 
 @tag("models")
@@ -129,26 +119,8 @@ class MandatModelTest(TestCase):
     def setUpTestData(cls):
         cls.aidant_marge = AidantFactory(username="Marge")
         cls.aidant_patricia = AidantFactory(username="Patricia")
-        cls.usager_homer = Usager.objects.create(
-            given_name="Homer",
-            family_name="Simpson",
-            birthdate="1902-06-30",
-            gender="male",
-            birthplace=27681,
-            birthcountry=99100,
-            email="homer@simpson.com",
-            sub="123",
-        )
-        cls.usager_ned = Usager.objects.create(
-            given_name="Ned",
-            family_name="Flanders",
-            birthdate="1902-06-30",
-            gender="male",
-            birthplace=26934,
-            birthcountry=99100,
-            email="ned@flanders.com",
-            sub="1234",
-        )
+        cls.usager_homer = UsagerFactory(given_name="Homer")
+        cls.usager_ned = UsagerFactory(family_name="Flanders")
 
     def test_saving_and_retrieving_mandat(self):
         first_mandat = Mandat.objects.create(
@@ -270,52 +242,52 @@ class AidantModelMethodsTest(TestCase):
             username="Lisa", organisation=cls.aidant_marge.organisation
         )
         cls.aidant_patricia = AidantFactory(username="Patricia")
-        cls.usager_homer = UsagerFactory(given_name="Homer", sub="123")
-        cls.usager_bart = UsagerFactory(given_name="Bart", sub="1235")
-        cls.usager_ned = UsagerFactory(given_name="Ned", sub="1234")
-        Mandat.objects.create(
+        cls.usager_homer = UsagerFactory(given_name="Homer")
+        cls.usager_ned = UsagerFactory(given_name="Ned")
+        cls.usager_bart = UsagerFactory(given_name="Bart")
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_homer,
             demarche="Carte grise",
             expiration_date=timezone.now() - timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_homer,
             demarche="social",
             expiration_date=timezone.now() + timedelta(days=365),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_homer,
             demarche="Revenus",
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_ned,
             demarche="Logement",
             expiration_date=timezone.now() - timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_ned,
             demarche="transports",
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_ned,
             demarche="famille",
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_ned,
             demarche="social",
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        Mandat.objects.create(
+        MandatFactory(
             aidant=cls.aidant_marge,
             usager=cls.usager_ned,
             demarche="travail",
@@ -408,16 +380,7 @@ class JournalModelTest(TestCase):
             last_name="Martin",
             organisation=OrganisationFactory(name="Commune de Vernon"),
         )
-        cls.usager_ned = Usager.objects.create(
-            given_name="Ned",
-            family_name="Flanders",
-            birthdate="1902-06-30",
-            gender="male",
-            birthplace=26934,
-            birthcountry=99100,
-            email="ned@flanders.com",
-            sub="1234",
-        )
+        cls.usager_ned = UsagerFactory(given_name="Ned", family_name="Flanders")
 
         cls.first_mandat = Mandat.objects.create(
             aidant=cls.aidant_thierry,

--- a/aidants_connect_web/tests/test_utilities.py
+++ b/aidants_connect_web/tests/test_utilities.py
@@ -1,0 +1,20 @@
+from django.test import tag, TestCase
+
+from aidants_connect_web.utilities import generate_sha256_hash
+
+
+@tag("utilities")
+class UtilitiesTest(TestCase):
+    def test_generate_sha256_hash(self):
+        hash_123 = "a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3"
+        hash_123salt = (
+            "81d40d94fee4fb4eeb1a21bb7adb93c06aad35b929c1a2b024ae33b3a9b79e23"
+        )
+        self.assertRaises(TypeError, generate_sha256_hash, "123")
+        self.assertEqual(generate_sha256_hash("123".encode()), hash_123)
+        self.assertEqual(generate_sha256_hash("123".encode("utf-8")), hash_123)
+        self.assertEqual(
+            generate_sha256_hash("123".encode() + "salt".encode()), hash_123salt
+        )
+        self.assertEqual(generate_sha256_hash("123salt".encode()), hash_123salt)
+        self.assertEqual(len(generate_sha256_hash("123salt".encode())), 64)

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -11,6 +11,7 @@ from pytz import timezone
 
 from aidants_connect_web.models import Connection, Usager
 from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
+from aidants_connect_web.utilities import generate_sha256_hash
 from aidants_connect_web.views.FC_as_FS import get_user_info
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
@@ -59,7 +60,10 @@ class FCCallback(TestCase):
         )
 
         self.usager_sub_fc = "123"
-        self.usager = UsagerFactory(given_name="Joséphine", sub=self.usager_sub_fc)
+        self.usager_sub = generate_sha256_hash(
+            f"{self.usager_sub_fc}{settings.FC_AS_FI_HASH_SALT}".encode()
+        )
+        self.usager = UsagerFactory(given_name="Joséphine", sub=self.usager_sub)
 
     def test_no_code_triggers_403(self):
         response = self.client.get("/callback/", data={"state": "test_state"})

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -10,9 +10,8 @@ import jwt
 from pytz import timezone
 
 from aidants_connect_web.models import Connection, Usager
-from aidants_connect_web.tests.factories import AidantFactory
+from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
 from aidants_connect_web.views.FC_as_FS import get_user_info
-
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 
@@ -59,18 +58,8 @@ class FCCallback(TestCase):
             id=2,
         )
 
-        self.usager = Usager.objects.create(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate="1969-12-15",
-            gender="female",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="123",
-            email="User@user.domain",
-            creation_date="2019-08-05T15:49:13.972Z",
-        )
+        self.usager_sub_fc = "123"
+        self.usager = UsagerFactory(given_name="Joséphine", sub=self.usager_sub_fc)
 
     def test_no_code_triggers_403(self):
         response = self.client.get("/callback/", data={"state": "test_state"})
@@ -136,9 +125,10 @@ class FCCallback(TestCase):
             "exp": self.epoch_date + 600,
             "iat": self.epoch_date - 600,
             "iss": "http://franceconnect.gouv.fr",
-            "sub": 123,
+            "sub": self.usager_sub_fc,
             "nonce": "test_nonce",
         }
+
         mock_response.json = mock.Mock(
             return_value={
                 "access_token": "b337567e-437a-4167-ba51-8f8b6772980b",
@@ -166,9 +156,9 @@ class FCCallback(TestCase):
             "yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRi"
             "NDQ4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjox"
             "NTQ3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29u"
-            "bmVjdC5nb3V2LmZyIiwic3ViIjoxMjMsIm5vbmNlIjoidGVzdF9ub25jZSJ9.vqQoJ3vovqC"
-            "nbXzu7_V7bgsIZH6PPLBkIzeWnSp2sqo'&state=test_state&post_logout_redirect_"
-            "uri=http://localhost:3000/logout-callback"
+            "bmVjdC5nb3V2LmZyIiwic3ViIjoiMTIzIiwibm9uY2UiOiJ0ZXN0X25vbmNlIn0.QGb2uhgG"
+            "wXvKaVT8FXwOzSObtuLrBRKigd7DVJwUG5s'&state=test_state"
+            "&post_logout_redirect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)
 
@@ -191,7 +181,7 @@ class FCCallback(TestCase):
             "exp": self.epoch_date + 600,
             "iat": self.epoch_date - 600,
             "iss": "http://franceconnect.gouv.fr",
-            "sub": 456,
+            "sub": "9b754782705c55ebfe10371c909f62e73a3e09fb566fc5d23040a29fae4e0ebb",
             "nonce": "test_nonce",
         }
         mock_response.json = mock.Mock(
@@ -218,6 +208,7 @@ class FCCallback(TestCase):
                 birthplace="70447",
                 birthcountry="99100",
                 email="User@user.domain",
+                sub="456",
             ),
             None,
         )
@@ -238,10 +229,11 @@ class FCCallback(TestCase):
             "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=b'ey"
             "J0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRiND"
             "Q4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ"
-            "3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmV"
-            "jdC5nb3V2LmZyIiwic3ViIjo0NTYsIm5vbmNlIjoidGVzdF9ub25jZSJ9.tuHulPV1IhyS7UZ"
-            "8q4QWrg8EAeF1vgpFOr-5vV-ags4'&state=test_state&post_logout_redirect_uri="
-            "http://localhost:3000/logout-callback"
+            "3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmVj"
+            "dC5nb3V2LmZyIiwic3ViIjoiOWI3NTQ3ODI3MDVjNTVlYmZlMTAzNzFjOTA5ZjYyZTczYTNlM"
+            "DlmYjU2NmZjNWQyMzA0MGEyOWZhZTRlMGViYiIsIm5vbmNlIjoidGVzdF9ub25jZSJ9.J8048"
+            "J_B5MgwQkLzX28yXTDFPB4mTeoyUGW9RSW5YZ4'&state=test_state&post_logout_redi"
+            "rect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)
 

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -33,10 +33,7 @@ class AuthorizeTests(TestCase):
         self.aidant_jacques = AidantFactory(
             username="jacques@domain.user", email="jacques@domain.user"
         )
-        Aidant.objects.create_user(
-            "Jacques", "jacques@domain.user", "motdepassedejacques"
-        )
-        self.usager = UsagerFactory(given_name="Joséphine")
+        self.usager = UsagerFactory(given_name="Joséphine", sub="123")
         MandatFactory(
             aidant=self.aidant_thierry,
             usager=self.usager,
@@ -200,7 +197,7 @@ class AuthorizeTests(TestCase):
         saved_items = Connection.objects.all()
         self.assertEqual(saved_items.count(), 2)
         connection = saved_items[1]
-        self.assertEqual(connection.usager.sub, self.usager.sub)
+        self.assertEqual(connection.usager.sub, "123")
         self.assertNotEqual(connection.nonce, "No Nonce Provided")
 
         url = reverse("fi_select_demarche") + "?connection_id=" + str(connection.id)
@@ -492,19 +489,6 @@ class UserInfoTests(TestCase):
             birthplace=70447,
             birthcountry=99100,
             sub="test_sub",
-            email="User@user.domain",
-            creation_date="2019-08-05T15:49:13.972Z",
-        )
-
-        self.usager_2 = UsagerFactory(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate=date(1969, 12, 25),
-            gender="F",
-            birthplace=70447,
-            birthcountry=99100,
-            sub="test_sub2",
             email="User@user.domain",
             creation_date="2019-08-05T15:49:13.972Z",
         )

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -16,7 +16,6 @@ from aidants_connect_web.models import (
     Aidant,
     Connection,
     Journal,
-    Usager,
 )
 from aidants_connect_web.tests.factories import (
     AidantFactory,
@@ -34,34 +33,27 @@ class AuthorizeTests(TestCase):
         self.aidant_jacques = AidantFactory(
             username="jacques@domain.user", email="jacques@domain.user"
         )
-        self.usager = UsagerFactory(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate="1969-12-15",
-            gender="female",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="123",
-            email="User@user.domain",
-            id=1,
+        Aidant.objects.create_user(
+            "Jacques", "jacques@domain.user", "motdepassedejacques"
         )
+        self.usager = UsagerFactory(given_name="Joséphine")
         MandatFactory(
-            aidant=Aidant.objects.get(username="thierry@thierry.com"),
-            usager=Usager.objects.get(sub="123"),
+            aidant=self.aidant_thierry,
+            usager=self.usager,
             demarche="Revenus",
             expiration_date=timezone.now() + timedelta(days=6),
         )
 
         MandatFactory(
-            aidant=Aidant.objects.get(username="thierry@thierry.com"),
-            usager=Usager.objects.get(sub="123"),
+            aidant=self.aidant_thierry,
+            usager=self.usager,
             demarche="Famille",
             expiration_date=timezone.now() + timedelta(days=12),
         )
+
         MandatFactory(
-            aidant=Aidant.objects.get(username=self.aidant_jacques.username),
-            usager=Usager.objects.get(sub="123"),
+            aidant=self.aidant_jacques,
+            usager=self.usager,
             demarche="Logement",
             expiration_date=timezone.now() + timedelta(days=12),
         )
@@ -71,7 +63,7 @@ class AuthorizeTests(TestCase):
         self.connection = Connection.objects.create(
             state="test_expiration_date_triggered",
             nonce="avalidnonce456",
-            usager=Usager.objects.get(sub="123"),
+            usager=self.usager,
             expires_on=date_further_away_minus_one_hour,
         )
 
@@ -208,7 +200,7 @@ class AuthorizeTests(TestCase):
         saved_items = Connection.objects.all()
         self.assertEqual(saved_items.count(), 2)
         connection = saved_items[1]
-        self.assertEqual(connection.usager.sub, "123")
+        self.assertEqual(connection.usager.sub, self.usager.sub)
         self.assertNotEqual(connection.nonce, "No Nonce Provided")
 
         url = reverse("fi_select_demarche") + "?connection_id=" + str(connection.id)
@@ -243,17 +235,7 @@ class FISelectDemarcheTest(TestCase):
             username='yasmina@yasmina.com',
             organisation=self.aidant_thierry.organisation
         )
-        self.usager = UsagerFactory(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate="1969-12-15",
-            gender="female",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="123",
-            email="User@user.domain",
-        )
+        self.usager = UsagerFactory(given_name="Joséphine")
 
         self.connection = Connection.objects.create(
             state="avalidstate123", nonce="avalidnonce456", usager=self.usager,
@@ -399,21 +381,14 @@ class TokenTests(TestCase):
     def setUp(self):
         self.code = "test_code"
         self.code_hash = make_password(self.code, settings.FC_AS_FI_HASH_SALT)
+        self.usager = UsagerFactory(given_name="Joséphine")
+        self.usager.sub = "avalidsub789"
+        self.usager.save()
         self.connection = Connection()
         self.connection.state = "avalidstate123"
         self.connection.code = self.code_hash
         self.connection.nonce = "avalidnonce456"
-        self.connection.usager = UsagerFactory(
-            given_name="Joséphine",
-            family_name="ST-PIERRE",
-            preferred_username="ST-PIERRE",
-            birthdate="1969-12-15",
-            gender="female",
-            birthplace="70447",
-            birthcountry="99100",
-            sub="test_sub",
-            email="User@user.domain",
-        )
+        self.connection.usager = self.usager
         self.connection.expires_on = datetime(
             2012, 1, 14, 3, 21, 34, tzinfo=pytz_timezone("Europe/Paris")
         )
@@ -449,13 +424,13 @@ class TokenTests(TestCase):
             "expires_in": 3600,
             "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJ0ZXN0X2NsaWVu"
             "dF9pZCIsImV4cCI6MTMyNjUxMDk5NCwiaWF0IjoxMzI2NTEwNjk0LCJpc3MiOiJsb2NhbGhvc"
-            "3QiLCJzdWIiOiJ0ZXN0X3N1YiIsIm5vbmNlIjoiYXZhbGlkbm9uY2U0NTYifQ.vCJ2XqD6KEg"
-            "I8lgTT0f1e9PA-A5BxRhn6F5av6Y8mFk",
+            "3QiLCJzdWIiOiJhdmFsaWRzdWI3ODkiLCJub25jZSI6ImF2YWxpZG5vbmNlNDU2In0.a7nbGA"
+            "-Ib9I1HaMb5iC9s4fDP1ZbIXUJpU-YbdYFcWA",
             "refresh_token": "5ieq7Bg173y99tT6MA",
             "token_type": "Bearer",
         }
 
-        self.assertEqual(str(response_json), str(awaited_response))
+        self.assertEqual(response_json, awaited_response)
 
     def test_wrong_grant_type_triggers_403(self):
         fc_request = dict(self.fc_request)
@@ -581,7 +556,7 @@ class UserInfoTests(TestCase):
             "gender": "F",
             "birthplace": "70447",
             "birthcountry": "99100",
-            "sub": "test_sub",
+            "sub": self.connection.usager.sub,
             "email": "User@user.domain",
             "creation_date": "2019-08-05T15:49:13.972Z",
         }

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -13,7 +13,6 @@ from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.models import Connection, Journal, Mandat, Usager
 from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
 from aidants_connect_web.views import new_mandat
-from aidants_connect_web.utilities import generate_sha256_hash
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 
@@ -63,11 +62,11 @@ class NewMandatRecapTests(TestCase):
         device = self.aidant_monique.staticdevice_set.create(id=2)
         device.token_set.create(token="323456")
 
-        self.test_usager_sub_fc = (
+        self.test_usager_sub = (
             "46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1"
         )
         self.test_usager = UsagerFactory(
-            given_name="Fabrice", birthplace=95277, sub=self.test_usager_sub_fc,
+            given_name="Fabrice", birthplace=95277, sub=self.test_usager_sub,
         )
         self.mandat_builder = Connection.objects.create(
             demarches=["papiers", "logement"], duree=365, usager=self.test_usager
@@ -103,10 +102,6 @@ class NewMandatRecapTests(TestCase):
         )
         self.assertEqual(Usager.objects.all().count(), 1)
         usager = Usager.objects.get(given_name="Fabrice")
-        self.assertEqual(
-            usager.sub,
-            generate_sha256_hash(self.test_usager_sub_fc + settings.FC_AS_FI_HASH_SALT),
-        )
         self.assertEqual(usager.birthplace, 95277)
         self.assertRedirects(response, "/creation_mandat/succes/")
 

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -11,8 +11,9 @@ from pytz import timezone
 
 from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.models import Connection, Journal, Mandat, Usager
-from aidants_connect_web.tests import factories
+from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
 from aidants_connect_web.views import new_mandat
+from aidants_connect_web.utilities import generate_sha256_hash
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 
@@ -21,7 +22,7 @@ fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 class NewMandatTests(TestCase):
     def setUp(self):
         self.client = Client()
-        self.aidant_thierry = factories.AidantFactory()
+        self.aidant_thierry = AidantFactory()
 
     def test_new_mandat_url_triggers_new_mandat_view(self):
         found = resolve("/creation_mandat/")
@@ -53,25 +54,20 @@ class NewMandatTests(TestCase):
 class NewMandatRecapTests(TestCase):
     def setUp(self):
         self.client = Client()
-        self.aidant_thierry = factories.AidantFactory()
+        self.aidant_thierry = AidantFactory()
         device = self.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="223456")
 
-        self.aidant_monique = factories.AidantFactory(username="monique@monique.com")
+        self.aidant_monique = AidantFactory(username="monique@monique.com")
         device = self.aidant_monique.staticdevice_set.create(id=2)
         device.token_set.create(token="323456")
 
-        self.test_usager = Usager.objects.create(
-            given_name="Fabrice",
-            family_name="MERCIER",
-            sub="46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1",
-            preferred_username="TROIS",
-            birthdate="1981-07-27",
-            gender="female",
-            birthplace="95277",
-            birthcountry="99100",
-            email="test@test.com",
+        self.test_usager_sub_fc = (
+            "46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1"
+        )
+        self.test_usager = UsagerFactory(
+            given_name="Fabrice", birthplace=95277, sub=self.test_usager_sub_fc,
         )
         self.mandat_builder = Connection.objects.create(
             demarches=["papiers", "logement"], duree=365, usager=self.test_usager
@@ -109,7 +105,7 @@ class NewMandatRecapTests(TestCase):
         usager = Usager.objects.get(given_name="Fabrice")
         self.assertEqual(
             usager.sub,
-            "46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1",
+            generate_sha256_hash(self.test_usager_sub_fc + settings.FC_AS_FI_HASH_SALT),
         )
         self.assertEqual(usager.birthplace, 95277)
         self.assertRedirects(response, "/creation_mandat/succes/")
@@ -229,19 +225,13 @@ class NewMandatRecapTests(TestCase):
 @tag("new_mandat")
 class GenerateMandatPreview(TestCase):
     def setUp(self):
-        self.aidant_thierry = factories.AidantFactory()
+        self.aidant_thierry = AidantFactory()
         self.client = Client()
 
-        self.test_usager = Usager.objects.create(
+        self.test_usager = UsagerFactory(
             given_name="Fabrice",
             family_name="MERCIER",
             sub="46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1",
-            preferred_username="TROIS",
-            birthdate="1981-07-27",
-            gender="female",
-            birthplace="95277",
-            birthcountry="99100",
-            email="test@test.com",
         )
         self.mandat_form = MandatForm(
             data={"demarche": ["papiers", "logement"], "duree": "short"}

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -57,7 +57,7 @@ class MandatCancelConfirmPageTests(TestCase):
             username="jacques@domain.user", email="jacques@domain.user"
         )
         self.usager_1 = UsagerFactory()
-        self.usager_2 = UsagerFactory(sub="1234")
+        self.usager_2 = UsagerFactory()
         self.mandat_1 = Mandat.objects.create(
             aidant=self.aidant_1,
             usager=self.usager_1,

--- a/aidants_connect_web/utilities.py
+++ b/aidants_connect_web/utilities.py
@@ -1,7 +1,15 @@
 import hashlib
 
 
-def generate_sha256_hash(value):
-    if not type(value) == bytes:
-        value = value.encode("utf-8")
+def generate_sha256_hash(value: bytes):
+    """
+    Generate a SHA-256 hash
+    https://docs.python.org/3/library/hashlib.html
+    SHA-256 is a hash function that takes bytes as input, and returns a hash
+    The length of the hash is 64 characters
+    To add a salt, concatenate the string with the salt ('string'+'salt')
+    You must encode your string to bytes beforehand ('stringsalt'.encode())
+    :param value: bytes
+    :return: a hash (string) of 64 characters
+    """
     return hashlib.sha256(value).hexdigest()

--- a/aidants_connect_web/utilities.py
+++ b/aidants_connect_web/utilities.py
@@ -1,0 +1,7 @@
+import hashlib
+
+
+def generate_sha256_hash(value):
+    if not type(value) == bytes:
+        value = value.encode("utf-8")
+    return hashlib.sha256(value).hexdigest()

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -117,7 +117,7 @@ def fc_callback(request):
 
     try:
         usager_sub = generate_sha256_hash(
-            decoded_token["sub"] + settings.FC_AS_FI_HASH_SALT
+            f"{decoded_token['sub']}{settings.FC_AS_FI_HASH_SALT}".encode()
         )
         usager = Usager.objects.get(sub=usager_sub)
     except Usager.DoesNotExist:
@@ -147,6 +147,10 @@ def get_user_info(fc_base: str, access_token: str) -> tuple:
     if user_info.get("birthplace") == "":
         user_info["birthplace"] = None
 
+    usager_sub = generate_sha256_hash(
+        f"{user_info['sub']}{settings.FC_AS_FI_HASH_SALT}".encode()
+    )
+
     try:
         usager = Usager.objects.create(
             given_name=user_info.get("given_name"),
@@ -155,7 +159,7 @@ def get_user_info(fc_base: str, access_token: str) -> tuple:
             gender=user_info.get("gender"),
             birthplace=user_info.get("birthplace"),
             birthcountry=user_info.get("birthcountry"),
-            sub=user_info.get("sub"),
+            sub=usager_sub,
             email=user_info.get("email"),
         )
         return usager, None


### PR DESCRIPTION
## 🌮 Objectif

Générer notre propre sub lorsque Aidants Connect est Fournisseur d'Identité

## 🔍 Implémentation

- A chaque création d'un usager, on génère un `sub` (dans la méthode save())
    - il est généré à partir du sub renvoyé par FranceConnect
    - un hash est généré, avec un salt
- Dans id_provider.py, lors de la creation du jwt token, le sub utilisé est le sub de l'usager

## 🏕 Amélioration continue

- Simplification et usage d'UsagerFactory dans les tests

## ⚠️ Informations supplémentaires

- sub ?
    - Identifiant technique (unique et stable dans le temps pour un individu donné) fourni par FranceConnect au FS. Le sub est présent dans l'IdToken retourné au FS ainsi que dans les informations d'identité. Le sub retourné par FranceConnect est spécifique à chaque fournisseur de service (i.e: Un usager aura toujours le même sub pour un FS donné, en revanche il aura un sub différent par FS qu'il utilise).
    - REQUIRED. Subject Identifier. Locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client, e.g., 24400320 or AItOawmwtWwcT0k51BayewNvutrJUqsvl6qs7A4. It MUST NOT exceed 255 ASCII characters in length. The sub value is a case-sensitive string.
