### PR TITLE
Etape G : Adapte les vues/tests à la révocation d'autorisations

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -202,9 +202,17 @@ class Usager(models.Model):
     def get_full_name(self):
         return str(self)
 
-    def get_autorisation(self, autorisation_id):
+    def get_mandat(self, mandat_id):
         try:
-            return self.autorisations.get(pk=autorisation_id)
+            return self.mandats.get(pk=mandat_id)
+        except Mandat.DoesNotExist:
+            return None
+
+    def get_autorisation(self, mandat_id, autorisation_id):
+        try:
+            return self.get_mandat(mandat_id).autorisations.get(pk=autorisation_id)
+        except AttributeError:
+            return None
         except Autorisation.DoesNotExist:
             return None
 

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -211,9 +211,7 @@ class Usager(models.Model):
     def get_autorisation(self, mandat_id, autorisation_id):
         try:
             return self.get_mandat(mandat_id).autorisations.get(pk=autorisation_id)
-        except AttributeError:
-            return None
-        except Autorisation.DoesNotExist:
+        except (AttributeError, Autorisation.DoesNotExist):
             return None
 
     def normalize_birthplace(self):

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -76,7 +76,7 @@
             </tbody>
           </table>
         {% else %}
-          <div class="notification" role="alert">Vous n’avez pas d'autorisation expiré avec cet usager.</div>
+          <div class="notification" role="alert">Vous n’avez pas d'autorisation expirée avec cet usager.</div>
         {% endif %}
       {% else %}
         <div class="notification" role="alert">Vous n’avez pas de mandat avec cet usager.</div>

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -9,7 +9,7 @@
   <div class="container">
     <div class="row">
       <h1 class="brand">
-        <a id="retour_usagers" href="{% url 'usagers' %}">Vos mandats</a>
+        <a id="retour_usagers" href="{% url 'usagers' %}">Vos usagers</a>
       </h1>
       <a id="add_mandat" class="button float-right" href="{% url 'new_mandat' %}">Créer un mandat</a>
     </div>
@@ -22,9 +22,9 @@
       </div>
     {% endif %}
     <div class="tiles">
-      {% if active_mandats or inactive_mandats %}
-        <h2>Mandats en cours</h2>
-        {% if active_mandats %}
+      {% if active_autorisations or inactive_autorisations %}
+        <h2>Autorisations en cours</h2>
+        {% if active_autorisations %}
           <!-- <input class="table__filter" type="text" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)" disabled> -->
           <table class="table">
             <thead>
@@ -38,24 +38,24 @@
               </tr>
             </thead>
             <tbody>
-              {% for mandat in active_mandats %}
+              {% for autorisation in active_autorisations %}
               <tr>
-                <td>{{ mandat.demarche }}</td>
-                <td title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</td>
-                <td title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</td>
+                <td>{{ autorisation.demarche }}</td>
+                <td title="{{ autorisation.creation_date }}">{{ autorisation.creation_date | date:"d F Y" }}</td>
+                <td title="{{ autorisation.expiration_date }}">{{ autorisation.expiration_date | date:"d F Y" }}</td>
                 <td>
-                  <a href="{% url 'usagers_mandats_cancel_confirm' usager_id=usager.id mandat_id=mandat.id %}" class="button-outline warning small float-right" title="Révoquer le mandat">&nbsp;🗑️</a>
+                  <a href="{% url 'usagers_mandats_autorisations_cancel_confirm' usager_id=usager.id mandat_id=autorisation.mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right" title="Révoquer le mandat">&nbsp;🗑️</a>
                 </td>
               </tr>
               {% endfor %}
             </tbody>
           </table>
         {% else %}
-          <div class="notification" role="alert">Vous n’avez pas de mandat en cours avec cet usager.</div>
+          <div class="notification" role="alert">Vous n’avez pas d'autorisation en cours avec cet usager.</div>
         {% endif %}
         <br />
-        <h2>Mandats expirés</h2>
-        {% if inactive_mandats %}
+        <h2>Autorisations expirés</h2>
+        {% if inactive_autorisations %}
           <!-- <input class="table__filter" type="text" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)" disabled> -->
           <table class="table">
             <thead>
@@ -66,17 +66,17 @@
               </tr>
             </thead>
             <tbody>
-              {% for mandat in inactive_mandats %}
+              {% for autorisation in inactive_autorisations %}
                 <tr>
-                  <td>{{ mandat.demarche }}</td>
-                  <td title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</td>
-                  <td title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</td>
+                  <td>{{ autorisation.demarche }}</td>
+                  <td title="{{ autorisation.creation_date }}">{{ autorisation.creation_date | date:"d F Y" }}</td>
+                  <td title="{{ autorisation.expiration_date }}">{{ autorisation.expiration_date | date:"d F Y" }}</td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
         {% else %}
-          <div class="notification" role="alert">Vous n’avez pas de mandat expiré avec cet usager.</div>
+          <div class="notification" role="alert">Vous n’avez pas d'autorisation expiré avec cet usager.</div>
         {% endif %}
       {% else %}
         <div class="notification" role="alert">Vous n’avez pas de mandat avec cet usager.</div>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html
@@ -19,10 +19,10 @@
             L'autorisation avec l'usager <strong>{{ usager }}</strong>,
             pour la démarche <strong>{{ autorisation.demarche }}</strong>,
             créé le <strong>{{ autorisation.creation_date | date:"d F Y" }}</strong> et expirant le <strong>{{ autorisation.expiration_date | date:"d F Y" }}</strong>,
-            va être <strong>révoqué</strong>.
+            va être <strong>révoquée</strong>.
           </p>
           <p>
-            <i>L'autorisation apparaîtra comme expiré dans l'espace usagers.</i>
+            <i>L'autorisation apparaîtra comme expirée dans l'espace usagers.</i>
           </p>
           <p>
             Cliquez sur le bouton "Je confirme" pour confirmer l'action.

--- a/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html
@@ -2,12 +2,12 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - Confirmer la révocation du mandat{% endblock %}
+{% block title %}Aidants Connect - Confirmer la révocation de l'autorisation{% endblock %}
 
 {% block content %}
 <section class="section">
   <div class="container">
-    <h1 class="brand">Confirmer la révocation du mandat</h1>
+    <h1 class="brand">Confirmer la révocation de l'autorisation</h1>
     <div class="tiles">
       <form method="post" class="panel">
         {% if error %}
@@ -16,13 +16,13 @@
         {% csrf_token %}
         <div class="form__group">
           <p>
-            Le mandat avec l'usager <strong>{{ usager }}</strong>,
-            pour la démarche <strong>{{ mandat.demarche }}</strong>,
-            créé le <strong>{{ mandat.creation_date | date:"d F Y" }}</strong> et expirant le <strong>{{ mandat.expiration_date | date:"d F Y" }}</strong>,
+            L'autorisation avec l'usager <strong>{{ usager }}</strong>,
+            pour la démarche <strong>{{ autorisation.demarche }}</strong>,
+            créé le <strong>{{ autorisation.creation_date | date:"d F Y" }}</strong> et expirant le <strong>{{ autorisation.expiration_date | date:"d F Y" }}</strong>,
             va être <strong>révoqué</strong>.
           </p>
           <p>
-            <i>Le mandat apparaîtra comme expiré dans l'espace usagers.</i>
+            <i>L'autorisation apparaîtra comme expiré dans l'espace usagers.</i>
           </p>
           <p>
             Cliquez sur le bouton "Je confirme" pour confirmer l'action.

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -246,7 +246,6 @@ class AutorisationModelTests(TestCase):
             organisation=cls.aidant_patricia.organisation,
             usager=cls.usager_ned,
             expiration_date=timezone.now() + timedelta(days=6),
-        )
 
     def test_saving_and_retrieving_autorisation(self):
         first_autorisation = AutorisationFactory(

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -246,6 +246,7 @@ class AutorisationModelTests(TestCase):
             organisation=cls.aidant_patricia.organisation,
             usager=cls.usager_ned,
             expiration_date=timezone.now() + timedelta(days=6),
+        )
 
     def test_saving_and_retrieving_autorisation(self):
         first_autorisation = AutorisationFactory(

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -282,9 +282,8 @@ class NewMandatRecapTests(TestCase):
         self.assertEqual(last_journal_entries[0].action, "create_autorisation")
         self.assertEqual(last_journal_entries[0].demarche, "papiers")
         self.assertEqual(last_journal_entries[1].action, "cancel_autorisation")
-        self.assertEqual(last_journal_entries[2].action, "update_autorisation")
-        self.assertEqual(last_journal_entries[3].action, "create_autorisation")
-        self.assertEqual(last_journal_entries[3].demarche, "logement")
+        self.assertEqual(last_journal_entries[2].action, "create_autorisation")
+        self.assertEqual(last_journal_entries[2].demarche, "logement")
 
         self.assertEqual(
             len(self.aidant_thierry.get_active_demarches_for_usager(self.test_usager)),
@@ -395,7 +394,6 @@ class NewMandatRecapTests(TestCase):
         last_autorisation.revocation_date = timezone.now()
         last_autorisation.save(update_fields=["revocation_date"])
 
-        Journal.objects.autorisation_update(last_autorisation, self.aidant_thierry)
         Journal.objects.autorisation_cancel(last_autorisation, self.aidant_thierry)
 
         # second session : 'updating' the autorisation
@@ -489,9 +487,8 @@ class NewMandatRecapTests(TestCase):
         self.assertEqual(last_journal_entries[0].action, "create_autorisation")
         self.assertEqual(last_journal_entries[0].demarche, "papiers")
         self.assertEqual(last_journal_entries[1].action, "cancel_autorisation")
-        self.assertEqual(last_journal_entries[2].action, "update_autorisation")
-        self.assertEqual(last_journal_entries[3].action, "create_autorisation")
-        self.assertEqual(last_journal_entries[3].demarche, "logement")
+        self.assertEqual(last_journal_entries[2].action, "create_autorisation")
+        self.assertEqual(last_journal_entries[2].demarche, "logement")
 
         self.assertEqual(
             len(self.aidant_thierry.get_active_demarches_for_usager(self.test_usager)),

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -116,6 +116,26 @@ class AutorisationCancelConfirmPageTests(TestCase):
             "aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html",
         )
 
+        response_incorrect_confirm_form = self.client.post(
+            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
+            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm",
+            data={},
+        )
+        self.assertTemplateUsed(
+            response_incorrect_confirm_form,
+            "aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html",
+        )
+
+        response_correct_confirm_form = self.client.post(
+            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
+            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm",
+            data={"csrfmiddlewaretoken": "coucou"},
+        )
+        url = f"/usagers/{self.usager_1.id}/"
+        self.assertRedirects(
+            response_correct_confirm_form, url, fetch_redirect_response=False
+        )
+
     def test_non_existing_autorisation_triggers_redirect(self):
         self.client.force_login(self.aidant_1)
         response = self.client.get(

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -20,9 +20,9 @@ urlpatterns = [
     path("usagers/", usagers.usagers_index, name="usagers"),
     path("usagers/<int:usager_id>/", usagers.usager_details, name="usager_details"),
     path(
-        "usagers/<int:usager_id>/mandats/<int:mandat_id>/cancel_confirm",
-        usagers.usagers_mandats_cancel_confirm,
-        name="usagers_mandats_cancel_confirm",
+        "usagers/<int:usager_id>/mandats/<int:mandat_id>/autorisations/<int:autorisation_id>/cancel_confirm",  # noqa
+        usagers.usagers_mandats_autorisations_cancel_confirm,
+        name="usagers_mandats_autorisations_cancel_confirm",
     ),
     # new mandat
     path("creation_mandat/", new_mandat.new_mandat, name="new_mandat"),

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -155,9 +155,6 @@ def new_mandat_recap(request):
                         similar_active_autorisation.save(
                             update_fields=["revocation_date"]
                         )
-                        Journal.objects.autorisation_update(
-                            similar_active_autorisation, aidant
-                        )
                         Journal.objects.autorisation_cancel(
                             similar_active_autorisation, aidant
                         )

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -76,7 +76,7 @@ def usagers_mandats_autorisations_cancel_confirm(
         django_messages.error(request, "L'autorisation a été révoquée")
         return redirect("dashboard")
     if autorisation.is_expired:
-        django_messages.error(request, "L'autorisation est déjà expirée")
+        django_messages.error(request, "L'autorisation a déjà expiré")
         return redirect("dashboard")
 
     if request.method == "POST":
@@ -88,13 +88,15 @@ def usagers_mandats_autorisations_cancel_confirm(
 
             Journal.objects.autorisation_cancel(autorisation, aidant)
 
-            django_messages.success(request, "Le mandat a été révoquée avec succès !")
+            django_messages.success(
+                request, "L'autorisation a été révoquée avec succès !"
+            )
             return redirect("usager_details", usager_id=usager.id)
 
         else:
             return render(
                 request,
-                "aidants_connect_web/new_mandat/usagers_mandats_autorisations_cancel_confirm.html",  # noqa
+                "aidants_connect_web/usagers_mandats_autorisations_cancel_confirm.html",
                 {
                     "aidant": aidant,
                     "usager": usager,


### PR DESCRIPTION
## 🌮 Objectif

Répare pour l'aidant:
- la liste de toutes les autorisations d'un usager
- la possibilité de révoquer une autorisation active 

## 🔍 Implémentation

- renomme `mandat` en `autorisation` dans les vues usagers_details et usagers_autorisation_cancel
- répare le workflow "révocation d'une autorisation"
- modifie l'url de révocation pour avoir à la fois le mandat_id et l'autorisation_id, et met à jour les tests
- ajout de tests pour vérifier l'intégrité de l'autorisation avant d'accéder à la page de revocation