### PR TITLE
Rename ambiguous setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ FC_AS_FI_SECRET=<insert_your_data>
 FC_AS_FI_CALLBACK_URL=https://...
 FC_AS_FI_HASH_SALT=""
 
-CONNECTION_EXPIRATION_TIME_MINUTES = 5
+FC_CONNECTION_AGE=300  # 5 minutes, in seconds
 
 # Number of minutes of inactivity before checking
 ACTIVITY_CHECK_THRESHOLD=0

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -30,9 +30,7 @@ FC_AS_FS_ID = os.environ["FC_AS_FS_ID"]
 FC_AS_FS_SECRET = os.environ["FC_AS_FS_SECRET"]
 FC_AS_FS_CALLBACK_URL = os.environ["FC_AS_FS_CALLBACK_URL"]
 
-CONNECTION_EXPIRATION_TIME_MINUTES = int(
-    os.environ["CONNECTION_EXPIRATION_TIME_MINUTES"]
-)
+FC_CONNECTION_AGE = int(os.environ["FC_CONNECTION_AGE"])
 
 if os.environ.get("FC_AS_FS_TEST_PORT"):
     FC_AS_FS_TEST_PORT = int(os.environ["FC_AS_FS_TEST_PORT"])

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -10,7 +10,7 @@ from django.contrib.postgres.fields import ArrayField
 
 def default_expiration_date():
     now = timezone.now()
-    return now + timedelta(minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES)
+    return now + timedelta(seconds=settings.FC_CONNECTION_AGE)
 
 
 class Organisation(models.Model):

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -84,9 +84,7 @@ class FCCallback(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    date_expired = date + timedelta(
-        minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES + 20
-    )
+    date_expired = date + timedelta(seconds=settings.FC_CONNECTION_AGE + 1200)
 
     @freeze_time(date_expired)
     def test_expired_connection_returns_403(self):

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -483,9 +483,7 @@ class TokenTests(TestCase):
             response = self.client.post("/token/", bad_request)
             self.assertEqual(response.status_code, 400)
 
-    date_expired = date + timedelta(
-        minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES + 20
-    )
+    date_expired = date + timedelta(seconds=settings.FC_CONNECTION_AGE + 1200)
 
     @freeze_time(date_expired)
     def test_expired_code_triggers_bad_request(self):
@@ -592,9 +590,7 @@ class UserInfoTests(TestCase):
         self.assertEqual(journal_entries.count(), 2)
         self.assertEqual(journal_entries[1].action, "use_mandat")
 
-    date_expired = date + timedelta(
-        minutes=settings.CONNECTION_EXPIRATION_TIME_MINUTES + 20
-    )
+    date_expired = date + timedelta(seconds=settings.FC_CONNECTION_AGE + 1200)
 
     @freeze_time(date_expired)
     def test_expired_access_token_returns_bad_request(self):

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -279,7 +279,7 @@ def token(request):
         "aud": settings.FC_AS_FI_ID,
         # The expiration time. in the format "seconds since epoch"
         # TODO Check if 10 minutes is not too much
-        "exp": int(time.time()) + settings.CONNECTION_EXPIRATION_TIME_MINUTES * 60,
+        "exp": int(time.time()) + settings.FC_CONNECTION_AGE,
         # The issued at time
         "iat": int(time.time()),
         # The issuer,  the URL of your Auth0 tenant


### PR DESCRIPTION
## 🌮 Objectif

Rendre plus explicite la sémantique d'un paramètre de configuration

## 🔍 Implémentation

- Renommage du paramètre `CONNECTION_EXPIRATION_TIME_MINUTES` en `FC_CONNECTION_AGE`

## ⚠️ Informations supplémentaires

Le nouveau nom du paramètre permet de comprendre qu'il concerne la connexion FranceConnect. Il présente également une analogie avec le `SESSION_COOKIE_AGE` de Django dont on peut éventuellement déduire qu'il a un usage similaire à ce dernier. Afin d'accroître cette similarité, la valeur de `FC_CONNECTION_AGE` est désormais exprimée en secondes plutôt qu'en minutes.