### PR TITLE
Ajoute le numéro de Solidarité numérique au login/ressources

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -301,6 +301,7 @@ CSP_IMG_SRC = (
     "'self'",
     "https://www.service-public.fr/resources/v-5cf79a7acf/web/css/img/png/",
     "https://societenumerique.gouv.fr/wp-content/uploads/2018/05/mockupkit-1.png",
+    "https://solidarite-numerique.fr/images/logo/phoneheart.svg",
 )
 CSP_SCRIPT_SRC = ("'self'", "'sha256-dzE1fiHF13yOIlSQf8CYbmucPoYAOHwQ70Y3OO70o+E='")
 CSP_STYLE_SRC = ("'self'",)

--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -78,3 +78,29 @@
 .fc-desc h2 {
   margin-bottom: 0;
 }
+
+#solidarite_numerique {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+#text_solidarite_numerique {
+  padding-left: 3em;
+  font-size: 3em;
+}
+
+#text_solidarite_numerique {
+  font-size: 1.2em;
+  line-height: 1.5em;
+}
+
+#tel_solidarite_numerique {
+  color: #213a64;
+  background-color: #ffc107;
+  font-weight: bold;
+  padding: 0.5em;
+  margin: 0.5em 0em;
+}
+#tel_solidarite_numerique a {
+  text-decoration: none;
+}

--- a/aidants_connect_web/templates/aidants_connect_web/resource_list.html
+++ b/aidants_connect_web/templates/aidants_connect_web/resource_list.html
@@ -18,13 +18,19 @@
   </div>
   <div class="card">
     <div class="card__cover">
-      <img src="{% static 'images/ressources/forumimage.png' %}" alt="Écran montrant le forum des aidants">
+      <img src="https://solidarite-numerique.fr/images/logo/phoneheart.svg" alt="Logo Solidarité Numérique">
     </div>
       <div class="card__content">
-        <h3 class="brand">Forum des aidants</h3>
-        <div class="card__meta"><span>Équipe Aidants Connect</span></div>
-        <p>Bientôt disponible</p>
+        <h3 class="brand">Solidarité Numérique</h3>
+        <div class="card__meta"><span>Mission Société Numérique</span></div>
+        <p>
+          Solidarité Numérique est le centre d’aide pour les démarches en ligne essentielles.
+          le service est joignable du lundi au vendredi, de 9h à 18h, par téléphone au <a href="tel:0170772372" title="Numéro de téléphone Solidarité numérique">01 70 772 372</a> (appel non surtaxé).
+        </p>
       </div>
+    <div class="card__extra">
+      <a href="https://solidarite-numerique.fr">solidarite-numerique.fr</a>
+    </div>
   </div>
 </div>
 <br>

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -2,6 +2,10 @@
 
 {% load static %}
 
+{% block extracss %}
+<link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
 {% block title %}Aidants Connect - Connexion{% endblock %}
 
 {% block content %}
@@ -49,17 +53,26 @@
             </div>
           {% endif %}
         </form>
-
         <br />
         <br />
-        <div class="text-center text-muted">
-
+      </div>
+    </section>
+    <section class="section section-grey">
+        <div class="container container-small">
           <h2>Vous êtes sur la page de connexion Aidants Connect</h2>
+          <h3>Vous cherchez de l'aide ?</h3>
+          <div id="solidarite_numerique">
+            <div id="logo_solidarite_numerique">
+              <img src="https://solidarite-numerique.fr/images/logo/phoneheart.svg" />
+            </div>
+            <div id="text_solidarite_numerique">
+              <p>Solidarité Numérique est le centre d’aide pour les démarches en ligne essentielles.</p>
+              <p>le service est joignable par téléphone, du lundi au vendredi, de 9h à 18h.</p>
+              <p><span id="tel_solidarite_numerique"><a href="tel:0170772372" title="Numéro de téléphone Solidarité numérique">01 70 772 372</a></span> (appel non surtaxé);</p>
+              <p>Vous pouvez aussi consulter <a href="https://solidarite-numerique.fr">solidarite-numerique.fr</a> où vous trouverez des explications sur de nombreuses démarches pendant le confinement.</p>
+            </div>
+          </div>
 
-          <h3>Vous cherchez à vous connecter à un service ?</h3>
-          <p>
-            <a href="https://franceconnect.gouv.fr/faq" target="_blank">La Foire Aux Questions FranceConnect</a> contient des informations pour vous aider.
-          </p>
 
           <h3>Vous êtes un aidant professionnel ?</h3>
           <p>
@@ -70,10 +83,8 @@
             Si vous souhaitez avoir des informations sur Aidants Connect,
             <a href="mailto:aidantsconnect@beta.gouv.fr?subject=[Site Aidants Connect - login] Demande d'informations">contactez-nous</a>.
           </p>
-
-         </div>
-      </div>
-    </section>
+        </div>
+     </section>
   </div>
 </div>
 {% endblock content %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -76,12 +76,8 @@
 
           <h3>Vous êtes un aidant professionnel ?</h3>
           <p>
-            Si vous êtes déjà habilité Aidants Connect, vous pouvez
-            <a href="mailto:aidantsconnect@beta.gouv.frsubject=[Site Aidants Connect - login] Demande d'aide au login">nous demander de l'aide</a>.
-          </p>
-          <p>
             Si vous souhaitez avoir des informations sur Aidants Connect,
-            <a href="mailto:aidantsconnect@beta.gouv.fr?subject=[Site Aidants Connect - login] Demande d'informations">contactez-nous</a>.
+            <a href="mailto:support.aidants@aidantsconnect.beta.gouv.fr?subject=[Site Aidants Connect - login] Demande d'informations">contactez-nous</a>.
           </p>
         </div>
      </section>


### PR DESCRIPTION
## 🌮 Objectif

Dans le cadre du confinement, de plus en plus de personnes peuvent se trouver désemparés.
Pour les accompagner, la Mission Société Numérique a lancé le service [Solidarité Numérique](https://solidarite-numerique.fr)
qui propose un site ainsi qu'un numéro de téléphone pour être accompagné sur les démarches en ligne.
L'objectif de cette PR est de communiquer aux aidants, comme aux usagers cherchant de l'aide que ce service existe et les modalités de contact.

## 🔍 Implémentation

- Remplace le lien vers la FAQ France Connect per un encart sur le service Solidarité Numérique;
- Ajoute une boite de ressource

## 🏕 Amélioration continue

- Mise à jour des adresses mail de contact

## 🖼️ Images
### Page de login
<img width="579" alt="Capture d’écran 2020-03-30 à 12 38 43" src="https://user-images.githubusercontent.com/13916213/77904823-7d805280-7285-11ea-9168-dd005200f065.png">

### Focus 
<img width="660" alt="Capture d’écran 2020-03-30 à 12 38 31" src="https://user-images.githubusercontent.com/13916213/77904837-83763380-7285-11ea-89bb-3b2776ff723c.png">

### Ressources
<img width="669" alt="Capture d’écran 2020-03-30 à 12 59 43" src="https://user-images.githubusercontent.com/13916213/77905353-668e3000-7286-11ea-83d8-753ba643228c.png">

