### PR TITLE
Fix birthplace normalization

### DIFF
--- a/aidants_connect_web/migrations/0019_normalize_usager_data.py
+++ b/aidants_connect_web/migrations/0019_normalize_usager_data.py
@@ -3,10 +3,28 @@
 from django.db import migrations, models
 
 
+def _normalize_birthplace(usager):
+
+    # This code is duplicated from the `normalize_birthplace` method
+    # of the `Usager` model, because such methods cannot be called
+    # during a data migration.
+    # See: https://stackoverflow.com/questions/28777338/django-migrations-runpython-not-able-to-call-model-methods  # noqa
+
+    if not usager.birthplace:
+        return None
+
+    normalized_birthplace = usager.birthplace.zfill(5)
+    if normalized_birthplace != usager.birthplace:
+        usager.birthplace = normalized_birthplace
+        usager.save(update_fields=["birthplace"])
+
+    return usager.birthplace
+
+
 def normalize_birthplace(apps, schema_editor):
     Usager = apps.get_model("aidants_connect_web", "Usager")
     for usager in Usager.objects.all():
-        usager.normalize_birthplace()
+        _normalize_birthplace(usager)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## 🌮 Objectif

Corrige la normalisation du lieu de naissance de l'usager

## 🔍 Implémentation

- Utilisation d'une fonction dans la migration de données

## ⚠️ Informations supplémentaires

Les méthodes d'un modèle Django ne peuvent pas être utilisées pendant une migration de données. [Voir ce post StackOverflow](https://stackoverflow.com/questions/28777338/django-migrations-runpython-not-able-to-call-model-methods) pour une explication plus complète.
