### PR TITLE
Améliorer la gestion des erreur

### DIFF
--- a/aidants_connect_web/templates/400.html
+++ b/aidants_connect_web/templates/400.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/main.html' %}
+{% block title %}Aidants Connect - requête erronée (400){% endblock %}
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>🤔 Il y a eu un souci technique lors de l'échange de données.</h1>
+    <h2>👩🏽‍💻 Code 400 : La syntaxe de la requête est erronée.</h2>
+    <p>Vous pouvez nous envoyer un mail à support@aidantsconnect.beta.gouv.fr avec: </p>
+    <ul>
+      <li>Type d'erreur : 400</li>
+      <li>La date, l'heure et votre fuseau horaire</li>
+      <li>L'URL de cette page</li>
+      <li>Ce que vous faisiez juste avant que cette erreur s'affiche</li>
+    </ul>
+    <p>ou cliquer sur <a href="mailto:support@aidantsconnect.beta.gouv.fr?&subject=Erreur%20403&body=Bonjour,%20%0D%0A%0D%0AJ'ai%20vu%20une%20erreur%20sur%20Aidants%20Connect.%20%0D%0A%0D%0AVoici les informations sur l'erreur%20(À%20compléter)%20%0D%0A%0D%0A-%20La%20date,%20l'heure%20et%20fuseau%20horaire%20:%0D%0A%0D%0A-%20L'URL%20de%20cette%20page%20:%0D%0A%0D%0A-%20Ce%20que%20vous%20faisiez%20juste%20avant%20que%20cette%20erreur%20s'affiche%20:">ce lien</a> pour avoir un email pré-rempli</p>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/403.html
+++ b/aidants_connect_web/templates/403.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/main.html' %}
+{% block title %}Aidants Connect - Accès refusé (403){% endblock %}
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>🤔 Vous n'avez pas la permission d'accéder à cette page</h1>
+    <h2>👩🏽‍💻 Code 403 : Accès refusé</h2>
+    <p>Vous pouvez nous envoyer un mail à support@aidantsconnect.beta.gouv.fr avec: </p>
+    <ul>
+      <li>Type d'erreur : 403</li>
+      <li>La date, l'heure et votre fuseau horaire</li>
+      <li>L'URL de cette page</li>
+      <li>Ce que vous faisiez juste avant que cette erreur s'affiche</li>
+    </ul>
+    <p>ou cliquer sur <a href="mailto:support@aidantsconnect.beta.gouv.fr?&subject=Erreur%20403&body=Bonjour,%20%0D%0A%0D%0AJ'ai%20vu%20une%20erreur%20sur%20Aidants%20Connect.%20%0D%0A%0D%0AVoici les informations sur l'erreur%20(À%20compléter)%20%0D%0A%0D%0A-%20La%20date,%20l'heure%20et%20fuseau%20horaire%20:%0D%0A%0D%0A-%20L'URL%20de%20cette%20page%20:%0D%0A%0D%0A-%20Ce%20que%20vous%20faisiez%20juste%20avant%20que%20cette%20erreur%20s'affiche%20:">ce lien</a> pour avoir un email pré-rempli</p>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/408.html
+++ b/aidants_connect_web/templates/408.html
@@ -1,0 +1,18 @@
+{% extends 'layouts/main.html' %}
+{% block title %}Aidants Connect - TimeOut (408){% endblock %}
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>🤔 Le temps imparti à la connexion FranceConnect est dépassé</h1>
+    <h2>👩🏽‍💻 Code 408 : Timeout</h2>
+    <p>Vous pouvez nous envoyer un mail à support@aidantsconnect.beta.gouv.fr avec: </p>
+    <ul>
+      <li>Type d'erreur : 408</li>
+      <li>La date, l'heure et votre fuseau horaire</li>
+      <li>L'URL de cette page</li>
+      <li>Ce que vous faisiez juste avant que cette erreur s'affiche</li>
+    </ul>
+    <p>ou cliquer sur <a href="mailto:support@aidantsconnect.beta.gouv.fr?&subject=Erreur%20408&body=Bonjour,%20%0D%0A%0D%0AJ'ai%20vu%20une%20erreur%20sur%20Aidants%20Connect.%20%0D%0A%0D%0AVoici les informations sur l'erreur%20(À%20compléter)%20%0D%0A%0D%0A-%20La%20date,%20l'heure%20et%20fuseau%20horaire%20:%0D%0A%0D%0A-%20L'URL%20de%20cette%20page%20:%0D%0A%0D%0A-%20Ce%20que%20vous%20faisiez%20juste%20avant%20que%20cette%20erreur%20s'affiche%20:">ce lien</a> pour avoir un email pré-rempli</p>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/500.html
+++ b/aidants_connect_web/templates/500.html
@@ -1,5 +1,5 @@
 {% extends 'layouts/main.html' %}
-
+{% block title %}Aidants Connect - Erreur interne du serveur (500){% endblock %}
 {% block content %}
 <section class="section">
   <div class="container">

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -38,15 +38,13 @@ TEST_FC_CONNECTION_AGE = 300
 @tag("new_mandat", "FC_as_FS")
 @override_settings(FC_CONNECTION_AGE=TEST_FC_CONNECTION_AGE)
 class FCCallback(TestCase):
-    date = datetime(2019, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
-    epoch_date = date.timestamp()
+    date = DATE
 
     @freeze_time(date)
     def setUp(self):
         self.client = Client()
         self.aidant = AidantFactory()
-        date = datetime(2019, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
-        self.epoch_date = date.timestamp()
+        self.epoch_date = DATE.timestamp()
 
         self.connection = Connection.objects.create(
             demarches=["argent", "papiers"],
@@ -55,7 +53,7 @@ class FCCallback(TestCase):
             connection_type="FS",
             nonce="test_nonce",
             id=1,
-            expires_on=date + timedelta(minutes=5),
+            expires_on=DATE + timedelta(minutes=5),
             aidant=self.aidant,
         )
         Connection.objects.create(

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -131,8 +131,8 @@ def authorize(request):
         try:
             connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
-                log.info("Connection has expired at authorize")
-                return HttpResponseBadRequest()
+                log.info("connection has expired at authorize")
+                return render(request, "408.html", status=408)
         except ObjectDoesNotExist:
             log.info("No connection corresponds to the connection_id:")
             log.info(parameters["connection_id"])
@@ -171,8 +171,8 @@ def fi_select_demarche(request):
         try:
             connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
-                log.info("Connection has expired at select demarche")
-                return HttpResponseBadRequest()
+                log.info("connection has expired at select_demarche")
+                return render(request, "408.html", status=408)
         except ObjectDoesNotExist:
             log.info("No connection corresponds to the connection_id:")
             log.info(parameters["connection_id"])
@@ -207,8 +207,8 @@ def fi_select_demarche(request):
         try:
             connection = Connection.objects.get(pk=parameters["connection_id"])
             if connection.is_expired:
-                log.info("Connection has expired at select demarche")
-                return HttpResponseBadRequest()
+                log.info("connection has expired at select_demarche")
+                return render(request, "408.html", status=408)
         except ObjectDoesNotExist:
             log.info("No connection corresponds to the connection_id:")
             log.info(parameters["connection_id"])
@@ -274,8 +274,8 @@ def token(request):
     try:
         connection = Connection.objects.get(code=code_hash)
         if connection.is_expired:
-            log.info("Connection has expired at token")
-            return HttpResponseBadRequest()
+            log.info("connection has expired at token")
+            return render(request, "408.html", status=408)
     except ObjectDoesNotExist:
         log.info("403: /token No connection corresponds to the code")
         log.info(parameters["code"])
@@ -329,8 +329,8 @@ def user_info(request):
     try:
         connection = Connection.objects.get(access_token=auth_token_hash)
         if connection.is_expired:
-            log.info("Connection has expired at user_info")
-            return HttpResponseBadRequest()
+            log.info("connection has expired at user_info")
+            return render(request, "408.html", status=408)
     except ObjectDoesNotExist:
         log.info("403: /user_info No connection corresponds to the access_token")
         log.info(auth_token)


### PR DESCRIPTION
## 🌮 Objectif

Pour les cas d'erreur 403 (Permission denied), 400 (Bad request) et 408 (Timeout)
- Comprendre l'erreur qui s'est produite
- Savoir quoi faire une fois qu'elle s'est produite

## 🔍 Implémentation

Deux implémentations différentes. 
Dans le cas des erreurs gérées par défaut par Django ([décrites ici](https://docs.djangoproject.com/fr/3.0/ref/views/#error-views), j'ai créé un template au nom de l'erreur.
Dans le cas du timeout, j'ai créé un template (408.html). Dès qu'on repère une connexion expirée dans id_provider ou FC_as_FS, on _render_ ce template avec le _status_ 408.

## 🏕 Amélioration continue

Dans les tests, la gestion des date, j'ai créé une constante qui permet de ne pas manipuler plusieurs fois un date time complexe.

## 🖼️ Images

<img width="1248" alt="Capture d’écran 2020-03-18 à 19 16 31" src="https://user-images.githubusercontent.com/13916213/76993471-2b6a3380-694d-11ea-9cf8-d8262156dd75.png">

