### PR TITLE
Add a command to anonymize the database

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,18 +22,18 @@ bash-prod: ## Open a bash shell on the production platform
 	scalingo run --region osc-secnum-fr1 --app aidants-connect-prod bash
 
 bash-preprod: ## Open a bash shell on the preproduction platform
-	scalingo run --region osc-fr1 --app aidants-connect-preprod bash
+	scalingo run --region osc-secnum-fr1 --app aidants-connect-preprod bash
 
 bash-inte: ## Open a bash shell on the integration platform
-	scalingo run --region osc-fr1 --app aidants-connect-integ bash
+	scalingo run --region osc-secnum-fr1 --app aidants-connect-integ bash
 bash-integ: bash-inte
 
 ds-prod: ## Open a Django shell on the production platform
 	scalingo run --region osc-secnum-fr1 --app aidants-connect-prod python manage.py shell_plus
 
 ds-preprod: ## Open a Django shell on the preproduction platform
-	scalingo run --region osc-fr1 --app aidants-connect-preprod python manage.py shell_plus
+	scalingo run --region osc-secnum-fr1 --app aidants-connect-preprod python manage.py shell_plus
 
 ds-inte: ## Open a Django shell on the integration platform
-	scalingo run --region osc-fr1 --app aidants-connect-integ python manage.py shell_plus
+	scalingo run --region osc-secnum-fr1 --app aidants-connect-integ python manage.py shell_plus
 ds-integ: ds-inte

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -59,6 +59,8 @@ else:
 
 ALLOWED_HOSTS = [os.environ["HOST"]]
 
+IS_PRODUCTION = "aidantsconnect.beta.gouv.fr" in ALLOWED_HOSTS
+
 
 # Application definition
 

--- a/aidants_connect_web/management/commands/anonymize_database.py
+++ b/aidants_connect_web/management/commands/anonymize_database.py
@@ -1,0 +1,62 @@
+import sys
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from aidants_connect_web.models import Aidant, Journal, Usager
+
+
+class Command(BaseCommand):
+
+    help = "Remove personal information from the database"
+
+    def handle(self, *args, **options):
+
+        # A little sanity check first.
+        if settings.IS_PRODUCTION:
+            self.stdout.write(
+                "Anonymizing the production database seems like a bad idea."
+            )
+            sys.exit(1)  # denotes an unsuccessful termination
+
+        self.stdout.write("Anonymizing database...")
+
+        self.stdout.write("  Removing Usagers' personal information...")
+        for usager in Usager.objects.order_by("id"):
+
+            uid = usager.id
+
+            self.stdout.write(f"    Usager #{uid}...")
+
+            original_email = usager.email
+
+            usager.given_name = f"UP-{uid}"   # UP = "Usager Prénom"
+            usager.family_name = f"UN-{uid}"  # UN = "Usager Nom"
+            usager.email = f"u{uid}@usager.fr"
+            usager.save()
+
+            for entry in Journal.objects.filter(usager__icontains=original_email):
+                entry.usager = usager.full_string_identifier
+                entry.save(anonymize=True)
+
+        self.stdout.write("  Removing Aidants' personal information...")
+        for aidant in Aidant.objects.exclude(
+            email__icontains="beta.gouv.fr"  # keep the staff accounts intact
+        ).order_by("id"):
+
+            aid = aidant.id
+
+            self.stdout.write(f"    Aidant #{aid}...")
+
+            original_email = aidant.email
+
+            aidant.first_name = f"AP-{aid}"  # AP = "Aidant Prénom"
+            aidant.last_name = f"AN-{aid}"   # AN = "Aidant Nom"
+            aidant.email = f"a{aid}@aidant.fr"
+            aidant.save()
+
+            for entry in Journal.objects.filter(initiator__icontains=original_email):
+                entry.initiator = aidant.full_string_identifier
+                entry.save(anonymize=True)
+
+        self.stdout.write("All done.")

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -221,12 +221,12 @@ class Usager(models.Model):
     def __str__(self):
         return f"{self.given_name} {self.family_name}"
 
+    def get_full_name(self):
+        return str(self)
+
     @property
     def full_string_identifier(self):
         return f"{self.get_full_name()} - {self.id} - {self.email}"
-
-    def get_full_name(self):
-        return str(self)
 
     def get_mandat(self, mandat_id):
         try:
@@ -513,7 +513,10 @@ class Journal(models.Model):
         return f"Entrée #{self.id} : {self.action} - {self.initiator}"
 
     def save(self, *args, **kwargs):
-        if self.id:
+
+        # Editing a journal entry is only allowed during database anonymization.
+        anonymize = kwargs.pop("anonymize", False)
+        if self.id and not anonymize:
             raise NotImplementedError("Editing is not allowed on journal entries")
         else:
             # COVID-19


### PR DESCRIPTION
This will make it more convenient to use realistic data in non-production environments, by transferring the production database and then easily removing all personal identification from it:
```shell
$ python manage.py anonymize_database
```

Also amend the `Makefile` to account for the fact that all environments are now hosted in the `SecNumCloud` Scalingo region.