### PR TITLE
Améliore l'accessibilité et le rendu en 'preview'

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/home_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/home_page.html
@@ -17,7 +17,7 @@
         </p>
         <p>Ce service sécurise et facilite le « faire pour le compte de ».</p>
       </div>
-      <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="" />
+      <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="Aidants Connect illustration" />
     </div>
   </div>
 </div>
@@ -27,26 +27,26 @@
     <h2 class="text-center">Le service Aidants Connect</h2>
     <div class="row">
       <div class="tile tile-colored text-center">
-        <img class="tile__icon" src="{% static 'images/key.svg' %}" />
+        <img class="tile__icon" src="{% static 'images/key.svg' %}" alt="Icon clé" />
         <h3>Aidants Connect sécurise juridiquement les aidants</h3>
         <p>qui accompagnent ces usagers sur les enjeux de confidentialité et de sécurité des données</p>
       </div>
       <div class="tile tile-colored text-center">
-        <img class="tile__icon" src="{% static 'images/help.svg' %}" />
+        <img class="tile__icon" src="{% static 'images/help.svg' %}" alt="Icon deux personnes" />
         <h3>Aidants Connect garantit un accompagnement humain</h3>
         <p>pour toutes les personnes qui, pour diverses raisons, ne peuvent pas faire leurs démarches en ligne</p></div>
       <div class="tile tile-colored text-center">
-        <img class="tile__icon" src="{% static 'images/people.svg' %}" />
+        <img class="tile__icon" src="{% static 'images/people.svg' %}" alt="Icon groupe de personnes" />
         <h3>Aidants Connect s’adresse à une diversité d’aidants professionnels</h3>
         <p>Travailleurs sociaux, agents publics d’accueil, médiateurs numériques...</p>
       </div>
       <div class="tile tile-colored text-center">
-        <img class="tile__icon" src="{% static 'images/build.svg' %}" />
+        <img class="tile__icon" src="{% static 'images/build.svg' %}" alt="Icon outil" />
         <h3>Aidants Connect a été co-construit avec des aidants</h3>
         <p>Des ateliers utilisateurs ont eu lieu dans une dizaine de territoires</p>
       </div>
       <div class="tile tile-colored text-center">
-        <img class="tile__icon" src="{% static 'images/cycle.svg' %}" />
+        <img class="tile__icon" src="{% static 'images/cycle.svg' %}" alt="Icon cycle" />
         <h3>Aidants Connect est évolutif</h3>
         <p>Le service s’adapte aux réalités du terrain et aux besoins des aidants</p>
       </div>
@@ -61,7 +61,7 @@
 </section>
 <section class="section section-grey fc-desc">
   <div class="container container-small">
-    <h2 class="text-center">Aidants Connect est un service qui utilise <img class="logo__fc" src="{% static 'images/fc_logo_v2.png'%}" /></h2>
+    <h2 class="text-center">Aidants Connect est un service qui utilise <img class="logo__fc" src="{% static 'images/fc_logo_v2.png'%}" alt="Logo FranceConnect" /></h2>
   </div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
@@ -20,7 +20,7 @@
           <div id="{{ demarche }}" class="tile">
             <input id="button-{{ demarche }}" type="submit" value="{{ demarche }}" name="chosen_demarche" />
             <label id="label_demarche" for="button-{{ demarche }}">
-              <img src="{{ demarche_info.icon }}">
+              <img src="{{ demarche_info.icon }}" alt="Icon {{ demarche_info.titre }}" />
               <h3>{{ demarche_info.titre }}</h3>
               <p>{{ demarche_info.description }}</p>
             </label>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -43,7 +43,7 @@
             <div id="{{ value }}" class="tile">
               <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" />
               <label class="label-demarche" for="button-{{ value }}">
-                <img src={{ label.icon }} alt="">
+                <img src="{{ label.icon }}" alt="Icon {{ label.titre }}" />
                 <h3 class="brand">{{ label.titre }}</h3>
                 <p>{{ label.description }}</p>
               </label>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_preview.html
@@ -20,8 +20,8 @@
 
 <section class="container">
   <div class="navbar__home text-center">
-    <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}"
-      alt="aidantsconnect.beta.gouv.fr" /><img src="{% static 'images/aidants-connect_logo.png' %}" class="navbar__gouvfr" alt="aidantsconnect.beta.gouv.fr" />
+    <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}" alt="Logo République Française Marianne" />
+    <img src="{% static 'images/aidants-connect_logo.png' %}" class="navbar__gouvfr" alt="Logo Aidants Connect" />
   </div>
   
   <h1>Mandat pour réaliser des démarches administratives en ligne au bénéfice d’un usager via le service

--- a/aidants_connect_web/templates/aidants_connect_web/statistiques.html
+++ b/aidants_connect_web/templates/aidants_connect_web/statistiques.html
@@ -43,7 +43,7 @@
           <div class="tile-box">
             <div class="tile text-center">
               <h3>
-                <img class="icon-inline" src={{ stat_item.icon }} alt="">
+                <img class="icon-inline" src="{{ stat_item.icon }}" alt="Icon {{ stat_item.title }}" />
                 {{ stat_item.title }}
               </h3>
               <h3>

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -2,8 +2,8 @@
 <footer class="footer" role="contentinfo">
   <div class="container">
     <div class="footer__logo">
-      <img src="{% static 'images/logo-msn2.png' %}" alt="Logo Mission Société Numérique">
-      <img class="logo__beta" src="{% static 'images/betagouvfr.svg' %}" alt="Logo beta.gouv.fr">
+      <img src="{% static 'images/logo-msn2.png' %}" alt="Logo Mission Société Numérique" />
+      <img class="logo__beta" src="{% static 'images/betagouvfr.svg' %}" alt="Logo beta.gouv.fr" />
       <ul class="footer__social">
         <li><a href="https://twitter.com/betagouv" title="Twitter"><svg class="icon icon-twitter"><use xlink:href="#twitter"></use></svg></a></li>
         <li><a href="https://github.com/betagouv/aidants_connect" title="Github"><svg class="icon icon-github"><use xlink:href="#github"></use></svg></a></li>

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -24,24 +24,25 @@
     }
   </script>
   <!-- Search Engine -->
-  <meta name="description" content="">
-  <meta name="image" content="">
+  <meta name="title" content="Aidants Connect - aidantsconnect.beta.gouv.fr">
+  <meta name="description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
+  <meta name="image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Schema.org for Google -->
   <meta itemprop="name" content="AidantConnect">
-  <meta itemprop="description" content="AidantConnect">
-  <meta itemprop="image" content="">
+  <meta itemprop="description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
+  <meta itemprop="image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="AidantConnect">
-  <meta name="twitter:description" content="AidantConnect">
+  <meta name="twitter:description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
   <meta name="twitter:site" content="@betagouv">
   <meta name="twitter:creator" content="betagouv">
-  <meta name="twitter:image:src" content="">
+  <meta name="twitter:image:src" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Open Graph general (Facebook, Pinterest & Google+) -->
   <meta name="og:title" content="AidantConnect">
-  <meta name="og:description" content="AidantConnect">
-  <meta name="og:image" content="">
-  <meta name="og:url" content="https://aidantconnect.beta.gouv.fr">
+  <meta name="og:description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
+  <meta name="og:image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
+  <meta name="og:url" content="https://aidantsconnect.beta.gouv.fr">
   <meta name="og:site_name" content="AidantConnect">
   <meta name="og:locale" content="fr_FR">
   <meta name="og:type" content="website">

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -28,22 +28,22 @@
   <meta name="description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
   <meta name="image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Schema.org for Google -->
-  <meta itemprop="name" content="AidantConnect">
+  <meta itemprop="name" content="Aidants Connect">
   <meta itemprop="description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
   <meta itemprop="image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
-  <meta name="twitter:title" content="AidantConnect">
+  <meta name="twitter:title" content="Aidants Connect">
   <meta name="twitter:description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
   <meta name="twitter:site" content="@betagouv">
   <meta name="twitter:creator" content="betagouv">
   <meta name="twitter:image:src" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <!-- Open Graph general (Facebook, Pinterest & Google+) -->
-  <meta name="og:title" content="AidantConnect">
+  <meta name="og:title" content="Aidants Connect">
   <meta name="og:description" content="Permettre à un aidant professionnel de réaliser des démarches administratives en ligne « à la place de » via une connexion sécurisée">
   <meta name="og:image" content="{% static 'images/aidantsconnect-illustration.svg' %}">
   <meta name="og:url" content="https://aidantsconnect.beta.gouv.fr">
-  <meta name="og:site_name" content="AidantConnect">
+  <meta name="og:site_name" content="Aidants Connect">
   <meta name="og:locale" content="fr_FR">
   <meta name="og:type" content="website">
 

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -2,8 +2,8 @@
 <header class="navbar">
   <div class="navbar__container">
     <a class="navbar__home" href="{% url 'home_page' %}">
-      <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}"
-        alt="aidantsconnect.beta.gouv.fr" /><img src="{% static 'images/aidants-connect_logo.png' %}" class="navbar__gouvfr" alt="aidantsconnect.beta.gouv.fr" />
+      <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}" alt="Logo République Française Marianne" />
+      <img src="{% static 'images/aidants-connect_logo.png' %}" class="navbar__gouvfr" alt="Logo Aidants Connect" />
     </a>
     <nav role="navigation">
       <ul class="nav__links">

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -138,7 +138,9 @@ def activity_check(request):
     if not url_has_allowed_host_and_scheme(
         next_page, allowed_hosts={request.get_host()}, require_https=True
     ):
-        log.warning("[AidantConnect] an unsafe URL was used through the activity check")
+        log.warning(
+            "[Aidants Connect] an unsafe URL was used through the activity check"
+        )
         return HttpResponseNotFound()
 
     aidant = request.user


### PR DESCRIPTION
## 🌮 Objectif

Avoir des `meta` remplies permet d'avoir un meilleur aperçu du site lorsqu'il est crawlé et partagé sur les réseaux sociaux (twitter, slack, ...).
Le champs `alt` améliore l'accessibilité du site pour les personnes mal-voyantes

## 🔍 Implémentation

- Remplissage des tags `meta` dans le <head>
- Ajout du champ `alt` sur les images lorsque manquant

preview
<img width="630" alt="Screenshot 2020-02-05 at 13 37 43" src="https://user-images.githubusercontent.com/7147385/73842368-bddec980-481c-11ea-8cf1-b12ff76f878e.png">

