### PR TITLE
Clarifie le nom de la page de l'application

### DIFF
--- a/aidants_connect_web/templates/404.html
+++ b/aidants_connect_web/templates/404.html
@@ -1,5 +1,7 @@
 {% extends 'layouts/main.html' %}
 
+{% block title %}Aidants Connect - Cette page n'existe pas (404){% endblock %}
+
 {% block content %}
 <section class="section">
   <div class="container">

--- a/aidants_connect_web/templates/aidants_connect_web/dashboard.html
+++ b/aidants_connect_web/templates/aidants_connect_web/dashboard.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Espace Aidant{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/guide_utilisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/guide_utilisation.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Guide d'utilisation{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/resources.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Sélectionnez l'usager{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/id_provider.css' %}" rel="stylesheet">
 {% endblock extracss %}
@@ -15,7 +17,7 @@
 <section class="section section-grey mandat-select__section">
   <div class="container">
     <form method="post">
-      <h2>Choisissez l'usager que vous souhaitez FranceConnecter</h2>
+      <h2>Sélectionnez l'usager que vous souhaitez FranceConnecter</h2>
       <p id="instructions">Seuls les usagers avec un mandat en cours sont affichés ici.</p>
       {% if usagers %}
         <fieldset>

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Sélectionnez la démarche{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/id_provider.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_print.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_print.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Impression du mandat{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/mandat_print.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Nouveau mandat{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Récapitulatif du nouveau mandat{% endblock %}
+
 {% block extracss %}
   <link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_success.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_success.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Nouveau mandat créé !{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - {{ usager.get_full_name }}{% endblock %}
+
 {% block extracss %}
   <link href="{% static 'css/usagers.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Usagers{% endblock %}
+
 {% block extracss %}
   <link href="{% static 'css/usagers.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_cancel_confirm.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_cancel_confirm.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Confirmer la révocation du mandat{% endblock %}
+
 {% block extracss %}
   <link href="{% static 'css/usagers.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/footer/cgu.html
+++ b/aidants_connect_web/templates/footer/cgu.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Conditions générales d'utilisation{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/footer/mentions_legales.html
+++ b/aidants_connect_web/templates/footer/mentions_legales.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Mentions légales{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/footer/statistiques.html
+++ b/aidants_connect_web/templates/footer/statistiques.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Statistiques{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -7,7 +7,8 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>Aidants Connect - aidantsconnect.beta.gouv.fr</title>
+  <title>{% block title %}Aidants Connect{% endblock %}</title>
+
 
   <link href="{% static 'css/template.min.css' %}" rel="stylesheet">
   <link href="{% static 'css/main.css' %}" rel="stylesheet">

--- a/aidants_connect_web/templates/login/email_sent.html
+++ b/aidants_connect_web/templates/login/email_sent.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Email envoyé (connexion){% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/login.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Connexion{% endblock %}
+
 {% block extracss %}
 <link href="{% static 'css/login.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/templates/registration/activity_check.html
+++ b/aidants_connect_web/templates/registration/activity_check.html
@@ -2,6 +2,8 @@
 
 {% load static %}
 
+{% block title %}Aidants Connect - Session expirée{% endblock %}
+
 {% block extracss %}
   <link href="{% static 'css/login.css' %}" rel="stylesheet">
 {% endblock extracss %}

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -46,6 +46,14 @@ class UsagersDetailsPageTests(TestCase):
         response = self.client.get(f"/usagers/{self.usager.id}/")
         self.assertTemplateUsed(response, "aidants_connect_web/usager_details.html")
 
+    def test_usager_details_template_dynamic_title(self):
+        self.client.force_login(self.aidant)
+        response = self.client.get(f"/usagers/{self.usager.id}/")
+        response_content = response.content.decode("utf-8")
+        self.assertIn(
+            f"<title>Aidants Connect - Homer Simpson</title>", response_content
+        )
+
 
 @tag("usagers")
 class MandatCancelConfirmPageTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Avoir un nom de page claire (dans le cas de plusieurs onglets, ou lorsque un lien est partagé)

## 🔍 Implémentation

- Rendre le nom de la page dynamique (chaque page a son propre nom)
- Un test rapide pour un usager

## 🖼️ Images

<img width="965" alt="Screenshot 2020-03-12 at 16 44 25" src="https://user-images.githubusercontent.com/7147385/76539441-1428d300-6481-11ea-805f-0cc1894022d5.png">

