### PR TITLE
Répare les urls dans le footer

### DIFF
--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -2,8 +2,12 @@
 <footer class="footer" role="contentinfo">
   <div class="container">
     <div class="footer__logo">
-      <img src="{% static 'images/logo-msn2.png' %}" alt="Logo Mission Société Numérique" />
-      <img class="logo__beta" src="{% static 'images/betagouvfr.svg' %}" alt="Logo beta.gouv.fr" />
+      <a href="https://societenumerique.gouv.fr/">
+        <img src="{% static 'images/logo-msn2.png' %}" alt="Logo Mission Société Numérique" />
+      </a>
+      <a href="https://beta.gouv.fr/">
+        <img class="logo__beta" src="{% static 'images/betagouvfr.svg' %}" alt="Logo beta.gouv.fr" />
+      </a>
       <ul class="footer__social">
         <li><a href="https://twitter.com/betagouv" title="Twitter"><svg class="icon icon-twitter"><use xlink:href="#twitter"></use></svg></a></li>
         <li><a href="https://github.com/betagouv/aidants_connect" title="Github"><svg class="icon icon-github"><use xlink:href="#github"></use></svg></a></li>
@@ -13,7 +17,7 @@
       <li>
         <h2 class="brand">aidantsconnect.beta.gouv.fr</h2>
       </li>
-      <li><a href="https://beta.gouv.fr/startups/aidants-connect">Une startup d’État de beta.gouv.fr</a></li>
+      <li><a href="https://beta.gouv.fr/startups/aidantsconnect">Une startup d’État de beta.gouv.fr</a></li>
       </ul>
       <ul class="footer__links">
       <li><a href="/cgu">Conditions d’utilisation</a></li>


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux usagers de mieux comprendre les parties prenantes d'Aidants Connect

## 🔍 Implémentation

- Répare l'url beta.gouv d'Aidants Connect
- Rajoute l'url sur les logos Mission Société Numérique & beta.gouv
