### PR TITLE
Répare la barre de navigation

### DIFF
--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -9,20 +9,7 @@
       <ul class="nav__links">
       {% if request.user.is_authenticated %}
         <li class="nav__item">
-          {% if aidant.is_authenticated %}
-            <a href="{% url 'dashboard' %}" {% if '/dashboard' in request.path or '/usagers' in request.path or '/creation_mandat' in request.path %}class="active"{% endif %}>
-              Espace aidant
-            </a>
-          </li>
-          <li class="nav__item">
-            <a href="{% url 'logout' %}">Se déconnecter</a>
-          </li>
-          {% else %}
-          <li class="nav__item">
-            <a href="{% url 'login' %}"  {% if '/accounts/login' in request.path %}class="active"{% endif %}>
-              Se connecter
-            </a>
-          {% endif %}
+          <a class="button-outline secondary" href="{% url 'dashboard' %}">Espace Aidant</a>
         </li>
         <li class="nav__item">
           <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources (accès libre)</a>


### PR DESCRIPTION
## 🌮 Objectif

Suite à une erreur de ma part dans le rebase de la branche de la nouvelle home page, la barre de navigation propose des éléments en double.
D'autre part, cette nouvelle barre de navigation ne propose plus un accès directe à l'"espace aidants" ce qui est embêtant pour la navigation en mode connecté.

## 🔍 Implémentation

- Dédoublonner la barre de navigation
- Ajouter un bouton vers l'espace aidant en mode connecté

## 🖼️ Images
Avant : 
<img width="1271" alt="Capture d’écran 2020-04-10 à 10 50 23" src="https://user-images.githubusercontent.com/13916213/78977933-42014600-7b19-11ea-97a5-4369543a07cc.png">

Apres : 
<img width="1272" alt="Capture d’écran 2020-04-10 à 10 38 52" src="https://user-images.githubusercontent.com/13916213/78977271-25184300-7b18-11ea-97e6-6811b21d83b1.png">
