### PR TITLE
Permet d'imprimer un justificatif lors de la révocation d'un mandat

### DIFF
--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -74,3 +74,35 @@ def check_mandat_is_not_expired(func):
         return func(request, *args, **kwargs)
 
     return actual_decorator
+
+
+def check_mandat_is_expired(func):
+    """
+    Decorator that checks that the mandat_id is already expired
+    """
+
+    def actual_decorator(request, *args, **kwargs):
+        mandat = get_object_or_404(Mandat, pk=kwargs["mandat_id"])
+        if not mandat.is_expired:
+            messages.error(request, f"Le mandat est toujours en cours")
+            return redirect("dashboard")
+        return func(request, *args, **kwargs)
+
+    return actual_decorator
+
+
+def check_mandat_is_cancelled(func):
+    """
+    Decorator that checks that the mandat_id has been cancelled
+    """
+
+    def actual_decorator(request, *args, **kwargs):
+        mandat = get_object_or_404(Mandat, pk=kwargs["mandat_id"])
+        if not mandat.has_cancel_journal_action:
+            messages.error(
+                request, f"Le mandat n'a pas été révoqué (en cours ou expiré)."
+            )
+            return redirect("dashboard")
+        return func(request, *args, **kwargs)
+
+    return actual_decorator

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -177,6 +177,10 @@ class Mandat(models.Model):
         return timezone.now() > self.expiration_date
 
     @property
+    def has_cancel_journal_action(self):
+        return Journal.objects.filter(mandat=self.id, action="cancel_mandat").exists()
+
+    @property
     def duree_in_days(self):
         duree_for_computer = self.expiration_date - self.last_mandat_renewal_date
         # we add one day so that duration is human friendly

--- a/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_cancel_success.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_cancel_success.html
@@ -1,0 +1,22 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block extracss %}
+<link href="{% static 'css/usagers.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1 class="brand">Le mandat a été révoqué avec succès !</h1>
+    <div class="tiles">
+      <a class="button">🖨 Imprimer le justificatif de cette révocation</a>
+      <br><br>
+      <p>
+        Pour retourner sur le profil de l'usager {{ usager.get_full_name }}, <a id="usager_link" href="{% url 'usagers_details' usager_id=usager.id %}">cliquez ici</a>.
+      </p>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -65,6 +65,10 @@ class CancelMandat(FunctionalTestCase):
         submit_button = self.selenium.find_elements_by_tag_name("input")[1]
         submit_button.click()
 
+        # Click on return to usager page
+        usager_button = self.selenium.find_element_by_id("usager_link")
+        usager_button.click()
+
         # See all mandats of usager page
         active_mandats_after = self.selenium.find_elements_by_class_name(
             "fake-table-row"

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -17,10 +17,16 @@ urlpatterns = [
     # usagers
     path("usagers/", usagers.usagers_index, name="usagers"),
     path("usagers/<int:usager_id>/", usagers.usagers_details, name="usagers_details"),
+    # revoquer mandat
     path(
         "usagers/<int:usager_id>/mandats/<int:mandat_id>/cancel_confirm",
         usagers.usagers_mandats_cancel_confirm,
-        name="usagers_mandats_cancel_confirm"
+        name="usagers_mandats_cancel_confirm",
+    ),
+    path(
+        "usagers/<int:usager_id>/mandats/<int:mandat_id>/cancel_success",
+        usagers.usagers_mandats_cancel_success,
+        name="usagers_mandats_cancel_success",
     ),
     # new mandat
     path("creation_mandat/", new_mandat.new_mandat, name="new_mandat"),

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -10,7 +10,9 @@ from aidants_connect_web.decorators import (
     activity_required,
     check_mandat_usager,
     check_mandat_aidant,
+    check_mandat_is_expired,
     check_mandat_is_not_expired,
+    check_mandat_is_cancelled,
 )
 
 
@@ -82,9 +84,11 @@ def usagers_mandats_cancel_confirm(request, usager_id, mandat_id):
 
             Journal.objects.mandat_cancel(mandat)
 
-            django_messages.success(request, "Le mandat a été révoqué avec succès !")
-
-            return redirect("usagers_details", usager_id=usager.id)
+            return redirect(
+                "usagers_mandats_cancel_success",
+                usager_id=usager.id,
+                mandat_id=mandat.id,
+            )
 
         else:
             return render(
@@ -97,3 +101,21 @@ def usagers_mandats_cancel_confirm(request, usager_id, mandat_id):
                     "error": "Erreur lors de l'annulation du mandat.",
                 },
             )
+
+
+@login_required
+@activity_required
+@check_mandat_usager
+@check_mandat_aidant
+@check_mandat_is_expired
+@check_mandat_is_cancelled
+def usagers_mandats_cancel_success(request, usager_id, mandat_id):
+    aidant = request.user
+    usager = get_object_or_404(Usager, pk=usager_id)
+    mandat = get_object_or_404(Mandat, pk=mandat_id)
+
+    return render(
+        request,
+        "aidants_connect_web/usagers_mandats_cancel_success.html",
+        {"aidant": aidant, "usager": usager, "mandat": mandat},
+    )


### PR DESCRIPTION
## 🌮 Objectif

Une fois un mandat (périmètre) révoqué, une page de confirmation offre la possibilité d'afficher et d'imprimer un justificatif

## 🔍 Implémentation

- Une nouvelle page `usagers/<usager_id>/mandats/<mandat_id>/cancel_success` après la confirmation de la révocation

TODO
- Il manque un template `mandat_cancel_proof` contenant le texte justificatif que l'aidant peut imprimer

BLOCAGE
Besoin de redéfinir la nation de mandat vs périmètre, car il serait peut-être préférable de révoquer un mandat entier et non juste un périmètre (Bérangère)

## 🖼️ Images

<img width="1365" alt="Screenshot 2020-02-20 at 17 26 18" src="https://user-images.githubusercontent.com/7147385/74956276-270e3180-5406-11ea-8597-2190c106c0ae.png">


