### PR TITLE
Mets à jours les tests avec le TOTP au login

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
+            - v2-dependencies-{{ checksum "requirements.txt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - v2-dependencies-
 
       - run:
           name: install dependencies

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -18,6 +18,7 @@ class CreateNewMandat(StaticLiveServerTestCase):
         cls.aidant = UserFactory()
         device = cls.aidant.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
+        device.token_set.create(token="123455")
         super().setUpClass()
         cls.selenium = WebDriver()
         cls.selenium.implicitly_wait(10)
@@ -102,7 +103,7 @@ class CreateNewMandat(StaticLiveServerTestCase):
         id_brief.click()
         id_otp_token = checkboxes[4]
         self.assertEqual(id_otp_token.get_attribute("id"), "id_otp_token")
-        id_otp_token.send_keys("123456")
+        id_otp_token.send_keys("123455")
         submit_button = checkboxes[-1]
         self.assertEqual(submit_button.get_attribute("type"), "submit")
         submit_button.click()

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -16,6 +16,8 @@ class UseNewMandat(StaticLiveServerTestCase):
     @classmethod
     def setUp(self):
         self.aidant = UserFactory()
+        device = self.aidant.staticdevice_set.create(id=self.aidant.id)
+        device.token_set.create(token="123456")
         UserFactory(
             username="jfremont@domain.user",
             email="jfremont@domain.user",

--- a/aidants_connect_web/tests/test_functional/test_view_mandats.py
+++ b/aidants_connect_web/tests/test_functional/test_view_mandats.py
@@ -15,6 +15,9 @@ class ViewMandats(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         cls.user = UserFactory()
+        device = cls.user.staticdevice_set.create(id=cls.user.id)
+        device.token_set.create(token="123456")
+
         cls.usager = Usager.objects.create(
             given_name="Joséphine",
             family_name="ST-PIERRE",

--- a/aidants_connect_web/tests/test_functional/utilities.py
+++ b/aidants_connect_web/tests/test_functional/utilities.py
@@ -4,6 +4,8 @@ from django.core import mail
 def login_aidant(self):
     login_field = self.selenium.find_element_by_id("id_email")
     login_field.send_keys("thierry@thierry.com")
+    otp_field = self.selenium.find_element_by_id("id_otp_token")
+    otp_field.send_keys("123456")
     submit_button = self.selenium.find_element_by_xpath("//button")
     submit_button.click()
     email_sent_title = self.selenium.find_element_by_tag_name("h1").text


### PR DESCRIPTION
## 🌮 Objectif
Les tests d'intégration  prennent en compte le TOTP lors du login

## 🔍 Implémentation

- Un `static_device` ainsi qu'un `static_token` "123456" sont ajouté aux Aidants des tests d'intégration.
- Le champs totp du login est rempli dans la fonction `login_aidant` qui est réutilisée dans les tests fonctionnels.

