### PR TITLE
Add link validity duration in the connection email

### DIFF
--- a/aidants_connect_web/templates/login/email_template.html
+++ b/aidants_connect_web/templates/login/email_template.html
@@ -317,6 +317,7 @@
                             </tr>
                           </tbody>
                         </table>
+                        <p>Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.</p>
                         <p>Bonne journée,</p>
                         <p>L'équipe Aidants Connect</p>
                       </td>

--- a/aidants_connect_web/templates/login/email_template.txt
+++ b/aidants_connect_web/templates/login/email_template.txt
@@ -2,6 +2,8 @@ Bonjour {{ user.first_name }} {{ user.last_name }},
 
 Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}
 
+Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.
+
 Bonne journée,
 
-L'équipe de {{ site.domain }}
+L'équipe {{ site.domain }}


### PR DESCRIPTION
## 🌮 Objectif

Améliorer l'expérience utilisateur lors de la connexion à l'application

## 🔍 Implémentation

- Ajout de la durée de validité du mail de connexion dans le texte de celui-ci

## ⚠️ Informations supplémentaires

Cette possibilité nous est offerte par [ce commit](https://github.com/betagouv/django-magicauth/commit/8a8143388bb15fad2823528201e22a31817da243) dans `django-magicauth`, qui est maintenant intégré à "notre" branche `add_totp` — elle-même en attente de _merge_ dans `master`.

