### PR TITLE
Ajoute les mentions légales

### DIFF
--- a/aidants_connect_web/templates/footer/mentions_legales.html
+++ b/aidants_connect_web/templates/footer/mentions_legales.html
@@ -1,0 +1,26 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block extracss %}
+<link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1 class="brand">Mentions légales</h1>
+
+    <h2>Éditeur</h2>
+
+    <p><a href="https://beta.gouv.fr">Incubateur de services numériques</a> de la Direction interministérielle du numérique et du système d'information et de communication de l'État (<a href="https://www.numerique.gouv.fr">DINUM</a>). 20, avenue de Ségur - 75007 Paris.
+
+    <p>Directeur de la publication : le directeur interministériel du numérique et du système d'information et de communication de l'État, Nadi Bou Hanna </p>
+
+    <h2>Hébergeur</h2>
+
+    <p>Scalingo. 15 avenue du Rhin, 67100 Strasbourg, France.</p>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -21,8 +21,9 @@
       </ul>
       <ul class="footer__links">
       <li><a href="/cgu">Conditions d’utilisation</a></li>
+      <li><a href="/mentions-legales">Mentions légales</a></li>
       <li><a href="/stats">Statistiques</a></li>
-      <li><a href="https://www.numerique.gouv.fr/dinsic/">DINSIC</a></li>
+      <li><a href="https://www.numerique.gouv.fr/">DINUM</a></li>
     </ul>
   </div>
 </footer>

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -38,6 +38,8 @@ urlpatterns = [
     path("stats/", service.statistiques, name="statistiques"),
     path("cgu/", service.cgu, name="cgu"),
     path("activity_check/", service.activity_check, name="activity_check"),
+    # footer
+    path("mentions-legales/", service.mentions_legales, name="mentions_legales"),
 ]
 
 urlpatterns.extend(magicauth_urls)

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -160,3 +160,7 @@ def activity_check(request):
     return render(
         request, "registration/activity_check.html", {"form": form, "aidant": aidant}
     )
+
+
+def mentions_legales(request):
+    return render(request, "footer/mentions_legales.html")


### PR DESCRIPTION
## 🌮 Objectif

Les visiteurs du site peuvent voir les contacts (éditeur, hébergeur) d'Aidants Connect
## 🔍 Implémentation

- Ajout d'une page statique mentions légales avec un lien dans le footer

## 🏕 Amélioration continue
- Remplacer "DINSIC" en "DINUM" dans le footer

- _Une liste d'autres modifications pas en lien directe avec la PR_

## ⚠️ Informations supplémentaires

_Si besoin_