### PR TITLE
Répare l'affichage de boutons sur la page de login (et activity check)

### DIFF
--- a/aidants_connect_web/static/css/login.css
+++ b/aidants_connect_web/static/css/login.css
@@ -1,4 +1,0 @@
-button.button {
-  margin-top: 2em;
-  margin-bottom: 2em;
-}

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -160,6 +160,10 @@ a.button-outline:hover {
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 }
 
+.form__group + .form__group {
+  margin-top: var(--space-s);
+}
+
 
 /* Media */
 

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -19,7 +19,7 @@
           </li>
           {% else %}
           <li class="nav__item">
-            <a href="{% url 'login' %}">
+            <a href="{% url 'login' %}"  {% if '/accounts/login' in request.path %}class="active"{% endif %}>
               Se connecter
             </a>
           {% endif %}

--- a/aidants_connect_web/templates/login/email_sent.html
+++ b/aidants_connect_web/templates/login/email_sent.html
@@ -4,10 +4,6 @@
 
 {% block title %}Aidants Connect - Email envoyé (connexion){% endblock %}
 
-{% block extracss %}
-<link href="{% static 'css/login.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
 <div class="page">
   <div class="main-page">

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -4,10 +4,6 @@
 
 {% block title %}Aidants Connect - Connexion{% endblock %}
 
-{% block extracss %}
-<link href="{% static 'css/login.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
 <div class="page">
   <div class="main-page">
@@ -27,31 +23,35 @@
             {% if messages %}
               <div>
                 {% for message in messages %}
-                  <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</p>
+                  <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
                 {% endfor %}
               </div>
             {% endif %}
             <div class="form__group">
               <h1>Aidants Connect est actuellement en expérimentation.</h1>
               <p><strong>Ce service est pour l'instant reservé aux aidants professionnels salariés d'une des 13 structures habilitées Aidants Connect.</strong></p>
-              <p>Si vous faites partie de l'une de ces structures, vous pouvez vous connecter :</p>
+              <label for="id_email">Si vous faites partie de l'une de ces structures, vous pouvez vous connecter :</label>
               <input type="email" id="id_email" class="form-control {% if form.errors %}state-invalid{% endif %}"
                 name="email" aria-describedby="emailHelp" placeholder="Votre adresse email" required />
               {% for error in form.email.errors %}
                 <div class="notification error" role="alert">{{ error }}</div>
               {% endfor %}
             </div>
-
-            <div class="form-group">
-              <label>{{ OTP_form.otp_token.label_tag }}</label>
+            <div class="form__group">
+              <label for="id_otp_token">{{ OTP_form.otp_token.label_tag }}</label>
               {{ OTP_form.otp_token }}
               {% for error in OTP_form.otp_token.errors %}
                 <div class="notification error" role="alert">{{ error }}</div>
               {% endfor %}
             </div>
-            <button type="submit" class="button">Valider</button>
+            <div class="form__group">
+              <button type="submit" class="button">Valider</button>
+            </div>
           {% endif %}
         </form>
+
+        <br />
+        <br />
         <div class="text-center text-muted">
 
           <h2>Vous êtes sur la page de connexion Aidants Connect</h2>

--- a/aidants_connect_web/templates/registration/activity_check.html
+++ b/aidants_connect_web/templates/registration/activity_check.html
@@ -4,24 +4,22 @@
 
 {% block title %}Aidants Connect - Session expirée{% endblock %}
 
-{% block extracss %}
-  <link href="{% static 'css/login.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
 <section class="section">
   <form method="post">
-      <h1>Bonjour {{ aidant.get_full_name }}</h1>
-      <h2>Votre session a expiré</h2>
-      {% if form.errors %}
-        <div class="notification warning">Ce code n'est pas valide</div>
-      {% endif %}
-      {% csrf_token %}
-        <div class="form__group">
-          <label>{{ form.otp_token.label_tag }}</label>
-          {{ form.otp_token }}
-          <button type="submit" class="button">Valider</button>
-        </div>
+    <h1>Bonjour {{ aidant.get_full_name }}</h1>
+    <h2>Votre session a expiré</h2>
+    {% if form.errors %}
+      <div class="notification warning">Ce code n'est pas valide</div>
+    {% endif %}
+    {% csrf_token %}
+    <div class="form__group">
+      <label for="id_otp_token">{{ form.otp_token.label_tag }}</label>
+      {{ form.otp_token }}
+    </div>
+    <div class="form__group">
+      <button type="submit" class="button">Valider</button>
+    </div>
   </form>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/registration/login.html
+++ b/aidants_connect_web/templates/registration/login.html
@@ -2,10 +2,6 @@
 
 {% load static %}
 
-{% block extracss %}
-  <link href="{% static 'css/login.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
 <section class="section">
   <form method="post" action="{% url 'login' %}">


### PR DESCRIPTION
## 🌮 Objectif

Répare l'affichage des formulaires de connexion/activité qui avait été cassés

## 🔍 Implémentation

- Suppression du fichier `login.css`
- utilisation de la classe `form__group` pour les boutons dans la page de login & activity check

## 🏕 Amélioration continue

- utilisation de `<label>` et rajout du paramètre `for=` lorsqu'il était manquant
- surlignage de `Se connecter` dans le header lorsque l'utilisateur est sur la page de login

## 🖼️ Images

avant
<img width="619" alt="Capture d’écran 2020-03-24 à 11 58 02" src="https://user-images.githubusercontent.com/7147385/77899624-355d3200-727d-11ea-96a8-d69d674b589f.png">

après
<img width="604" alt="Screenshot 2020-03-24 at 19 07 37" src="https://user-images.githubusercontent.com/7147385/77461453-dcb41200-6e02-11ea-946a-8a603a4f8e1d.png">

