### PR TITLE
Sauvegarde l'email de l'usager

### DIFF
--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -271,6 +271,7 @@ class GetUserInfoTests(TestCase):
         usager, error = get_user_info("abc", "def")
 
         self.assertEqual(usager.given_name, "Fabrice")
+        self.assertEqual(usager.email, "test@test.com")
         self.assertEqual(error, None)
 
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -153,6 +153,7 @@ def get_user_info(fc_base: str, access_token: str) -> tuple:
             birthplace=user_info.get("birthplace"),
             birthcountry=user_info.get("birthcountry"),
             sub=user_info.get("sub"),
+            email=user_info.get("email"),
         )
         return usager, None
 


### PR DESCRIPTION
## 🌮 Objectif

S'assurer que toutes les informations envoyées par FC sont renvoyées lors de l'utilisation d'un mandat.

## 🔍 Implémentation

Lors de la création d'un usager (`FC_as_FS`), on récupère l'email renvoyé par FC.
