### PR TITLE
Explicite la source du code de sécurité TOTP

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -257,6 +257,9 @@ MAGICAUTH_EMAIL_HTML_TEMPLATE = "login/email_template.html"
 MAGICAUTH_EMAIL_TEXT_TEMPLATE = "login/email_template.txt"
 MAGICAUTH_ENABLE_2FA = True
 
+# TOTP
+OTP_TOTP_ISSUER = os.getenv("OTP_TOTP_ISSUER", "Aidants Connect")
+
 # Emails
 EMAIL_BACKEND = os.getenv(
     "EMAIL_BACKEND", "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
## 🌮 Objectif

Permet de définir l'issuer du TOTP

## 🔍 Implémentation

- Rajoute `OTP_TOTP_ISSUER` dans les settings

## ⚠️ Informations supplémentaires

- Il faut mettre `OTP_TOTP_ISSUER` dans le .env si on veut modifier la valeur par défaut ("Aidants Connect")