### PR TITLE
Etape F-4 : Sort la journalisation des autorisation des signaux

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -487,24 +487,6 @@ class JournalManager(models.Manager):
 
         return journal_entry
 
-    def autorisation_update(self, autorisation: Autorisation, aidant: Aidant):
-        usager = autorisation.usager
-
-        journal_entry = self.create(
-            initiator=aidant.full_string_identifier,
-            usager=usager.full_string_identifier,
-            action="update_autorisation",
-            demarche=autorisation.demarche,
-            duree=autorisation.duree_in_days,
-            autorisation=autorisation.id,
-            # COVID-19
-            is_remote_mandat=True,
-            additional_information="Mandat conclu à distance "
-            "pendant l'état d'urgence sanitaire (23 mars 2020)",
-        )
-
-        return journal_entry
-
     def autorisation_use(
         self,
         aidant: Aidant,
@@ -549,7 +531,6 @@ class Journal(models.Model):
         ("create_attestation", "Création d'une attestation"),
         ("create_autorisation", "Création d'une autorisation"),
         ("use_autorisation", "Utilisation d'une autorisation"),
-        ("update_autorisation", "Renouvellement d'une autorisation"),
         ("cancel_autorisation", "Révocation d'une autorisation"),
     )
     # mandatory

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -347,7 +347,7 @@ class Autorisation(models.Model):
 
     @property
     def duree_in_days(self):
-        duree_for_computer = self.expiration_date - self.creation_date
+        duree_for_computer = self.mandat.expiration_date - self.creation_date
         # we add one day so that duration is human friendly
         # i.e. for a human, there is one day between now and tomorrow at the same time,
         # and 0 for a computer
@@ -469,9 +469,8 @@ class JournalManager(models.Manager):
         )
         return journal_entry
 
-    def autorisation_creation(self, autorisation: Autorisation):
-        aidant = autorisation.aidant
-        usager = autorisation.usager
+    def autorisation_creation(self, autorisation: Autorisation, aidant: Aidant):
+        usager = autorisation.mandat.usager
 
         journal_entry = self.create(
             initiator=aidant.full_string_identifier,
@@ -489,7 +488,6 @@ class JournalManager(models.Manager):
         return journal_entry
 
     def autorisation_update(self, autorisation: Autorisation, aidant: Aidant):
-        aidant = autorisation.aidant
         usager = autorisation.usager
 
         journal_entry = self.create(
@@ -527,8 +525,8 @@ class JournalManager(models.Manager):
 
     def autorisation_cancel(self, autorisation: Autorisation, aidant: Aidant):
         journal_entry = self.create(
-            initiator=autorisation.aidant.full_string_identifier,
-            usager=autorisation.usager.full_string_identifier,
+            initiator=aidant.full_string_identifier,
+            usager=autorisation.mandat.usager.full_string_identifier,
             action="cancel_autorisation",
             demarche=autorisation.demarche,
             duree=autorisation.duree_in_days,

--- a/aidants_connect_web/signals.py
+++ b/aidants_connect_web/signals.py
@@ -1,16 +1,9 @@
 from django.contrib.auth.signals import user_logged_in
-from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from aidants_connect_web.models import Autorisation, Journal
+from aidants_connect_web.models import Journal
 
 
 @receiver(user_logged_in)
 def on_login(sender, user, request, **kwargs):
     Journal.objects.connection(user)
-
-
-@receiver(post_save, sender=Autorisation)
-def on_autorisation_change(sender, instance, created, **kwargs):
-    if created:
-        Journal.objects.autorisation_creation(instance)

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -632,13 +632,6 @@ class JournalModelTests(TestCase):
         self.assertEqual(entry.action, "use_autorisation")
         self.assertEqual(entry.demarche, "transports")
 
-    def test_log_autorisation_update_complete(self):
-        entry = Journal.objects.autorisation_update(
-            autorisation=self.first_autorisation, aidant=self.aidant_thierry
-        )
-        self.assertEqual(len(Journal.objects.all()), 3)
-        self.assertEqual(entry.action, "update_autorisation")
-
     def test_log_autorisation_cancel_complete(self):
         entry = Journal.objects.autorisation_cancel(
             autorisation=self.first_autorisation, aidant=self.aidant_thierry

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -574,8 +574,8 @@ class UserInfoTests(TestCase):
 
         journal_entries = Journal.objects.all()
 
-        self.assertEqual(journal_entries.count(), 2)
-        self.assertEqual(journal_entries[1].action, "use_autorisation")
+        self.assertEqual(journal_entries.count(), 1)
+        self.assertEqual(journal_entries.first().action, "use_autorisation")
 
     date_expired = date + timedelta(seconds=settings.FC_CONNECTION_AGE + 1200)
 

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -163,7 +163,7 @@ def new_mandat_recap(request):
                         )
 
                     # Create new demarche autorisation
-                    Autorisation.objects.create(
+                    autorisation = Autorisation.objects.create(
                         aidant=aidant,
                         usager=usager,
                         demarche=demarche,
@@ -172,6 +172,7 @@ def new_mandat_recap(request):
                         last_renewal_token=connection.access_token,
                         is_remote=True,
                     )
+                    Journal.objects.autorisation_creation(autorisation, aidant)
 
             except AttributeError as error:
                 log.error("Error happened in Recap")


### PR DESCRIPTION
## 🌮 Objectif
Conserver l'`initiator` des actions journalisées. 

## 🔍 Implémentation

### Avant 
A chaque `save` du mandat (création ou mise à jour), le signal `post_save` permet de journaliser automatiquement les modifications et leur `initiator`

### Problème
L'aidant n'est plus présent dans l'autorisation (ou sa FK `mandat`) et il n'est plus possible d'y accéder dans le signal.

### Solution et implémentation
- Sortir la journalisation du signal pour la remettre dans les views
- Mettre à jour les méthodes pour qu'elle prennent un nouvel argument : aidant
- Mettre à jour les tests

## ⚠️ Informations supplémentaires

Cette modifications n'a pas été portée sur la révocation des autorisation, que ce soit suite à la création d'un mandat ou d'une révocation à la main.
