### PR TITLE
Add error pages

### DIFF
--- a/aidants_connect_web/templates/500.html
+++ b/aidants_connect_web/templates/500.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/main.html' %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>🤔 Aidants Connect rencontre une difficulté</h1>
+    <h2>👩🏽‍💻 Code 500 : Erreur interne du serveur</h2>
+    <p>Vous pouvez nous envoyer un mail à support@aidantsconnect.beta.gouv.fr avec: </p>
+    <ul>
+      <li>Type d'erreur: 500</li>
+      <li>La date, l'heure et votre fuseau horaire</li>
+      <li>L'url de cette page</li>
+      <li>Ce que vous faisiez juste avant que cette erreur s'affiche</li>
+    </ul>
+    <p>ou cliquez sur <a href="mailto:support@aidantsconnect.beta.gouv.fr?&subject=Erreur%20500&body=Bonjour,%20%0D%0A%0D%0AJ'ai%20vu%20une%20erreur%20sur%20Aidants%20Connect.%20%0D%0A%0D%0AVoici les informations sur l'erreur%20(À%20compléter)%20%0D%0A%0D%0A-%20La%20date,%20l'heure%20et%20fuseau%20horaire%20:%0D%0A%0D%0A-%20L'url%20de%20cette%20page%20:%0D%0A%0D%0A-%20Ce%20que%20vous%20faisiez%20juste%20avant%20que%20cette%20erreur%20s'affiche%20:">ce lien</a> pour avoir un email pré-rempli</p>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -72,7 +72,7 @@ class LogoutPageTests(TestCase):
         self.assertRedirects(response, "/")
 
 
-@tag("service", "this")
+@tag("service")
 class ActivityCheckPageTests(TestCase):
     def setUp(self):
         self.aidant_thierry = AidantFactory()


### PR DESCRIPTION
## 🌮 Objectif
Donner un call to action aux utilisateurs qui rencontrent une erreur 500

## 🔍 Implémentation

Django permet de gérer facilement l'UX d'un certain nombre d'erreur type via les _Error views_
https://docs.djangoproject.com/en/3.0/ref/views/#error-views

> The default 500 view passes no variables to the 500.html template and is rendered with an empty Context to lessen the chance of additional errors.


## ⚠️ Informations supplémentaires

Pour tester, on peut aller sur l'interface d'admin et utiliser une barre de recherche.

## 🖼️ Images
### Erreur 500
<img width="966" alt="Capture d’écran 2020-03-13 à 18 19 55" src="https://user-images.githubusercontent.com/13916213/76645618-a69ca580-6559-11ea-9f8a-20c6fa475a1c.png">

Le contenu du mail est semblable à
<img width="738" alt="Capture d’écran 2020-03-13 à 18 40 32" src="https://user-images.githubusercontent.com/13916213/76645915-40fce900-655a-11ea-9b0c-f480a33eb52b.png">

