### PR TITLE
Améliore la visualisation de nos indicateurs d'impact

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -356,3 +356,6 @@ CELERY_ACCEPT_CONTENT = [JSON_CONTENT_TYPE]
 ETAT_URGENCE_2020_LAST_DAY = datetime.strptime(
     os.getenv("ETAT_URGENCE_2020_LAST_DAY"), "%d/%m/%Y %H:%M:%S %z"
 )
+
+# Staff Organisation name
+STAFF_ORGANISATION_NAME = "BetaGouv"

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -448,6 +448,11 @@ class JournalManager(models.Manager):
         return journal_entry
 
 
+class JournalQuerySet(models.QuerySet):
+    def not_staff(self):
+        return self.exclude(initiator__icontains=settings.STAFF_ORGANISATION_NAME)
+
+
 class Journal(models.Model):
     ACTIONS = (
         ("connect_aidant", "Connexion d'un aidant"),
@@ -476,6 +481,7 @@ class Journal(models.Model):
     is_remote_mandat = models.BooleanField(default=False)
 
     objects = JournalManager()
+    stats_objects = JournalQuerySet.as_manager()
 
     class Meta:
         verbose_name = "entrée de journal"
@@ -492,3 +498,10 @@ class Journal(models.Model):
 
     def delete(self, *args, **kwargs):
         raise NotImplementedError("Deleting is not allowed on journal entries")
+
+    @property
+    def usager_id(self):
+        try:
+            return int(self.usager.split(" - ")[1])
+        except (IndexError, ValueError):
+            return None

--- a/aidants_connect_web/templates/footer/statistiques.html
+++ b/aidants_connect_web/templates/footer/statistiques.html
@@ -15,33 +15,88 @@
     <h1 class="brand">Statistiques d'Aidants Connect</h1>
     <div class="tiles">
       <!-- Statistiques List -->
-      {% for stat_group in statistiques_list %}
-        <h2>{{ stat_group.name }}</h2>
+    <h2>Déploiement</h2>
         <div class="grid">
-          {% for stat_item in stat_group.values %}
           <div class="tile-box">
             <div class="tile text-center">
+              <h3>Structures</h3>
               <h3>
-                {{ stat_item.title }}{% if stat_item.subtitle %}*{% endif %}
-              </h3>
-              <h3>
-                <strong>{{ stat_item.value }}</strong>
+                <strong>{{ organisations_count }}</strong>
               </h3>
             </div>
+          </div>
+          <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Aidants</h3>
+              <h3>
+                <strong>{{ aidants_count }}</strong>
+              </h3>
+            </div>
+          </div>
+       </div>
+    <h2>Mandats</h2>
+        <div class="grid">
+          <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Mandats créés</h3>
+              <h3><strong>
+                {{ mandats_count }}
+                </strong></h3>
+            </div>
             <p class="tile-subtitle">
-              {% if stat_item.subtitle %}
-                *{{ stat_item.subtitle }}
-              {% endif %}
-              &nbsp;
+              depuis le 18/03/2020
             </p>
           </div>
-          {% endfor %}
+          <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Mandats actifs</h3>
+              <h3><strong>{{ mandats_active_count }}</strong></h3>
+            </div>
+          </div>
         </div>
-      {% endfor %}
-      <!-- Statistiques démarches -->
-      <h2>Démarches</h2>
-      <div class="grid small-grid">
-        {% for stat_item in statistiques_demarches %}
+    <h2>Usagers</h2>
+        <div class="grid">
+          <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Usagers</h3>
+              <h3><strong>{{ usagers_with_mandat_count }}</strong></h3>
+            </div>
+          </div>
+          <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Usagers actif</h3>
+              <h3><strong>{{ usagers_with_mandat_active_count }}</strong></h3>
+            </div>
+          </div>
+        </div>
+    <h2>Démarches France Connect accompagnées</h2>
+      <div class="grid grid">
+        <div class="tile-box">
+            <div class="tile text-center">
+              <h3>Depuis le lancement</h3>
+              <h3><strong>
+                  Usagers accompagnés : {{ usagers_helped_count }}
+                  <br>
+                  Connexions effectuées : {{ authorisation_use_count }}
+                  <br>
+              </strong></h3>
+            </div>
+          </div>
+        <div class="tile-box">
+            <div class="tile text-center">
+              <h3>30 derniers jours</h3>
+              <h3><strong>
+                  Usagers accompagnés : {{ usagers_helped_recent_count }}
+                  <br>
+                  Connexions effectuées : {{ authorisation_use_recent_count }}
+                  <br>
+              </strong></h3>
+            </div>
+          </div>
+      </div>
+      <h4>Par type de démarche</h4>
+    <div class="grid small-grid">
+        {% for stat_item in demarches_count %}
           <div class="tile-box">
             <div class="tile text-center">
               <h3>

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
-
+from datetime import timedelta
 from django.contrib.auth import get_user_model
+from django.utils.timezone import now
 
 from aidants_connect_web.models import (
     Connection,
@@ -50,6 +51,10 @@ class MandatFactory(factory.DjangoModelFactory):
     aidant = factory.SubFactory(AidantFactory)
     usager = factory.SubFactory(UsagerFactory)
     demarche = "justice"
+    expiration_date = factory.LazyAttribute(lambda f: now() + timedelta(days=7))
+    last_mandat_renewal_date = factory.LazyAttribute(
+        lambda f: now() - timedelta(days=1)
+    )
 
     class Meta:
         model = Mandat


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir en un coup d'oeil comprendre l'impact qu'à Aidants Connect sur les Aidants et sur les usagers.

## 🔍 Implémentation

- Création de tests avec une une situation complexe dans le setup (3 aidants, plein d'usagers avec des mandats...) suivis de tests simples qui cherchent que ce sont les bonnes stats qui remontent.
- Ajout d'une propriété `usager_id` dans le journal qui permet de récupérer facilement le pk d'un usager partir d'une entrée de journal.
- Ajout dans la view de beaucoup de préparation de données pour les rendre lisible dans la page stat.
- Transfert de la logique de display dans le template.

Voici les données qui seront maintenant disponibles : 
* "organisations": organisations qui ne sont pas `betagouv`,
* "aidants": aidants, dans la base, qui ne sont pas associé à `betagouv`,
* "mandats_total": mandats (papiers) signé,
* "mandats_active": mandats (papiers) qui n'ont pas expiré ou qui ne sont pas révoqués,
* "usagers_with_mandat_total": usager qui ont signé au moins un mandat,
* "usagers_with_mandat_active": usagers qui ont au moins un mandat actif,
*  "authorisation_use": nombre de fois où il y a eu des connexion FC avec Aidants Connect _en tant que fi_ ,
* "authorisation_use_recent": nombre de fois où il y a eu des connexion FC avec Aidants Connect _en tant que fi_ ces 30 derniers jours,
* "usagers_helped": Nombre d'usagers qui ont été franceconnecté via AidantConnect,
* "usagers_helped_recent": Nombre d'usagers qui ont été franceconnecté via AidantConnect ces 30 derniers jours,
* "statistiques_demarches": Périmètre des franceconnexions, classé en nombre décroissant

## ⚠️ Informations supplémentaires
Les caveats que je vois : 
* Les aidants recensés ne check pas si l'aidant est actif
* Le comptage de mandat dépend de l'action mandat_print du journal qui a été mis en prod après le lancement. Il se pourrait qu'on ne compte pas tous les mandats.
* Les filtres dépendent de l'orthographe exact de `BetaGouv`, ça peut être flaky

## 🖼️ Images

Image venant de localhost (avec peu de données)
<img width="643" alt="Capture d’écran 2020-04-28 à 18 08 13" src="https://user-images.githubusercontent.com/13916213/80510752-71b6a780-897b-11ea-813b-fbf896dd1e55.png">
