### PR TITLE
Simplifie le Site public d'Aidants Connect

### DIFF
--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -1,30 +1,14 @@
-.hero .row > img {
-  max-width: 40%;
-}
-
-.hero__description {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  max-width: none;
+.hero-img {
+  width: 60%;
+  margin: 1em;
+  max-height: 50em;
+  max-width: 50em;
 }
 
 @media (max-width: 749px) {
   .section {
     padding: 2em 0;
   }
-}
-
-.panel {
-  color: black;
-}
-
-.panel + .panel {
-  margin-top: 0;
-}
-
-.panel p:first-child {
-  margin-top: 0;
 }
 
 .section-color {
@@ -104,3 +88,4 @@
 #tel_solidarite_numerique a {
   text-decoration: none;
 }
+

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -36,6 +36,15 @@ a.navbar__home:hover {
   color: #fff;
 }
 
+.nav__item a {
+  padding: .5em 2em;
+}
+
+.nav__item a.button-filled  {
+  background-color: #0053b3;
+  color: white;
+}
+
 
 /* Container & main */
 

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -54,10 +54,13 @@ h1, h2, h3, h4, h5, h6 {
 
 h1.brand, h2.brand, h3.brand, h4.brand, h5.brand, h6.brand {
   font-family: "Evolventa";
-  font-weight: 700;
+  font-weight: 800;
   margin-bottom: 0;
 }
 
+.hero__container {
+  padding: 5em 2em 5em 2em;
+}
 
 /* Footer */
 

--- a/aidants_connect_web/templates/aidants_connect_web/about_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/about_page.html
@@ -1,0 +1,43 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block extracss %}
+<link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+
+<section class="section ac-service">
+  <div class="container">
+    <h1>Le service Aidants Connect</h1>
+    <div class="row">
+      <div class="tile tile-home text-center">
+        <img class="tile__icon large__icon" src="{% static 'images/key.svg' %}" alt="Icon clé" />
+        <h3>Aidants Connect sécurise juridiquement les aidants</h3>
+        <p>qui accompagnent ces usagers sur les enjeux de confidentialité et de sécurité des données</p>
+      </div>
+      <div class="tile tile-home text-center">
+        <img class="tile__icon large__icon" src="{% static 'images/help.svg' %}" alt="Icon deux personnes" />
+        <h3>Aidants Connect garantit un accompagnement humain</h3>
+        <p>pour toutes les personnes qui, pour diverses raisons, ne peuvent pas faire leurs démarches en ligne</p>
+      </div>
+      <div class="tile tile-home text-center">
+        <img class="tile__icon large__icon" src="{% static 'images/people.svg' %}" alt="Icon groupe de personnes" />
+        <h3>Aidants Connect s’adresse à une diversité d’aidants professionnels</h3>
+        <p>Travailleurs sociaux, agents publics d’accueil, médiateurs numériques...</p>
+      </div>
+      <div class="tile tile-home text-center">
+        <img class="tile__icon large__icon" src="{% static 'images/build.svg' %}" alt="Icon outil" />
+        <h3>Aidants Connect a été co-construit avec des aidants</h3>
+        <p>Des ateliers utilisateurs ont eu lieu dans une dizaine de territoires</p>
+      </div>
+      <div class="tile tile-home text-center">
+        <img class="tile__icon large__icon" src="{% static 'images/cycle.svg' %}" alt="Icon cycle" />
+        <h3>Aidants Connect est évolutif</h3>
+        <p>Le service s’adapte aux réalités du terrain et aux besoins des aidants</p>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/home_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/home_page.html
@@ -9,62 +9,16 @@
 {% block content %}
 <div class="hero">
   <div class="hero__container">
-    <div class="row">
-      <div class="hero__description text-center">
-        <h1 class="brand">Bienvenue sur Aidants Connect</h1>
-        <p class="lead-text">
-          Vous accompagnez régulièrement des personnes en difficulté avec le numérique dans la réalisation de démarches en ligne ? Aidants Connect est fait pour vous !
-        </p>
-        <p>Ce service sécurise et facilite le « faire pour le compte de ».</p>
-        <p><i>Pour mieux prendre en main l'outil, des ressources sont à votre disposition <a href="{% url 'guide_utilisation' %}">ici</a>.</i></p>
-      </div>
-      <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="Aidants Connect illustration" />
+      <h1 class="brand">Bienvenue sur Aidants Connect</h1>
+      <p>Ce service sécurise et facilite le « faire pour le compte de ».</p>
+      <div class="hero-img"><img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="Aidants Connect illustration"/></div>
     </div>
   </div>
 </div>
-<div class="notification full-width" role="alert">Vous êtes sur un site en construction, l’interface proposée sera amenée à changer grâce à vos <a href="https://github.com/betagouv/Aidants_Connect/issues/new">retours</a> !</div>
-<section class="section section-grey ac-service">
-  <div class="container">
-    <h2 class="text-center">Le service Aidants Connect</h2>
-    <div class="row">
-      <div class="tile tile-home tile-colored text-center">
-        <img class="tile__icon large__icon" src="{% static 'images/key.svg' %}" alt="Icon clé" />
-        <h3>Aidants Connect sécurise juridiquement les aidants</h3>
-        <p>qui accompagnent ces usagers sur les enjeux de confidentialité et de sécurité des données</p>
-      </div>
-      <div class="tile tile-home tile-colored text-center">
-        <img class="tile__icon large__icon" src="{% static 'images/help.svg' %}" alt="Icon deux personnes" />
-        <h3>Aidants Connect garantit un accompagnement humain</h3>
-        <p>pour toutes les personnes qui, pour diverses raisons, ne peuvent pas faire leurs démarches en ligne</p>
-      </div>
-      <div class="tile tile-home tile-colored text-center">
-        <img class="tile__icon large__icon" src="{% static 'images/people.svg' %}" alt="Icon groupe de personnes" />
-        <h3>Aidants Connect s’adresse à une diversité d’aidants professionnels</h3>
-        <p>Travailleurs sociaux, agents publics d’accueil, médiateurs numériques...</p>
-      </div>
-      <div class="tile tile-home tile-colored text-center">
-        <img class="tile__icon large__icon" src="{% static 'images/build.svg' %}" alt="Icon outil" />
-        <h3>Aidants Connect a été co-construit avec des aidants</h3>
-        <p>Des ateliers utilisateurs ont eu lieu dans une dizaine de territoires</p>
-      </div>
-      <div class="tile tile-home tile-colored text-center">
-        <img class="tile__icon large__icon" src="{% static 'images/cycle.svg' %}" alt="Icon cycle" />
-        <h3>Aidants Connect est évolutif</h3>
-        <p>Le service s’adapte aux réalités du terrain et aux besoins des aidants</p>
-      </div>
-    </div>
-  </div>
-</section>
-<section class="section">
-  <div class="container">
-    <h2>Des outils à votre disposition</h2>
-    {% include 'aidants_connect_web/resource_list.html' %}
-  </div>
-</section>
-<section class="section section-grey fc-desc">
+<section class="section section-grey">
   <div class="container container-small">
-    <h2 class="text-center">Aidants Connect est un service qui utilise <img class="logo__fc" src="{% static 'images/fc_logo_v2.png'%}" alt="Logo FranceConnect" /></h2>
-    <p class="text-center"><a href="https://franceconnect.gouv.fr/faq" target="_blank">En savoir plus sur FranceConnect</a></p>
+    <h2 class="text-center brand">Je souhaite suivre l’évolution d'Aidants Connect</h2>
+    <p class="text-center">Envoyez un mail à <a href="mailto:contact@aidantsconnect.beta.gouv.fr">contact@aidantsconnect.beta.gouv.fr</a> pour vous inscrire à notre newsletter.</p>
   </div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/ressource_page.html
+++ b/aidants_connect_web/templates/aidants_connect_web/ressource_page.html
@@ -1,0 +1,16 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block extracss %}
+<link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>Des outils à votre disposition</h1>
+    {% include 'aidants_connect_web/resource_list.html' %}
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -8,6 +8,7 @@
       <a href="https://beta.gouv.fr/">
         <img class="logo__beta" src="{% static 'images/betagouvfr.svg' %}" alt="Logo beta.gouv.fr" />
       </a>
+
       <ul class="footer__social">
         <li><a href="https://twitter.com/betagouv" title="Twitter"><svg class="icon icon-twitter"><use xlink:href="#twitter"></use></svg></a></li>
         <li><a href="https://github.com/betagouv/aidants_connect" title="Github"><svg class="icon icon-github"><use xlink:href="#github"></use></svg></a></li>

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -84,9 +84,6 @@
     {% include 'layouts/nav.html' %}
   {% endblock nav %}
 
-  {% block hero %}
-  {% endblock %}
-
   <main>
   {% block content %}
   {% endblock %}

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -7,7 +7,7 @@
     </a>
     <nav role="navigation">
       <ul class="nav__links">
-
+      {% if request.user.is_authenticated %}
         <li class="nav__item">
           {% if aidant.is_authenticated %}
             <a href="{% url 'dashboard' %}" {% if '/dashboard' in request.path or '/usagers' in request.path or '/creation_mandat' in request.path %}class="active"{% endif %}>
@@ -24,6 +24,23 @@
             </a>
           {% endif %}
         </li>
+        <li class="nav__item">
+          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources (accès libre)</a>
+        </li>
+        <li class="nav__item">
+          <a class="button-outline secondary" href="{% url 'logout' %}">Se déconnecter</a>
+        </li>
+      {% else %}
+        <li class="nav__item">
+            <a class="button-outline secondary" href="{% url 'about' %}">A propos</a>
+        </li>
+        <li class="nav__item">
+          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources (accès libre)</a>
+        </li>
+        <li class="nav__item">
+          <a class="button-outline primary button-filled" href="{% url 'login' %}" >Connexion à l'espace aidant</a>
+        </li>
+      {% endif %}
       </ul>
     </nav>
   </div>

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -66,6 +66,8 @@ urlpatterns = [
     path("stats/", service.statistiques, name="statistiques"),
     path("cgu/", service.cgu, name="cgu"),
     path("activity_check/", service.activity_check, name="activity_check"),
+    path("ressources/", service.ressources, name="ressources"),
+    path("a-propos/", service.about, name="about"),
     # footer
     path("mentions-legales/", service.mentions_legales, name="mentions_legales"),
 ]

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -10,8 +10,6 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 
-from secrets import token_urlsafe
-
 from aidants_connect_web.forms import OTPForm
 from aidants_connect_web.models import Organisation, Aidant, Usager, Mandat, Journal
 
@@ -33,12 +31,7 @@ def humanize_demarche_names(name: str) -> str:
 
 
 def home_page(request):
-    random_string = token_urlsafe(10)
-    return render(
-        request,
-        "aidants_connect_web/home_page.html",
-        {"random_string": random_string, "aidant": request.user},
-    )
+    return render(request, "aidants_connect_web/home_page.html",)
 
 
 @login_required

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -158,3 +158,11 @@ def cgu(request):
 
 def mentions_legales(request):
     return render(request, "footer/mentions_legales.html")
+
+
+def ressources(request):
+    return render(request, "aidants_connect_web/ressource_page.html")
+
+
+def about(request):
+    return render(request, "aidants_connect_web/about_page.html")


### PR DESCRIPTION
## 🌮 Objectif

Rendre le message d'Aidants Connect plus clair

## 🔍 Implémentation

Séparation de la home page en 3 pages distinctes :
- Une page d'accueil qui contient l'inscription à la newsletter
- Une page "A propos" qui présente les principes du service
- Une page Ressources

Les boutons de navigations ont été revus pour être plus facilement repérables.

## 🏕 Amélioration continue

- Suppression de quelques éléments de CSS qui étaient devenus obsolètes

## ⚠️ Informations supplémentaires

- Il faudra faire attention à la barre de navigation une fois connecté.

## 🖼️ Images
### La barre de navigation 
#### visiteur
<img width="485" alt="Capture d’écran 2020-03-27 à 11 16 24" src="https://user-images.githubusercontent.com/13916213/77750487-2af42b80-7024-11ea-9290-803a5e36694e.png">

#### Aidant connecté
<img width="445" alt="Capture d’écran 2020-03-27 à 11 17 24" src="https://user-images.githubusercontent.com/13916213/77750528-3d6e6500-7024-11ea-9959-be3389602460.png">

### Home Page

<img width="1263" alt="Capture d’écran 2020-03-20 à 17 49 11" src="https://user-images.githubusercontent.com/13916213/77466740-f9ecde80-6e0a-11ea-93c8-e521dbb357dd.png">

### nouvelles pages 
<img width="1251" alt="Capture d’écran 2020-03-24 à 19 56 25" src="https://user-images.githubusercontent.com/13916213/77466750-ff4a2900-6e0a-11ea-8f78-cf769b19c76a.png">
<img width="1254" alt="Capture d’écran 2020-03-24 à 19 56 34" src="https://user-images.githubusercontent.com/13916213/77466759-02451980-6e0b-11ea-8aee-119df92c7ebf.png">

