### PR TITLE
Lint code before running tests on CI platform

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,8 +46,8 @@ jobs:
           name: run unit tests
           command: |
             . venv/bin/activate
-            python manage.py test
             flake8
+            python manage.py test
 
       - store_artifacts:
           path: test-reports


### PR DESCRIPTION
## 🌮 Objectif

Accélérer l'exécutions des tests sur CircleCI

## 🔍 Implémentation

- Exécution du _linter_ avant celle des tests unitaires (voir [cette carte Trello](https://trello.com/c/339sFhoX))

## ⚠️ Informations supplémentaires

En cas de détection de problèmes de style, le _run_ de test échouera ainsi plus vite 😄 