### PR TITLE
Simplifie le déploiement

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
+postdeploy: python manage.py migrate
 web: gunicorn aidants_connect.wsgi --log-file -
 worker: celery worker --app aidants_connect --beat --loglevel INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler


### PR DESCRIPTION
## 🌮 Objectif

Permet de lancer la commande `python manage.py migrate` automatiquement à chaque déploiement

## 🔍 Implémentation

Scalingo propose un hook `postdeploy` qui permet de lancer une commande au moment du déploiement (`release` dans le monde Heroku)
- La doc de Scalingo sur le sujet est [ici](https://doc.scalingo.com/platform/app/postdeploy-hook)
- Si la commande échoue, le déploiement est arrêté et Scalingo reste sur la version actuelle fonctionnelle
- Ca permet d'éviter de devoir se connecter en bash sur la plateforme pour lancer la commande

Comment on s'assure que ça marche ?
- Lors du dernier déploiement j'ai essayé de le rajouter au moment du déploiement sur l'integ, et ça n'a posé de soucis
- Je l'utilise aussi sur Heroku

Et si on veut mettre plusieurs commandes au moment du postdeploy ?
- Une seule ligne postdeploy possible AFAIK
- Mais on peut pointer vers un script bash 😃par exemple `./release-tasks.sh`