### PR TITLE
Améliore la lisibilité de la page de statistiques

### DIFF
--- a/aidants_connect_web/static/css/dashboard.css
+++ b/aidants_connect_web/static/css/dashboard.css
@@ -21,6 +21,11 @@ a:hover {
 .tile-box {
   width: 100%;
 }
+
+#statistics h3 {
+  font-size: 1.2em;
+}
+
 .tile-subtitle {
   margin: 0;
   font-style: italic;


### PR DESCRIPTION
## 🌮 Objectif

Améliorer la lisibilité de la page de statistiques

## 🔍 Implémentation

- réduction de la taille des h3 de la page de statistiques
## 🖼️ Images

Avant : 
<img width="722" alt="Capture d’écran 2020-05-06 à 17 36 23" src="https://user-images.githubusercontent.com/13916213/81197290-62a9a800-8fc0-11ea-9d40-1bbbef480b90.png">
Apres : 
<img width="755" alt="Capture d’écran 2020-05-06 à 17 36 35" src="https://user-images.githubusercontent.com/13916213/81197221-5291c880-8fc0-11ea-915b-1401c1b02013.png">





