### PR TITLE
Make connection deletion command a Celery task

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: gunicorn aidants_connect.wsgi --log-file -
+worker: celery worker --app aidants_connect --beat --loglevel INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Appliquez les migrations de la base de données :
 python manage.py migrate
 ```
 
-Créez un `superuser` :
+Créez un _superuser_ :
 
 ```shell
 python manage.py createsuperuser --username <insert_admin_name>
@@ -200,7 +200,7 @@ Puis il vous faudra recréer la base de donnée PostgreSQL :
     psql
     ```
 
-- Puis, dans l'invite de commande psql :
+- Puis, dans l'invite de commande `psql` :
 
     ```sql
     DROP DATABASE aidants_connect;
@@ -209,7 +209,7 @@ Puis il vous faudra recréer la base de donnée PostgreSQL :
     \q
     ```
 
-Ensuite, de retour dans le shell, pour lancer les migrations :
+Ensuite, de retour dans le _shell_, pour lancer les migrations :
 
 ```shell
 python manage.py makemigrations
@@ -224,15 +224,25 @@ Enfin, chargez les données :
     python manage.py loaddata db.json
     ```
 
-- Soit des données de test (création d'un superuser `admin@email.com` rattaché à une Organisation `BetaGouv`) :
+- Soit des données de test (création d'un _superuser_ `admin@email.com` rattaché à une `Organisation` `BetaGouv`) :
 
     ```shell
     python manage.py loaddata admin.json
     python manage.py loaddata usager_mandat.json
     ```
 
-- Soit repartir de zero en recréant un superuser (plus de détails dans la séction [Installer l'application](#installer-lapplication)) :
+- Soit repartir de zéro en recréant un _superuser_ (plus de détails dans la section [Installer l'application](#installer-lapplication)) :
 
     ```shell
     python manage.py createsuperuser
     ```
+
+### Purger les connexions expirées
+
+Les objets Django de type `Connection` repésentent une forme de cache pendant l'établissement de la connexion FranceConnect.
+À ce titre, ils contiennent des données personnelles et doivent donc être purgés régulièrement pour respecter nos engagements en la matière.
+Pour ce faire, il suffit d'exécuter ou de planifier la commande suivante :
+
+```shell
+python manage.py delete_expired_connections
+```

--- a/aidants_connect/__init__.py
+++ b/aidants_connect/__init__.py
@@ -1,0 +1,5 @@
+# This will make sure the Celery app is always imported
+# when Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/aidants_connect/celery.py
+++ b/aidants_connect/celery.py
@@ -1,0 +1,14 @@
+# This configuration file is taken from the official Celery documentation:
+# http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html
+# Please refer to it for additional information.
+
+import os
+
+from celery import Celery
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "aidants_connect.settings")
+
+app = Celery("aidants_connect")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -10,10 +10,13 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
 
-import os
-from dotenv import load_dotenv
 from datetime import timedelta
+import os
+
+from dotenv import load_dotenv
+
 from aidants_connect.postgres_url import turn_psql_url_into_param
+
 
 load_dotenv(verbose=True)
 
@@ -72,6 +75,7 @@ INSTALLED_APPS = [
     "django_otp",
     "django_otp.plugins.otp_static",
     "django_otp.plugins.otp_totp",
+    "django_celery_beat",
 ]
 
 MIDDLEWARE = [
@@ -335,3 +339,14 @@ HEADLESS_FUNCTIONAL_TESTS = (
 BYPASS_FIRST_LIVESERVER_CONNECTION = (
     True if os.getenv("BYPASS_FIRST_LIVESERVER_CONNECTION") == "True" else False
 )
+
+# Celery settings
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+JSON_CONTENT_TYPE = "application/json"
+JSON_SERIALIZER = "json"
+
+CELERY_BROKER_URL = REDIS_URL
+CELERY_RESULT_BACKEND = REDIS_URL
+CELERY_RESULT_SERIALIZER = JSON_SERIALIZER
+CELERY_TASK_SERIALIZER = JSON_SERIALIZER
+CELERY_ACCEPT_CONTENT = [JSON_CONTENT_TYPE]

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -1,6 +1,18 @@
 from django.contrib.admin import ModelAdmin
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 
+from django_celery_beat.admin import (
+    ClockedScheduleAdmin,
+    PeriodicTaskAdmin,
+)
+from django_celery_beat.models import (
+    ClockedSchedule,
+    CrontabSchedule,
+    IntervalSchedule,
+    PeriodicTask,
+    SolarSchedule,
+)
+
 from django_otp.admin import OTPAdminSite
 from django_otp.plugins.otp_static.admin import StaticDeviceAdmin
 from django_otp.plugins.otp_static.models import StaticDevice
@@ -12,11 +24,11 @@ from magicauth.models import MagicToken
 from aidants_connect_web.forms import AidantChangeForm, AidantCreationForm
 from aidants_connect_web.models import (
     Aidant,
-    Usager,
-    Mandat,
-    Journal,
     Connection,
+    Journal,
+    Mandat,
     Organisation,
+    Usager,
 )
 
 
@@ -104,5 +116,13 @@ admin_site.register(Connection)
 admin_site.register(Organisation, VisibleToStaff)
 
 admin_site.register(MagicToken)
-admin_site.register(StaticDevice, StaticDeviceStaffAdmin)
-admin_site.register(TOTPDevice, TOTPDeviceStaffAdmin)
+admin_site.register(StaticDevice, StaticDeviceAdmin)
+admin_site.register(TOTPDevice, TOTPDeviceAdmin)
+
+
+# Also register the Django Celery Beat models
+admin_site.register(PeriodicTask, PeriodicTaskAdmin)
+admin_site.register(IntervalSchedule)
+admin_site.register(CrontabSchedule)
+admin_site.register(SolarSchedule)
+admin_site.register(ClockedSchedule, ClockedScheduleAdmin)

--- a/aidants_connect_web/management/commands/delete_expired_connections.py
+++ b/aidants_connect_web/management/commands/delete_expired_connections.py
@@ -1,23 +1,10 @@
 from django.core.management.base import BaseCommand
-from django.template.defaultfilters import pluralize
 
-from aidants_connect_web.models import Connection
+from aidants_connect_web.tasks import delete_expired_connections
 
 
 class Command(BaseCommand):
     help = "Deletes the expired `Connection` objects from the database"
 
     def handle(self, *args, **options):
-        self.stdout.write("Deleting expired connections...")
-
-        expired_connections = Connection.objects.expired()
-        deleted_connections_count, _ = expired_connections.delete()
-
-        if deleted_connections_count > 0:
-            self.stdout.write(
-                f"Successfully deleted {deleted_connections_count} "
-                f"connection{pluralize(deleted_connections_count)}!"
-            )
-
-        else:
-            self.stdout.write("No connection to delete.")
+        delete_expired_connections()

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -1,0 +1,29 @@
+import logging
+
+from django.template.defaultfilters import pluralize
+
+from celery import shared_task
+
+from aidants_connect_web.models import Connection
+
+
+logger = logging.getLogger()
+
+
+@shared_task
+def delete_expired_connections():
+
+    logger.info("Deleting expired connections...")
+
+    expired_connections = Connection.objects.expired()
+    deleted_connections_count, _ = expired_connections.delete()
+
+    if deleted_connections_count > 0:
+        logger.info(
+            f"Successfully deleted {deleted_connections_count} "
+            f"connection{pluralize(deleted_connections_count)}!"
+        )
+    else:
+        logger.info("No connection to delete.")
+
+    return deleted_connections_count

--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from io import StringIO
 
 from django.core.management import call_command
 from django.test import tag, TestCase
@@ -24,17 +23,14 @@ class DeleteExpiredConnectionsTest(TestCase):
     def test_delete_expired_connections(self):
         self.assertEqual(Connection.objects.count(), 2)
 
-        out = StringIO()
         command_name = "delete_expired_connections"
 
-        call_command(command_name, stdout=out)
+        call_command(command_name)
         remaining_connections = Connection.objects.all()
         self.assertEqual(remaining_connections.count(), 1)
         self.assertEqual(remaining_connections.first().id, self.conn_2.id)
-        self.assertIn("Successfully deleted 1 connection!", out.getvalue())
 
-        call_command(command_name, stdout=out)
+        call_command(command_name)
         remaining_connections = Connection.objects.all()
         self.assertEqual(remaining_connections.count(), 1)
         self.assertEqual(remaining_connections.first().id, self.conn_2.id)
-        self.assertIn("No connection to delete.", out.getvalue())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 Django==3.0.4
 
+celery[redis]==4.4.0
 django-admin-honeypot==1.1.0
+django-celery-beat==2.0.0
 django-csp==3.6
 django-otp==0.8.1
 django-referrer-policy==1.0


### PR DESCRIPTION
## 🌮 Objectif

Permettre l'exécution de tâches planifiées, récurrentes ou non.

## 🔍 Implémentation

- Ajout de [`celery`](https://docs.celeryproject.org/en/stable/) et [`django-celery-beat`](https://django-celery-beat.readthedocs.io/en/latest/) aux `requirements` du projet.
- Configuration de ces composants applicatifs.
- Configuration du back-office Django pour administrer les tâches planifiées.
- Conversion de la commande d'effacement des connexions expirées en tâche planifiable.

## ⚠️ Informations supplémentaires

L'utilisation de `celery` implique de rajouter un composant à notre architecture pour jouer le rôle de _broker_ de tâches. Les plus fréquemment utilisés sont RabbitMQ et Redis ; ce dernier étant le seul disponible sur Scalingo, il remporte aisément notre préférence 😉 

Elle implique également de rajouter un process _worker_ dans l'application Scalingo, qui est ici configuré via le fichier `Procfile`.

## 🖼️ Images

<img width="1280" alt="bgad-celery01" src="https://user-images.githubusercontent.com/492387/75795614-da661700-5d72-11ea-92f2-5d17bb3387ad.png">

<img width="1280" alt="bgad-celery02" src="https://user-images.githubusercontent.com/492387/75795635-e18d2500-5d72-11ea-8667-4f93d36afe01.png">

<img width="1280" alt="bgad-celery03" src="https://user-images.githubusercontent.com/492387/75795649-e7830600-5d72-11ea-8dbb-cf7cec9bfef4.png">

<img width="1280" alt="bgad-celery04" src="https://user-images.githubusercontent.com/492387/75795659-ece05080-5d72-11ea-89db-9c653c96a2a3.png">

