### PR TITLE
Etape F-3 : Adapte les vues/modèle à la vue de statistiques

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -242,6 +242,15 @@ def get_staff_organisation_name_id() -> int:
         return 1
 
 
+class MandatQuerySet(models.QuerySet):
+    def active(self):
+        return (
+            self.exclude(expiration_date__lt=timezone.now())
+            .filter(autorisations__revocation_date__isnull=True)
+            .distinct()
+        )
+
+
 class Mandat(models.Model):
     organisation = models.ForeignKey(
         Organisation, on_delete=models.CASCADE, default=get_staff_organisation_name_id,
@@ -255,6 +264,8 @@ class Mandat(models.Model):
         max_length=16, choices=AutorisationDureeKeywords.choices, null=True
     )
     is_remote = models.BooleanField(default=False)
+
+    objects = MandatQuerySet.as_manager()
 
     @property
     def is_expired(self) -> bool:


### PR DESCRIPTION
## 🌮 Objectif

Utilise le comptage de mandats pour faire les statistiques du site

## 🔍 Implémentation

- Dans la vue `service`, on change les méthodes de comptage des mandats qui passaient par les entrées de journal.
- On ajoute dans les modèles un queryset `.active` pour les mandats qui filtre les mandats non-expirés et dont les autorisations ne sont pas toutes révoquées.
