### PR TITLE
Fix user session duration to 24 hours

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,9 @@ ADMIN_URL=gestion/
 ADMIN_NAME="mon nom"
 ADMIN_EMAIL=monnom@domain.user
 
+# Sessions
+SESSION_COOKIE_AGE=86400  # 24 hours, in seconds
+
 # Security measures
 SESSION_COOKIE_SECURE=False # True in prod
 CSRF_COOKIE_SECURE=False # True in prod

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -304,6 +304,12 @@ CSP_FRAME_SRC = (
 ADMIN_URL = os.getenv("ADMIN_URL")
 ADMINS = [(os.getenv("ADMIN_NAME"), os.getenv("ADMIN_EMAIL"))]
 
+# Sessions
+SESSION_COOKIE_AGE = int(
+    os.getenv("SESSION_COOKIE_AGE", 86400)
+)  # default: 24 hours, in seconds
+SESSION_EXPIRE_AT_BROWSER_CLOSE = False
+
 # Cookie security
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SECURE = False if os.getenv("SESSION_COOKIE_SECURE") == "False" else True


### PR DESCRIPTION
## 🌮 Objectif

Fixer à 24 heures la durée maximale de la session d'un·e aidant·e.

## 🔍 Implémentation

- Ajout explicite des paramètres [`SESSION_COOKIE_AGE`](https://docs.djangoproject.com/fr/3.0/ref/settings/#session-cookie-age) et [`SESSION_EXPIRE_AT_BROWSER_CLOSE`](https://docs.djangoproject.com/fr/3.0/ref/settings/#session-expire-at-browser-close) au fichier `settings.py`