### PR TITLE
Répare la cloture des tests fonctionnels

### DIFF
--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -109,7 +109,6 @@ class AidantChangeFormTest(TestCase):
         )
         self.organisation_nantes = OrganisationFactory(name="Association Aide'o'Web")
         self.nantes_id = self.organisation_nantes.id
-
         AidantFactory(
             first_name="Henri",
             last_name="Bernard",
@@ -127,7 +126,6 @@ class AidantChangeFormTest(TestCase):
             profession="Mediateur",
             organisation=self.organisation_nantes,
         )
-
         self.aidant2.set_password("nananana")
 
     def test_change_email_propagates_to_username(self):

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -20,7 +20,6 @@ class CancelMandat(FunctionalTestCase):
         cls.aidant_thierry = AidantFactory()
         device = cls.aidant_thierry.staticdevice_set.create(id=cls.aidant_thierry.id)
         device.token_set.create(token="123456")
-
         cls.aidant_jacqueline = AidantFactory(
             username="jfremont@domain.user",
             email="jfremont@domain.user",
@@ -47,7 +46,6 @@ class CancelMandat(FunctionalTestCase):
             demarche="logement",
             expiration_date=timezone.now() + timedelta(days=12),
         )
-
         super().setUpClass()
 
     def test_cancel_mandat(self):

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -20,11 +20,6 @@ class CreateNewMandat(FunctionalTestCase):
         device.token_set.create(token="123455")
         super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.selenium.quit()
-        super().tearDownClass()
-
     def test_create_new_mandat(self):
         self.open_live_url("/usagers/")
 

--- a/aidants_connect_web/tests/test_functional/test_use_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_use_mandat.py
@@ -14,9 +14,19 @@ from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCa
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 
+FC_URL_PARAMETERS = (
+    f"state=34"
+    f"&nonce=45"
+    f"&response_type=code"
+    f"&client_id={settings.FC_AS_FI_ID}"
+    f"&redirect_uri={settings.FC_AS_FI_CALLBACK_URL}"
+    f"&scope=openid profile email address phone birth"
+    f"&acr_values=eidas1"
+)
+
+
 @tag("functional", "id_provider")
 class UseNewMandat(FunctionalTestCase):
-    @classmethod
     def setUp(self):
         self.aidant = AidantFactory()
         device = self.aidant.staticdevice_set.create(id=self.aidant.id)
@@ -28,15 +38,12 @@ class UseNewMandat(FunctionalTestCase):
             first_name="Jacqueline",
             last_name="Fremont",
         )
-
         self.usager_josephine = UsagerFactory(
             given_name="Joséphine", family_name="ST-PIERRE"
         )
-
         self.usager_anne = UsagerFactory(
             given_name="Anne Cécile Gertrude", family_name="EVALOUS"
         )
-
         MandatFactory(
             aidant=self.aidant,
             usager=self.usager_josephine,
@@ -56,53 +63,41 @@ class UseNewMandat(FunctionalTestCase):
             expiration_date=timezone.now() + timedelta(days=12),
         )
 
-        super().setUpClass()
-
     def test_use_mandat_with_preloging(self):
-        self.use_a_mandat(prelogin=True)
+        # prelogin
+        self.open_live_url("/dashboard/")
+        login_aidant(self)
 
-    def test_use_mandat_without_preloging(self):
-        self.use_a_mandat(prelogin=False)
-
-    def use_a_mandat(self, prelogin: bool):
-        browser = self.selenium
-
-        if prelogin:
-            self.open_live_url("/dashboard/")
-            login_aidant(self)
-
-        parameters = (
-            f"state=34"
-            f"&nonce=45"
-            f"&response_type=code"
-            f"&client_id={settings.FC_AS_FI_ID}"
-            f"&redirect_uri={settings.FC_AS_FI_CALLBACK_URL}"
-            f"&scope=openid profile email address phone birth"
-            f"&acr_values=eidas1"
-        )
-
-        url = f"/authorize/?{parameters}"
+        url = f"/authorize/?{FC_URL_PARAMETERS}"
         self.open_live_url(url)
 
-        if not prelogin:
-            login_aidant(self)
+        self.use_a_mandat()
 
+    def test_use_mandat_without_preloging(self):
+        url = f"/authorize/?{FC_URL_PARAMETERS}"
+        self.open_live_url(url)
+
+        login_aidant(self)
+
+        self.use_a_mandat()
+
+    def use_a_mandat(self):
         # Select usager
-        welcome_aidant = browser.find_element_by_tag_name("h1").text
+        welcome_aidant = self.selenium.find_element_by_tag_name("h1").text
         self.assertEqual(
             welcome_aidant, "Bienvenue sur votre Espace Aidants Connect, Thierry"
         )
-        usagers = browser.find_elements_by_id("label-usager")
+        usagers = self.selenium.find_elements_by_id("label-usager")
         self.assertEqual(len(usagers), 1)
         self.assertEqual(usagers[0].text, "Joséphine ST-PIERRE")
         usagers[0].click()
 
         # Select Démarche
-        step2_title = browser.find_element_by_id("instructions").text
+        step2_title = self.selenium.find_element_by_id("instructions").text
         self.assertIn("En selectionnant une démarche", step2_title)
-        demarches = browser.find_elements_by_id("label_demarche")
+        demarches = self.selenium.find_elements_by_id("label_demarche")
         self.assertEqual(len(demarches), 2)
         last_demarche = demarches[-1]
         last_demarche.click()
         time.sleep(2)
-        self.assertIn("fcp.integ01.dev-franceconnect.fr", browser.current_url)
+        self.assertIn("fcp.integ01.dev-franceconnect.fr", self.selenium.current_url)

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -45,7 +45,6 @@ class FCCallback(TestCase):
         self.client = Client()
         self.aidant = AidantFactory()
         self.epoch_date = DATE.timestamp()
-
         self.connection = Connection.objects.create(
             demarches=["argent", "papiers"],
             duree=1,
@@ -62,7 +61,6 @@ class FCCallback(TestCase):
             nonce="test_another_nonce",
             id=2,
         )
-
         self.usager_sub_fc = "123"
         self.usager_sub = generate_sha256_hash(
             f"{self.usager_sub_fc}{settings.FC_AS_FI_HASH_SALT}".encode()

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -236,11 +236,9 @@ class FISelectDemarcheTest(TestCase):
             organisation=self.aidant_thierry.organisation,
         )
         self.usager = UsagerFactory(given_name="Joséphine")
-
         self.connection = Connection.objects.create(
             state="avalidstate123", nonce="avalidnonce456", usager=self.usager,
         )
-
         date_further_away_minus_one_hour = datetime(
             2019, 1, 9, 8, tzinfo=pytz_timezone("Europe/Paris")
         )
@@ -260,7 +258,6 @@ class FISelectDemarcheTest(TestCase):
             expiration_date=mandat_creation_date + timedelta(days=6),
             creation_date=mandat_creation_date,
         )
-
         self.mandat_2 = MandatFactory(
             aidant=self.aidant_thierry,
             usager=self.usager,
@@ -268,7 +265,6 @@ class FISelectDemarcheTest(TestCase):
             expiration_date=mandat_creation_date + timedelta(days=6),
             creation_date=mandat_creation_date,
         )
-
         self.mandat_3 = MandatFactory(
             aidant=self.aidant_thierry,
             usager=self.usager,
@@ -483,7 +479,6 @@ class TokenTests(TestCase):
 class UserInfoTests(TestCase):
     def setUp(self):
         self.client = Client()
-
         self.usager = UsagerFactory(
             given_name="Joséphine",
             family_name="ST-PIERRE",
@@ -496,16 +491,13 @@ class UserInfoTests(TestCase):
             email="User@user.domain",
             creation_date="2019-08-05T15:49:13.972Z",
         )
-
         self.aidant_thierry = AidantFactory()
-
         self.mandat = MandatFactory(
             aidant=self.aidant_thierry,
             usager=self.usager,
             demarche="transports",
             expiration_date=timezone.now() + timedelta(days=6),
         )
-
         self.access_token = "test_access_token"
         self.access_token_hash = make_password(
             self.access_token, settings.FC_AS_FI_HASH_SALT

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -57,11 +57,9 @@ class NewMandatRecapTests(TestCase):
         device = self.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="223456")
-
         self.aidant_monique = AidantFactory(username="monique@monique.com")
         device = self.aidant_monique.staticdevice_set.create(id=2)
         device.token_set.create(token="323456")
-
         self.test_usager_sub = (
             "46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1"
         )


### PR DESCRIPTION
## 🌮 Objectif

Avoir Firefox qui se ferme correctement à la fin de nos tests (lorsqu'ils sont lancés avec `HEADLESS_FUNCTIONAL_TESTS = False`)

## 🔍 Implémentation

La source du problème venait du fichier `test_use_mandat.py`
- sûrement à cause de son `setUp()` qui appellait `super().setUpClass()` à la fin
- j'en ai profité pour cleaner et clarifier un peu le code, et enlever les `tearDownClass()` inutiles (car déjà définis dans notre `FunctionalTestCase`)

## ⚠️ Informations supplémentaires

Pour tester il faut mettre `HEADLESS_FUNCTIONAL_TESTS = False` dans son .env

