### PR TITLE
Ajoute des réponses autour des mandats et données personnelles à la FAQ

### DIFF
--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -88,4 +88,7 @@
 #tel_solidarite_numerique a {
   text-decoration: none;
 }
+#faq-content{
+  border-top: 1px solid #c9d3df;
+}
 

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -12,7 +12,7 @@
           <a class="button-outline secondary" href="{% url 'dashboard' %}">Espace Aidant</a>
         </li>
         <li class="nav__item">
-          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources (accès libre)</a>
+          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources</a>
         </li>
         <li class="nav__item">
           <a class="button-outline secondary" href="{% url 'logout' %}">Se déconnecter</a>
@@ -22,10 +22,13 @@
             <a class="button-outline secondary" href="{% url 'about' %}">A propos</a>
         </li>
         <li class="nav__item">
-          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources (accès libre)</a>
+          <a class="button-outline secondary" href="{% url 'ressources' %}">Ressources</a>
         </li>
         <li class="nav__item">
-          <a class="button-outline primary button-filled" href="{% url 'login' %}" >Connexion à l'espace aidant</a>
+          <a class="button-outline secondary" href="{% url 'faq_generale' %}">FAQ</a>
+        </li>
+        <li class="nav__item">
+          <a class="button-outline primary button-filled" href="{% url 'login' %}" >Se connecter</a>
         </li>
       {% endif %}
       </ul>

--- a/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
+++ b/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
@@ -1,0 +1,109 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - FAQ{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section section-white">
+  <div class="container container-small">
+    <h1 class="section__title">Foire aux questions</h1>
+    <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
+  </div>
+  <div class="dashboard" id="faq-content">
+    <aside class="side-menu" role="navigation">
+      <ul>
+        <li><a href={% url "faq_generale" %}>Le service Aidants Connect</a></li>
+        <li><a href={% url "faq_mandat" %}>Le mandat</a></li>
+        <li><a class="active" href={% url "faq_donnees_personnelles" %}>Les données personnelles</a></li>
+      </ul>
+    </aside>
+    <div class="main">
+      <div class="panel">
+        <h2 id="questions-RGPD">Questions sur la protection des données personnelles</h2>
+        <h3 id="utilisation-session-aidant">
+          Qui est responsable si une autre personne que l’aidant·e réalise des démarches sur l’ordinateur de l’aidant·e alors que celui-ci n’est pas sécurisé ?
+        </h3>
+        <p>
+          La responsabilité des structures et des aidant·es pourra être recherchée. Il appartient aux aidant·es et aux structures habilitées de sécuriser les postes informatiques et les outils utilisés dans le cadre des mandats (par des dispositifs techniques et/ou par des mesures organisationnelles). Il est fortement conseillé d’utiliser les outils de travail adaptés au fait que l’aidant·e va recevoir ou visualiser des informations personnelles sur l’usager.
+        </p>
+        <p>
+          Les aidant·es doivent se prémunir des risques liés à l’utilisation frauduleuse de leur matériel informatique. Il s’agit donc d’avoir un ordinateur en mesure d’être protégé par un mot de passe, un gestionnaire de mots de passe, un antivirus, un verrouillage automatique, etc… (voir les recommandations de la CNIL
+          <a href="https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers" target="_blank" rel="noopener">
+            https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers
+          </a>
+          )
+        </p>
+        <p>
+        Les aidant·es et les structures habilitées doivent signaler tout vol ou perte de moyens d’identification au service Aidants Connect (téléphone portable, ordinateur, autres…).
+        </p>
+        <p>
+
+        Aidants Connect supprimera rapidement le compte de l’aidant·e pour éviter que celui-ci ne soit frauduleusement utilisé par d’autres personnes.
+        </p>
+
+        <h3 id="documents-récupérés-par-un-tiers-">
+          Quelle est la responsabilité de l’aidant·e si des documents, contenant des données personnelles, conservés par la structure, sont récupérés par un tiers ?
+        </h3>
+        <p>
+          La responsabilité de l’aidant·e pourrait être engagée si l’aidant·e a scanné un document contenant des données personnelles d’un·e usager·ère et que ce fichier est volé ou détruit. Il appartient à l’aidant·e de respecter les procédures internes de sa structure, qui auront été établies avec son ou sa Délégué·e à la protection des données.
+        </p>
+        <p>
+        Dès lors, si des données personnelles ont été volées, détruites ou perdues, il faut respecter les procédures internes de votre structure pour toute perte ou vol de données personnelles.
+        </p>
+        <p>
+        S’il s’agit de vos identifiants et/ou téléphone portable, vous devez informer Aidants Connect afin que nous puissions procéder à la suppression de votre compte.
+        </p>
+        <h3 id="conservation-des-données">
+          Conservation des données et des documents officiels : quelle est la réglementation en vigueur ? Et le RGPD ?
+        </h3>
+        <p>
+          La réglementation en vigueur est le règlement général sur la protection des données du 27 avril 2016 et à la loi n°78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés (dite «&nbsp;loi informatique et libertés&nbsp;»).
+        </p>
+        <p>
+        Sur Aidants Connect, la collecte et le traitement des données à caractère personnel, effectués à partir du site, sont conformes au règlement général sur la protection des données du 27 avril 2016 et à la loi informatique et libertés.&nbsp;Les informations concernant ces traitements sont disponibles sur
+          <a href="https://aidantsconnect.beta.gouv.fr/cgu/" target="_blank" rel="noopener">
+            https://aidantsconnect.beta.gouv.fr/cgu/
+          </a>
+        </p>
+        <h3 id="garder-les-codes">
+          Quels risques prenons-nous&nbsp;en gardant les codes ? En consultant une messagerie à la place de ? Si l’aidant·e doit consulter les mails pour le compte de l’usager, quelle est la limite de confidentialité&nbsp;?
+        </h3>
+        <p>
+          Cela revient à la question de la conservation et la visualisation des données personnelles.
+        </p>
+        <p>
+        À ce sujet, la CNIL donne le conseil suivant aux aidant·es professionnel·les :
+        </p>
+        <blockquote>
+          <p>
+            «&nbsp;Pour chacun·e des usager·ères que vous accompagnez, utilisez bien un compte de messagerie dédié aux
+            démarches administratives. Si l’usager·ère n’a pas d’adresse électronique, proposez-lui de lui en créer une
+            mais toujours dans le cadre de votre mandat. En fonction des besoins liés à son suivi, il est possible de
+            rediriger tout ou partie des courriers électroniques de l’usager·ère vers votre compte de messagerie
+            professionnelle. Dans ce cas, précisez-le explicitement dans le mandat et n’oubliez pas de supprimer ces
+            courriers électroniques (e-mails) dès la fin de l’accompagnement social.&nbsp;»
+          </p>
+          <p>
+          Source :
+              <a href="https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers" target="_blank" rel="noopener">
+                https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers
+              </a>
+              .
+            </p>
+        </blockquote>
+        <h3 id="valeur-juridique-mandat">
+          Quelle est la valeur juridique d’une décharge / d’un mandat signé par la personne et autorisant l’aidant·e à faire la démarche ?
+        </h3>
+        <p>
+          Qu’il soit donné à l’oral ou à l’écrit, un mandat est un contrat entre des personnes et/ou des structures. On peut donner mandat pour faire en son nom l’intégralité des démarches qui nous incombent et cela pour la durée que l’on souhaite.
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/public_website/faq/generale.html
+++ b/aidants_connect_web/templates/public_website/faq/generale.html
@@ -13,27 +13,36 @@
   <div class="container container-small">
     <h1 class="section__title">Foire aux questions</h1>
     <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
-    <div class="panel">
-      <h3 id="Aidants-Connect-qu’est-ce-que-c’est">Aidants Connect qu’est-ce que c’est?</h3>
-      <p>Aidants Connect permet à des aidant·es professionnel·les de réaliser des démarches administratives à la place d’un·e usager·ère et ce, <strong>de façon sécurisée.</strong></p>
-      <p>Toutes les informations sur le fonctionnement du service sont documentées dans <a href="../aidants_connect_web/guide_utilisation.html">notre guide d'utilisation</a></p>
-      <h3 id="contacter-l’équipe">Comment contacter l’équipe Aidants Connect ?</h3>
-      <p>
-        Vous pouvez nous envoyer un mail à l'adresse :
-        <a href="mailto:contact@aidantsconnect.beta.gouv.fr?subject=[Site Aidants Connect - FAQ] Demande d'informations" target="_blank" rel="noopener">
-          contact@aidantsconnect.beta.gouv.fr
-        </a>
-      </p>
-
-      <h3 id="A-qui-s’adresse-AC-">A qui s’adresse Aidants Connect ?</h3>
-      <p>
-        Aidants Connect s’adresse à des structures qui emploient des aidant·es professionnel·les qui accompagnent régulièrement
-        des usager·ères dans la réalisation de leurs démarches en ligne.
-        Il peut s’agir de travailleur·euses sociaux·ales, agents publics d’accueil, médiateur·ices numériques, etc.
-        Le service est aujourd’hui expérimenté par un nombre limité de structures.
-      </p>
-
-      <h3 id="aidant·es-habilités">Qui sont les aidant·es habilités à utiliser Aidants Connect ?</h3>
+  </div>
+  <div class="dashboard" id="faq-content">
+    <aside class="side-menu" role="navigation">
+      <ul>
+        <li><a class="active" href={% url "faq_generale" %}>Le service Aidants Connect</a></li>
+        <li><a href={% url "faq_mandat" %}>Le mandat</a></li>
+        <li><a href={% url "faq_donnees_personnelles" %}>Les données personnelles</a></li>
+      </ul>
+    </aside>
+    <div class="main">
+      <div class="panel">
+        <h2 id="questions-generales">Questions générales</h2>
+        <h3 id="Aidants-Connect-qu’est-ce-que-c’est">Aidants Connect qu’est-ce que c’est?</h3>
+        <p>Aidants Connect permet à des aidant·es professionnel·les de réaliser des démarches administratives à la place d’un·e usager·ère et ce, <strong>de façon sécurisée.</strong></p>
+        <p>Toutes les informations sur le fonctionnement du service sont documentées dans <a href="../../aidants_connect_web/guide_utilisation.html">notre guide d'utilisation</a></p>
+        <h3 id="contacter-l’équipe">Comment contacter l’équipe Aidants Connect ?</h3>
+        <p>
+          Vous pouvez nous envoyer un mail à l'adresse :
+          <a href="mailto:contact@aidantsconnect.beta.gouv.fr?subject=[Site Aidants Connect - FAQ] Demande d'informations" target="_blank" rel="noopener">
+            contact@aidantsconnect.beta.gouv.fr
+          </a>
+        </p>
+          <h3 id="A-qui-s’adresse-AC">A qui s’adresse Aidants Connect ?</h3>
+        <p>
+          Aidants Connect s’adresse à des structures qui emploient des aidant·es professionnel·les qui accompagnent régulièrement
+          des usager·ères dans la réalisation de leurs démarches en ligne.
+          Il peut s’agir de travailleur·euses sociaux·ales, agents publics d’accueil, médiateur·ices numériques, etc.
+          Le service est aujourd’hui expérimenté par un nombre limité de structures.
+        </p>
+        <h3 id="aidant·es-habilités">Qui sont les aidant·es habilité·es à utiliser Aidants Connect ?</h3>
       <p>
         Les aidant·es habilité·es sont des aidant·es salarié·es d’une structure habilitée Aidants Connect.
         Ils et elles accompagnent des usager·ères dans la réalisation de leurs démarches administratives en ligne.</p>
@@ -111,7 +120,7 @@
 
       <h3 id="plusieurs-langues">Le mandat Aidants Connect existe-t-il dans plusieurs langues ?</h3>
       <p>À ce jour, le mandat existe en français uniquement.</p>
-
+    </div>
     </div>
   </div>
 </section>

--- a/aidants_connect_web/templates/public_website/faq/mandat.html
+++ b/aidants_connect_web/templates/public_website/faq/mandat.html
@@ -1,0 +1,202 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - FAQ{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section section-white">
+  <div class="container container-small">
+    <h1 class="section__title">Foire aux questions</h1>
+    <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
+  </div>
+  <div class="dashboard" id="faq-content">
+    <aside class="side-menu" role="navigation">
+      <ul>
+        <li><a href={% url "faq_generale" %}>Le service Aidants Connect</a></li>
+        <li><a class="active" href={% url "faq_mandat" %}>Le mandat</a></li>
+        <li><a href={% url "faq_donnees_personnelles" %}>Les données personnelles</a></li>
+      </ul>
+    </aside>
+    <div class="main">
+      <div class="panel">
+        <h2 id="questions-mandat">Questions sur le mandat</h2>
+        <h3 id="qualification-aidant">
+          Qu’est ce qui va rendre l’aidant·e qualifié·e pour faire une démarche « à la place de » ? Faut-il une qualification
+          spécifique ?
+        </h3>
+        <h4 id="Qui-est-qualifié-à-être-aidant-">
+          Qui est qualifié·e à être aidant·e ?
+        </h4>
+        <p>Toute personne peut accepter un mandat et faire des démarches administratives à la place d’un·e usager·ère. Il n’y a donc
+          pas de formation ou qualification spécifique à recevoir.</p>
+        <h4 id="Qui-est-qualifié-pour-AC">
+          Qui est qualifié·e pour utiliser Aidants Connect ?
+        </h4>
+        <p>
+          Le service Aidants&nbsp;Connect est pour le moment réservé à des «&nbsp;aidant·es professionnel·les&nbsp;» c’est-à-dire des
+          personnes ayant un statut professionnel (Fonctionnaire, CDD ou CDI) tel que travailleur·ses sociaux·ales, agents publics
+          d’accueil ou médiateur·ices numériques salarié·es d’une structure de droit privé.
+        </p>
+        <p>
+        De plus, pendant la période d’expérimentation, Aidants Connect n’est ouvert qu’à un nombre limité de structures.
+        </p>
+        <h3 id="Qui-peut-bénéficier">
+          Quelles sont les personnes qui peuvent bénéficier d’Aidants Connect&nbsp;?
+        </h3>
+        <p>Pour bénéficier d’un accompagnement via Aidants Connect, l’usager·ère doit :</p>
+        <ul>
+          <li>être en capacité de conclure un mandat (pas de tutelle ou de curatelle) ;</li>
+          <li>souhaiter être accompagné·e dans la réalisation de ses démarches administratives en ligne ;</li>
+          <li>être en contact avec une structure habilitée Aidants Connect.</li>
+        </ul>
+
+        <h3>
+          Est-ce que les personnes qui ont déjà été aidées peuvent être aidées par plusieurs aidant·es (suivi des parcours) ?
+        </h3>
+        <h4 id="1-Plusieurs-aidants-dans-la-même-structure">
+        1. Plusieurs aidant·es dans la même structure
+        </h4>
+        <p>
+          Dans le cadre d’Aidants Connect, tou·tes les aidant·es habilité·es au sein d’une même structure ont accès aux mandats de
+          cette structure. Cela veut dire qu’un·e usager·ère peut être accompagné·e par tou·tes les aidant·es d’une même structure.
+        </p>
+        <p>Cependant, ce mandat ne sera pas visible par les aidant·es habilité·es travaillant dans une autre structure.</p>
+        <p>Enfin, il est important de noter qu’aucune information concernant les démarches effectuées ou l’état de ces démarches
+          n’est accessible sur Aidants Connect.
+        </p>
+        <h4 id="2-Avoir-des-mandats-dans-des-structures-différentes">
+          2. Avoir des mandats dans des structures différentes.
+        </h4>
+        <p>Un·e usager·ère peut avoir des mandats dans différentes structures tant qu’ils ne couvrent pas les mêmes démarches.</p>
+        <h5 id="21-Si-les-mandats-concernent-les-mêmes-périmètres">
+          2.1. Si les mandats concernent les mêmes périmètres</h5>
+        <p>
+          Tant que le mandat n’est pas donné sur les mêmes démarches, un·e usager·ère peut avoir des mandats sur le même périmètre
+          avec des structures différentes.
+        </p>
+        <blockquote>
+          <p>
+            Ex : un usager peut donner mandat à deux structures sur le périmètre “Transport”, si dans l’une, il demande à
+            l’aidant·e de vérifier son nombre de point de permis et dans l’autre, l’aider à immatriculer son véhicule.
+          </p>
+        </blockquote>
+        <h5 id="22-Si-les-mandats-concernent-la-même-démarche">
+          2.2. Si les mandats concernent la même démarche
+        </h5>
+        <p>
+          Cependant, un·e usager·ère ne peut pas avoir un mandat sur la même démarche avec des structures différentes.
+          Il est de la responsabilité de l’usager·ère de révoquer le premier mandat s’il ou elle souhaite transférer l’autorisation de faire
+          en son nom à la nouvelle structure.
+        </p>
+        <p>
+          Il est recommandé à l’aidant·e, lors de l’échange avec l’usager·ère, de lui demander s’il ou elle a déjà donné mandat à une autre
+          personne ou structure pour accomplir les mêmes démarches en son nom.</p>
+        <h3 id="Quelles-précautions-prendre-quand-on-accomplit-des-démarches-au-nom-d’un-usager-">
+          Quelles précautions prendre quand on accomplit des démarches au nom d’un·e usager·ère ?
+        </h3>
+        <p>
+          Les mandats pour accomplir des démarches pour le compte d’un·e usager·ère peuvent être donnés oralement ou par écrit.
+          Ils sont avant tout fondés sur une relation de confiance entre l’usager·ère et la personne à qui il ou elle donne mandat.</p>
+        <p>
+          Pour se prémunir de toutes difficultés qui pourraient survenir quant aux démarches à effectuer pour l’usager·ère
+          (c’est-à-dire la mission qui est confiée par l’usager·ère à l’aidant·e), il est préférable de garder une trace écrite
+          de la demande.
+        </p>
+        <p>
+          Le mandat Aidants Connect sécurise donc les aidant·es dans les démarches qu’ils ou elles accomplissent au nom de l’usager.
+        </p>
+        <p>
+          En pratique, le mandat est conclu entre une structure labellisée «&nbsp;Aidants Connect&nbsp;» et l’usager·ère.
+          Ce mandat précise le champ d’action et la durée pendant laquelle les aidant·es de la structure peuvent agir au nom
+          de l’usager·ère.
+        </p>
+        <p>
+          Lors de l’entretien avec l’usager·ère, l’aidant·e doit aborder les points suivants afin de valider le consentement de
+          l’usager·ère (comme le recommande la CNIL :
+          <a href="https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers" target="_blank" rel="noopener">
+            https://www.cnil.fr/fr/professionnels-du-secteur-social-comment-mieux-proteger-les-donnees-de-vos-usagers
+          </a>
+          )&nbsp;:
+        </p>
+        <ul>
+          <li>vérifier l’objet et le périmètre de l’intervention ;</li>
+          <li>vérifier qu’il ou elle a bien la capacité à agir (qu’il ou elle n'est pas sous tutelle ou curatelle par exemple)&nbsp;;</li>
+          <li>expliquer la ou les raisons pour lesquelles les informations le ou la concernant sont collectées et leurs utilités ;</li>
+          <li>lister et lui rappeler ses droits sur ses données (accès, rectification, suppression, etc.) ;</li>
+          <li>rappeler la possibilité pour l’usager·ère de retirer à tout moment son mandat ou son consentement à utiliser ses données.</li>
+        </ul>
+        <p>Lorsque l’aidant·e exécute ses mandats, il ou elle doit en outre prendre les précautions suivantes afin de protéger les informations des usagers&nbsp;:</p>
+          <ul>
+            <li>se déconnecter du compte de l’usager·ère lorsque la démarche est terminée ;</li>
+            <li>toujours verrouiller sa session sur son ordinateur lorsque il s’en s’éloigne ;</li>
+            <li>sécuriser son smartphone en le verrouillant par un schéma ou un code PIN par exemple.</li>
+          </ul>
+        <h3 id="Qui-est-responsable-en-cas-d’erreur">
+          Qui est responsable des déclarations en cas d’erreur ou d'omission ? Ex : déclaration d’impôts
+        </h3>
+        <p>
+          L’aidant·e doit exécuter la mission qui lui a été confiée en respectant scrupuleusement les instructions reçues.
+          Il ou elle est notamment tenu·e à une obligation de diligence, de prudence et de loyauté envers l’usager. Sa responsabilité
+          peut être engagée, sauf force majeure, soit lorsqu’il ou elle n’a pas accompli sa mission, soit lorsqu’il ou elle a commis une faute
+          dans l’exercice de sa mission, faute qui doit être prouvée par l’usager. Toutefois, s’il ou elle a agi de bonne foi,
+          sa responsabilité ne pourra être recherchée.
+        </p>
+        <p>
+          L’aidant·e doit informer l’usager·ère de ses actions (démarches effectuées, données transmises, etc.).
+          La loi lui en fait obligation.</p>
+        <p>
+          Pour sa part, l’usager·ère est obligé·e de fournir des informations justes, fiables et pertinentes.
+          Il ou elle doit exécuter tous les engagements contractés par l’aidant·e dans le cadre du mandat.
+          Si aucune faute n’est imputable à l’aidant·e, l’usager·ère ne peut se dispenser de faire les remboursements ou paiements
+          ni faire réduire le montant des frais et avances sous le prétexte qu’ils pouvaient être moindres.
+        </p>
+        <h3 id="droit-à-l’erreur">
+          Qu’en est-il du droit à l’erreur&nbsp;?
+        </h3>
+        <p>
+          Dans le cas où une information transmise par l’usager·ère est erronée, ou dans le cas d’une omission,
+          l’usager·ère pourra faire valoir son droit à l’erreur dans le cadre de la loi &nbsp;(
+          <a href="https://www.service-public.fr/particuliers/vosdroits/F34677" target="_blank" rel="noopener">
+            https://www.service-public.fr/particuliers/vosdroits/F34677
+          </a>
+          ).
+        </p>
+        <p>
+        Par exemple, voici une ressource pour l’exercice du droit à l’erreur en matière fiscale (
+          <a href="https://bofip.impots.gouv.fr/bofip/11919-PGP.html" target="_blank" rel="noopener">
+            https://bofip.impots.gouv.fr/bofip/11919-PGP.html
+          </a>
+          )
+        </p>
+
+        <h3 id="responsable-en-cas-de-problème">
+          Qui est responsable en cas de problème ? La structure ou l’aidant·e ?
+        </h3>
+        <p>
+          En cas de problème, Aidants Connect dispose des informations nominales pour déterminer quel·le aidant·e a effectué des
+          actions de création ou d’utilisation de mandats sur Aidants Connect.
+        </p>
+        <p>
+          Ces informations pourront être mises à disposition sous réserve de validation par le service juridique de la DINUM
+          quant au bien-fondé de la requête.
+        </p>
+        <h3 id="Comment-l’usager-signe-t-il-le-mandat-">
+          Comment l’usager·ère signe-t-il ou signe-t-elle le mandat ?
+        </h3>
+        <p>L’usager·ère signe le mandat en trois étapes:</p>
+        <ul>
+          <li>il ou elle s’identifie. En utilisant FranceConnect pour se connecter, cela équivaut, pour l’usager·ère, à montrer une pièce d’identité. L’identité de l’usager·ère est donc garantie.</li>
+          <li>il ou elle donne son consentement. En cochant une case prévue à cet effet lors de la création du mandat, il ou elle consent au mandat. Cette action enregistrée par Aidants Connect est matérialisée dans le mandat en PDF.</li>
+          <li>Après chaque validation, Aidant Connect crée une empreinte numérique unique (appelée «&nbsp;Hash&nbsp;») qui permet de garantir l’intégrité du mandat, c’est-à-dire le fait que le document n’a subi aucune modification (volontaire ou involontaire).</li>
+        </ul>
+
+      </div>
+    </div>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -330,8 +330,8 @@ class GuideUtilisationTests(TestCase):
 class FAQTests(TestCase):
     def test_faq_url_triggers_the_correct_view(self):
         found = resolve("/faq/")
-        self.assertEqual(found.func, service.faq)
+        self.assertEqual(found.func, service.faq_generale)
 
     def test_faq_url_triggers_the_correct_template(self):
         response = self.client.get("/faq/")
-        self.assertTemplateUsed(response, "footer/faq.html")
+        self.assertTemplateUsed(response, "public_website/faq/generale.html")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -66,10 +66,17 @@ urlpatterns = [
     path("guide_utilisation/", service.guide_utilisation, name="guide_utilisation"),
     path("ressources/", service.ressources, name="ressources"),
     path("a-propos/", service.about, name="about"),
+    # FAQ
+    path("faq/", service.faq_generale, name="faq_generale"),
+    path("faq/mandat/", service.faq_mandat, name="faq_mandat"),
+    path(
+        "faq/donnees-personnelles/",
+        service.faq_donnees_personnelles,
+        name="faq_donnees_personnelles",
+    ),
     # footer
     path("stats/", service.statistiques, name="statistiques"),
     path("cgu/", service.cgu, name="cgu"),
-    path("faq/", service.faq, name="faq"),
     path("mentions-legales/", service.mentions_legales, name="mentions_legales"),
 ]
 

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -181,5 +181,13 @@ def about(request):
     return render(request, "aidants_connect_web/about_page.html")
 
 
-def faq(request):
-    return render(request, "footer/faq.html")
+def faq_generale(request):
+    return render(request, "public_website/faq/generale.html")
+
+
+def faq_mandat(request):
+    return render(request, "public_website/faq/mandat.html")
+
+
+def faq_donnees_personnelles(request):
+    return render(request, "public_website/faq/donnees_personnelles.html")


### PR DESCRIPTION
## 🌮 Objectif

Informer les aidants autour des problématiques qui les intéressent (ici le mandat et les données personnelles) dans un langage accessible.

## 🔍 Implémentation

- On ajoute deux nouvelles pages de FAQ : mandat et données personnelles
- La barre de navigation contient maintenant la FAQ
- Une barre de navigation secondaire apparaît dans la FAQ

## 🏕 Amélioration continue

- Création d'un répertoire "public_website" pour les template du site public

## 🖼️ Images

<img width="1257" alt="Capture d’écran 2020-05-18 à 18 10 30" src="https://user-images.githubusercontent.com/13916213/82235754-709de800-9933-11ea-92d1-cbf50196b8c1.png">
