### PR TITLE
Donne aux aidants un accès à tous les usagers de leur organisation

### DIFF
--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -1,10 +1,6 @@
-from django.shortcuts import redirect, get_object_or_404
-from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.conf import settings
 from django.utils import timezone
-
-from aidants_connect_web.models import Mandat
 
 
 def activity_required(view=None, redirect_field_name="next"):
@@ -26,51 +22,3 @@ def activity_required(view=None, redirect_field_name="next"):
         redirect_field_name=redirect_field_name,
     )
     return decorator if (view is None) else decorator(view)
-
-
-def check_mandat_usager(func):
-    """
-    Decorator that checks that the mandat_id corresponds to the usager_id
-    specified in the request url
-    """
-
-    def actual_decorator(request, *args, **kwargs):
-        mandat = get_object_or_404(Mandat, pk=kwargs["mandat_id"])
-        if not (mandat.usager_id == kwargs["usager_id"]):
-            messages.error(request, f"Erreur de permissions")
-            return redirect("dashboard")
-        return func(request, *args, **kwargs)
-
-    return actual_decorator
-
-
-def check_mandat_aidant(func):
-    """
-    Decorator that checks that the mandat_id was created by
-    the current user (the logged in Aidant)
-    TODO: manage futur Organisation roles
-    """
-
-    def actual_decorator(request, *args, **kwargs):
-        mandat = get_object_or_404(Mandat, pk=kwargs["mandat_id"])
-        if not (mandat.aidant_id == request.user.id):
-            messages.error(request, f"Erreur de permissions")
-            return redirect("dashboard")
-        return func(request, *args, **kwargs)
-
-    return actual_decorator
-
-
-def check_mandat_is_not_expired(func):
-    """
-    Decorator that checks that the mandat_id is not yet expired
-    """
-
-    def actual_decorator(request, *args, **kwargs):
-        mandat = get_object_or_404(Mandat, pk=kwargs["mandat_id"])
-        if mandat.is_expired:
-            messages.error(request, f"Le mandat est déjà expiré")
-            return redirect("dashboard")
-        return func(request, *args, **kwargs)
-
-    return actual_decorator

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -36,73 +36,98 @@ class Aidant(AbstractUser):
     def get_usagers(self):
         """
         :return: a queryset of usagers who have a mandat (both active & expired)
-        with the aidant
+        with the aidant's organisation.
         """
-        mandats_for_aidant = Mandat.objects.filter(aidant=self)
-        usagers = (
-            Usager.objects.filter(mandats__in=mandats_for_aidant)
-            .distinct()
-            .order_by("family_name")
-        )
-        return usagers
+        return Usager.objects.visible_by(self).distinct()
+
+    def get_usager(self, usager_id):
+        """
+        :return: an usager or `None`.
+        """
+        try:
+            return self.get_usagers().get(pk=usager_id)
+        except Usager.DoesNotExist:
+            return None
+
+    def get_active_usagers(self):
+        """
+        :return: a queryset of usagers who have an active mandat
+        with the aidant's organisation.
+        """
+        return self.get_usagers().active()
 
     def get_usagers_with_active_mandat(self):
         """
         :alternate name: get_active_usagers()
-        :return: a queryset of usagers who have a active mandat with the aidant
         """
-        active_mandats_for_aidant = Mandat.objects.active().filter(aidant=self)
-        usagers = (
-            Usager.objects.filter(mandats__in=active_mandats_for_aidant)
-            .distinct()
-            .order_by("family_name")
-        )
-        return usagers
+        return self.get_active_usagers()
+
+    def get_mandats(self):
+        """
+        :return: a queryset of mandats visible by this aidant.
+        """
+        return Mandat.objects.visible_by(self).distinct()
+
+    def get_mandat(self, mandat_id):
+        """
+        :return: a mandat or `None`.
+        """
+        try:
+            return self.get_mandats().get(pk=mandat_id)
+        except Mandat.DoesNotExist:
+            return None
+
+    def get_mandats_for_usager(self, usager):
+        """
+        :param usager:
+        :return: a queryset of the specified usager's mandats.
+        """
+        return self.get_mandats().for_usager(usager)
 
     def get_active_mandats_for_usager(self, usager):
         """
         :param usager:
-        :return: a queryset of the active mandats with the usagers
+        :return: a queryset of the specified usager's active mandats.
         """
-        active_mandats = (
-            Mandat.objects.active()
-            .filter(usager=usager, aidant=self)
-            .order_by("creation_date")
-        )
-        return active_mandats
+        return self.get_mandats_for_usager(usager).active()
 
     def get_expired_mandats_for_usager(self, usager):
         """
         :param usager:
-        :return: a queryset of the expired mandats with the usagers
+        :return: a queryset of the specified usager's expired mandats.
         """
-        expired_mandats = (
-            Mandat.objects.expired()
-            .filter(usager=usager, aidant=self)
-            .order_by("creation_date")
-        )
-        return expired_mandats
+        return self.get_mandats_for_usager(usager).expired()
 
     def get_active_demarches_for_usager(self, usager):
         """
         :param usager:
-        :return: list of demarche the usager and the aidant have a active mandat for
+        :return: a list of demarches the usager has active mandats for
+        in this aidant's organisation.
         """
-        active_mandats = Mandat.objects.active().filter(usager=usager, aidant=self)
-        return active_mandats.values_list("demarche", flat=True)
+        return self.get_active_mandats_for_usager(usager).values_list(
+            "demarche", flat=True
+        )
 
     def get_last_action_timestamp(self):
-        a = (
-            Journal.objects.filter(initiator=self.full_string_identifier)
-            .last()
-            .creation_date
-        )
-        return a
+        """
+        :return: the timestamp of this aidant's last logged action or `None`.
+        """
+        try:
+            return (
+                Journal.objects.filter(initiator=self.full_string_identifier)
+                .last()
+                .creation_date
+            )
+        except AttributeError:
+            return None
 
 
-class UsagerManager(models.Manager):
+class UsagerQuerySet(models.QuerySet):
     def active(self):
         return self.filter(mandats__expiration_date__gt=timezone.now()).distinct()
+
+    def visible_by(self, aidant):
+        return self.filter(mandats__aidant__organisation=aidant.organisation).distinct()
 
 
 class Usager(models.Model):
@@ -126,7 +151,7 @@ class Usager(models.Model):
 
     creation_date = models.DateTimeField(default=timezone.now)
 
-    objects = UsagerManager()
+    objects = UsagerQuerySet.as_manager()
 
     class Meta:
         ordering = ["family_name", "given_name"]
@@ -139,18 +164,30 @@ class Usager(models.Model):
         return f"{self.get_full_name()} - {self.id} - {self.email}"
 
     def get_full_name(self):
-        return f"{self.given_name} {self.family_name}"
+        return str(self)
+
+    def get_mandat(self, mandat_id):
+        try:
+            return self.mandats.get(pk=mandat_id)
+        except Mandat.DoesNotExist:
+            return None
 
 
-class MandatManager(models.Manager):
+class MandatQuerySet(models.QuerySet):
     def active(self):
         return self.exclude(expiration_date__lt=timezone.now())
 
     def expired(self):
         return self.exclude(expiration_date__gt=timezone.now())
 
-    def demarche(self, demarche):
+    def for_usager(self, usager):
+        return self.filter(usager=usager)
+
+    def for_demarche(self, demarche):
         return self.filter(demarche=demarche)
+
+    def visible_by(self, aidant):
+        return self.filter(aidant__organisation=aidant.organisation)
 
 
 class Mandat(models.Model):
@@ -171,7 +208,7 @@ class Mandat(models.Model):
         blank=False, default="No token provided"
     )
 
-    objects = MandatManager()
+    objects = MandatQuerySet.as_manager()
 
     class Meta:
         unique_together = ["aidant", "demarche", "usager"]

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -42,25 +42,20 @@ class Aidant(AbstractUser):
 
     def get_usager(self, usager_id):
         """
-        :return: an usager or `None`.
+        :return: an usager or `None` if the aidant isn't allowed
+        by a mandat to access this usager.
         """
         try:
             return self.get_usagers().get(pk=usager_id)
         except Usager.DoesNotExist:
             return None
 
-    def get_active_usagers(self):
+    def get_usagers_with_active_mandat(self):
         """
         :return: a queryset of usagers who have an active mandat
         with the aidant's organisation.
         """
         return self.get_usagers().active()
-
-    def get_usagers_with_active_mandat(self):
-        """
-        :alternate name: get_active_usagers()
-        """
-        return self.get_active_usagers()
 
     def get_mandats(self):
         """
@@ -70,7 +65,8 @@ class Aidant(AbstractUser):
 
     def get_mandat(self, mandat_id):
         """
-        :return: a mandat or `None`.
+        :return: a mandat or `None` if this mandat is not
+        visible by this aidant.
         """
         try:
             return self.get_mandats().get(pk=mandat_id)
@@ -87,14 +83,16 @@ class Aidant(AbstractUser):
     def get_active_mandats_for_usager(self, usager):
         """
         :param usager:
-        :return: a queryset of the specified usager's active mandats.
+        :return: a queryset of the specified usager's active mandats
+        that are visible by this aidant.
         """
         return self.get_mandats_for_usager(usager).active()
 
     def get_expired_mandats_for_usager(self, usager):
         """
         :param usager:
-        :return: a queryset of the specified usager's expired mandats.
+        :return: a queryset of the specified usager's expired mandats
+        that are visible by this aidant.
         """
         return self.get_mandats_for_usager(usager).expired()
 
@@ -127,6 +125,11 @@ class UsagerQuerySet(models.QuerySet):
         return self.filter(mandats__expiration_date__gt=timezone.now()).distinct()
 
     def visible_by(self, aidant):
+        """
+        :param aidant:
+        :return: a new QuerySet instance only filtering in the usagers who have
+        a mandat with this aidant's organisation.
+        """
         return self.filter(mandats__aidant__organisation=aidant.organisation).distinct()
 
 

--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -20,7 +20,7 @@
     {% endif %}
     <div class="tiles">
       <h2 class="float-left">Les usagers avec qui vous avez un mandat</h2>
-      {% if aidant_usagers %}
+      {% if usagers %}
         <!-- <input class="table__filter" type="text" name="input_val" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)"> -->
         <table class="table">
           <thead>
@@ -31,7 +31,7 @@
           </thead>
         </table>
         <!-- fake table body (cannot have a working link inside a td) -->
-        {% for usager in aidant_usagers %}
+        {% for usager in usagers %}
           <div class="row fake-table-row">
             <div class="col-66">
               <a href="{% url 'usager_details' usager_id=usager.id %}">{{ usager.get_full_name }}</a>

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -446,10 +446,10 @@ class JournalModelTest(TestCase):
             expiration_date=timezone.now() + timedelta(days=365),
         )
 
-        logs = Journal.objects.all()
-        self.assertEqual(len(logs), 3)
+        journal_entries = Journal.objects.all()
+        self.assertEqual(len(journal_entries), 3)
 
-        last_entry = logs.last()
+        last_entry = journal_entries.last()
         self.assertEqual(last_entry.action, "create_mandat")
         self.assertIn("Ned Flanders", last_entry.usager)
         self.assertEqual(last_entry.mandat, mandat.id)

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from aidants_connect_web.models import Mandat
 from aidants_connect_web.tests.factories import (
     AidantFactory,
+    MandatFactory,
     UsagerFactory,
 )
 from aidants_connect_web.views import usagers
@@ -35,6 +36,7 @@ class UsagersDetailsPageTests(TestCase):
         self.client = Client()
         self.aidant = AidantFactory()
         self.usager = UsagerFactory()
+        self.mandat = MandatFactory(aidant=self.aidant, usager=self.usager)
 
     def test_usager_details_url_triggers_the_usager_details_view(self):
         found = resolve(f"/usagers/{self.usager.id}/")
@@ -84,14 +86,15 @@ class MandatCancelConfirmPageTests(TestCase):
             response, "aidants_connect_web/usagers_mandats_cancel_confirm.html"
         )
 
-    def test_non_existant_mandat_triggers_404(self):
+    def test_non_existing_mandat_triggers_redirect(self):
         self.client.force_login(self.aidant_1)
         response = self.client.get(
             f"/usagers/{self.usager_1.id}/mandats/3/cancel_confirm"
         )
-        self.assertEqual(response.status_code, 404)
+        url = "/dashboard/"
+        self.assertRedirects(response, url, fetch_redirect_response=False)
 
-    def test_non_existant_usager_triggers_404(self):
+    def test_non_existing_usager_triggers_redirect(self):
         self.client.force_login(self.aidant_1)
         response = self.client.get(
             f"/usagers/{self.usager_2.id + 1}/mandats/{self.mandat_1.id}/cancel_confirm"

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -78,6 +78,7 @@ def check_request_parameters(
 @login_required
 @activity_required
 def authorize(request):
+
     if request.method == "GET":
         parameters = {
             "state": request.GET.get("state"),
@@ -130,7 +131,7 @@ def authorize(request):
         try:
             connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
-                log.info("Connexion has expired at authorize")
+                log.info("Connection has expired at authorize")
                 return HttpResponseBadRequest()
         except ObjectDoesNotExist:
             log.info("No connection corresponds to the connection_id:")
@@ -138,10 +139,14 @@ def authorize(request):
             logout(request)
             return HttpResponseForbidden()
 
+        aidant = request.user
         chosen_usager = Usager.objects.get(pk=parameters["chosen_usager"])
-        if chosen_usager not in request.user.get_usagers_with_active_mandat():
-            log.info("This usager does not have a valid mandat with the aidant")
-            log.info(request.user.id)
+        if chosen_usager not in aidant.get_usagers_with_active_mandat():
+            log.info(
+                "This usager does not have a valid mandat "
+                "with the aidant's organisation"
+            )
+            log.info(aidant.id)
             logout(chosen_usager.id)
             logout(request)
             return HttpResponseForbidden()

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -85,7 +85,7 @@ def statistiques(request):
             {
                 "title": demarche,
                 "icon": settings.DEMARCHES[demarche]["icon"],
-                "value": Mandat.objects.demarche(demarche).count(),
+                "value": Mandat.objects.for_demarche(demarche).count(),
             }
         )
     demarches_aggregation.sort(key=lambda x: x["value"], reverse=True)


### PR DESCRIPTION
🌮 Objectif

Permettre aux aidants de visualiser et interagir avec tous les usagers de leur organisation, plutôt que seulement ceux avec lesquels ils ont personnellement signé un mandat
🔍 Implémentation

    Amélioration et refactorisation de managers personnalisés pour les objets Aidant et Mandat
    Utilisation de ces managers dans les vues du projet pour effectuer les contrôles requis
    Supression du mécanisme précédent basé sur un pipeline de décorateurs effectuant une série de contrôles

⚠️ Informations supplémentaires

Cette PR ne peut pas être mergée avant ma PR précédente.