### PR TITLE
Cacher temporairement les vidéos dans le guide d'utilisation

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/guide_utilisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/guide_utilisation.html
@@ -18,11 +18,10 @@
 <section id="videos" class="section section-grey">
   <div class="container">
     <h1 class="section__title">Des vidéos pour comprendre et se former</h1>
-    <p class="section__subtitle">Visionnez 4 courtes vidéos pour comprendre et utiliser avec aisance FranceConnect et Aidants Connect</p>
-    <!-- <br> -->
+    <p class="section__subtitle">Bientôt disponible</p>
+    <!-- <p class="section__subtitle">Visionnez 4 courtes vidéos pour comprendre et utiliser avec aisance FranceConnect et Aidants Connect</p>
     <div class="cards">
       <div class="row">
-        <!-- CARD 1 -->
         <div class="card">
           <div class="card__cover">
             <iframe width="536" height="250" src="https://www.youtube.com/embed/zbcVpxaN8zc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -36,7 +35,6 @@
             </p>
           </div>
         </div>
-        <!-- CARD 2 -->
         <div class="card">
           <div class="card__cover">
             <iframe width="560" height="250" src="https://www.youtube.com/embed/r_Z8-1K1OPM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
@@ -56,9 +54,7 @@
     <div class="cards">
       <div class="row">
         <div class="card">
-          <div class="card__cover">
-            <!-- <iframe width="560" height="250" src="https://www.youtube.com/embed/r_Z8-1K1OPM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
-          </div>
+          <div class="card__cover"></div>
           <div class="card__content">
             <h2>Les aspects juridiques relatifs au tiers de confiance</h2>
             <div class="card__meta">Vidéo et lien à venir</div>
@@ -69,9 +65,7 @@
           </div>
         </div>
         <div class="card">
-          <div class="card__cover">
-            <!-- <iframe width="560" height="250" src="https://www.youtube.com/embed/zbcVpxaN8zc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
-          </div>
+          <div class="card__cover"></div>
           <div class="card__content">
             <h2>Comment générer un mandat et réaliser une démarche avec Aidants Connect ?</h2>
             <div class="card__meta">Vidéo et lien à venir</div>
@@ -82,7 +76,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </div> -->
   </div>
 </section>
 


### PR DESCRIPTION
## 🌮 Objectif

Attendre d'avoir toutes les vidéos avant de les afficher dans le guide d'utilisation

## 🔍 Implémentation

- On garde la section Videos, mais on affiche un message 'bientot disponible'

## 🖼️ Images

![screenshot-localhost_3000-2020 02 17-20_33_36](https://user-images.githubusercontent.com/7147385/74682234-bf69a380-51c5-11ea-9d0e-86c44995ed2f.png)
