### PR TITLE
Fix using a `Mandat` made by another `Aidant`

### DIFF
--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -217,7 +217,7 @@ def fi_select_demarche(request):
         try:
             chosen_mandat = Mandat.objects.get(
                 usager=connection.usager,
-                aidant=request.user,
+                aidant__organisation=request.user.organisation,
                 demarche=parameters["chosen_demarche"],
                 expiration_date__gt=timezone.now(),
             )


### PR DESCRIPTION
## 🌮 Objectif

Corriger un bug lors de l'utilisation par un aidant d'un mandat créé par un autre aidant de son organisation — fonctionnalité introduite par la PR #162.

## 🔍 Implémentation

- Filtrage du mandat à utiliser par l'organisation plutôt que par l'aidant créateur
- Ajout d'un test unitaire