### PR TITLE
Afficher les mandats en cours d'un usager (au lieu des autorisations)

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -282,6 +282,9 @@ class MandatQuerySet(models.QuerySet):
             .distinct()
         )
 
+    def inactive(self):
+        return self.filter(expiration_date__lt=timezone.now())
+
 
 class Mandat(models.Model):
     organisation = models.ForeignKey(
@@ -315,15 +318,14 @@ class Mandat(models.Model):
 
     def admin_is_active(self):
         return self.is_active
+
     admin_is_active.boolean = True
     admin_is_active.short_description = "is active"
 
 
 class AutorisationQuerySet(models.QuerySet):
     def active(self):
-        return self.exclude(
-            mandat__expiration_date__lt=timezone.now()
-        ).filter(
+        return self.exclude(mandat__expiration_date__lt=timezone.now()).filter(
             revocation_date__isnull=True
         )
 
@@ -578,7 +580,6 @@ class Journal(models.Model):
             duree=duree,
             access_token=access_token,
             attestation_hash=attestation_hash,
-
             # COVID-19
             is_remote_mandat=is_remote_mandat,
             additional_information=(cls.INFO_REMOTE_MANDAT if is_remote_mandat else ""),
@@ -596,7 +597,6 @@ class Journal(models.Model):
             demarche=autorisation.demarche,
             duree=autorisation.duration_for_humans,
             autorisation=autorisation.id,
-
             # COVID-19
             is_remote_mandat=mandat.is_remote,
             additional_information=(cls.INFO_REMOTE_MANDAT if mandat.is_remote else ""),

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -283,7 +283,10 @@ class MandatQuerySet(models.QuerySet):
         )
 
     def inactive(self):
-        return self.filter(expiration_date__lt=timezone.now())
+        return self.filter(
+            Q(expiration_date__lt=timezone.now())
+            | ~Q(autorisations__revocation_date__isnull=True)
+        ).distinct()
 
 
 class Mandat(models.Model):

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -11,7 +11,7 @@
       <h1 class="margin-bottom-0">
         <a id="retour_usagers" href="{% url 'usagers' %}">Vos usagers</a>
       </h1>
-      <a id="add_mandat" class="button float-right" href="{% url 'new_mandat' %}">Créer un mandat</a>
+      <a id="add_mandat" class="button float-right" href="{% url 'new_mandat' %}">📝&nbsp;Créer un mandat</a>
     </div>
     <h2>&nbsp;↳ {{ usager.get_full_name }}</h2>
     {% if messages %}
@@ -26,120 +26,119 @@
 
 <section class="section section-grey">
   <div class="container">
-    {% if active_mandats or inactive_mandats %}
-      <h2>Mandats en cours</h2>
-      {% if active_mandats %}
-        {% for mandat in active_mandats %}
-          <div class="panel">
-            <div class="row">
-              <h4 class="margin-bottom-0">
-                📝&nbsp;Mandat valable encore {{ mandat.expiration_date | timeuntil }}
-                <small title="{{ mandat.expiration_date }}">(jusqu'au {{ mandat.expiration_date | date:"d F Y" }})</small>
-              </h4>
-              <div class="float-right">
-                <a id="view_mandat_attestation" class="button">🖨&nbsp;Voir l'attestation</a>
-                <a id="view_mandat_attestation" class="button-outline warning">🗑️&nbsp;Révoquer</a>
-              </div>
-            </div>
-            <ul class="label-list">
-              <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
-              <li class="label">{{ mandat.get_duree_keyword_display }}</li>
-              <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
-            </ul>
-            <br />
-            <h6>{{ mandat.autorisations.count }} démarches</h6>
-            <div>
-              <table class="table">
-                <thead>
-                  <tr>
-                    <th class="th-40">Périmètre de la démarche</th>
-                    <!-- <th class="th-20">Date de création</th> -->
-                    <th class="th-20">Date d'expiration</th>
-                    <th class="th-20">
-                      <span class="float-right">Actions</span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for autorisation in mandat.autorisations.all %}
-                    <tr>
-                      <td>{{ autorisation.demarche }}</td>
-                      <td>
-                        {% if not autorisation.revocation_date %}
-                          <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
-                        {% else %}
-                          <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
-                        {% endif %}
-                      </td>
-                      <td>
-                        {% if not autorisation.revocation_date %}
-                          <a href="{% url 'usagers_mandats_autorisations_cancel_confirm' usager_id=usager.id mandat_id=mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right" title="Révoquer l'autorisation">&nbsp;🗑️</a>
-                        {% endif %}
-                      </td>
-                    </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
+    <h2>Mandats en cours</h2>
+    {% if active_mandats %}
+      {% for mandat in active_mandats %}
+        <div id="active-mandat-panel" class="panel">
+          <div class="row">
+            <h4 class="margin-bottom-0">
+              📝&nbsp;Mandat valable encore {{ mandat.expiration_date | timeuntil }}
+              <small title="{{ mandat.expiration_date }}">(jusqu'au {{ mandat.expiration_date | date:"d F Y" }})</small>
+            </h4>
+            <div class="float-right">
+              <a id="view_mandat_attestation" class="button">🖨&nbsp;Voir l'attestation</a>
+              <a id="view_mandat_attestation" class="button-outline warning">🗑️&nbsp;Révoquer</a>
             </div>
           </div>
-        {% endfor %}
-      {% else %}
-        <div class="notification" role="alert">Vous n’avez pas de mandats en cours avec cet usager.</div>
-      {% endif %}
+          <ul class="label-list">
+            <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
+            <li class="label">{{ mandat.get_duree_keyword_display }}</li>
+            <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
+          </ul>
+          <br />
+          <h6>{{ mandat.autorisations.count }} démarches</h6>
+          <div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th class="th-40">Périmètre de la démarche</th>
+                  <th class="th-20">Date d'expiration</th>
+                  <th class="th-20">
+                    <span class="float-right">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for autorisation in mandat.autorisations.all %}
+                  <tr id="active-mandat-autorisation-row">
+                    <td>{{ autorisation.demarche }}</td>
+                    <td>
+                      {% if not autorisation.revocation_date %}
+                        <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
+                      {% else %}
+                        <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
+                      {% endif %}
+                    </td>
+                    <td>
+                      {% if not autorisation.revocation_date %}
+                        <a href="{% url 'usagers_mandats_autorisations_cancel_confirm' usager_id=usager.id mandat_id=mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right" title="Révoquer l'autorisation">&nbsp;🗑️</a>
+                      {% endif %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endfor %}
+    {% else %}
+      <div class="notification" role="alert">Vous n’avez pas de mandats en cours avec cet usager.</div>
+    {% endif %}
 
-      <br >
+    <br />
 
-      <h2>Mandats expirés ou révoqués</h2>
-      {% if inactive_mandats %}
-        {% for mandat in inactive_mandats %}
-          <div class="panel">
+    <h2>Mandats expirés ou révoqués</h2>
+    {% if inactive_mandats %}
+      {% for mandat in inactive_mandats %}
+        <div id="inactive-mandat-panel" class="panel">
+          <div class="row">
             <h4>
               📝&nbsp;Mandat expiré depuis {{ mandat.expiration_date | timesince }}
               <small title="{{ mandat.expiration_date }}">(le {{ mandat.expiration_date | date:"d F Y" }})</small>
             </h4>
-            <ul class="label-list">
-              <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
-              <li class="label">{{ mandat.get_duree_keyword_display }}</li>
-              <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
-            </ul>
-            <br />
-            <h6>{{ mandat.autorisations.count }} démarche{{ mandat.autorisations.count | pluralize }}</h6>
-            <div>
-              <table class="table">
-                <thead>
-                  <tr>
-                    <th class="th-40">Périmètre de la démarche</th>
-                    <!-- <th class="th-20">Date de création</th> -->
-                    <th class="th-20">Date d'expiration</th>
-                    <th class="th-20">
-                      <span class="float-right">Actions</span>
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {% for autorisation in mandat.autorisations.all %}
-                    <tr>
-                      <td>{{ autorisation.demarche }}</td>
-                      <td>
-                        {% if not autorisation.revocation_date %}
-                          <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
-                        {% else %}
-                          <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
-                        {% endif %}
-                      </td>
-                      <td></td>
-                    </tr>
-                  {% endfor %}
-                </tbody>
-              </table>
+            <div class="float-right">
+              <a id="view_mandat_attestation" class="button">🖨&nbsp;Voir l'attestation</a>
             </div>
           </div>
-        {% endfor %}
-      {% else %}
-        <div class="notification" role="alert">Vous n’avez pas de mandat expiré avec cet usager.</div>
-      {% endif %}
+          <ul class="label-list">
+            <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
+            <li class="label">{{ mandat.get_duree_keyword_display }}</li>
+            <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
+          </ul>
+          <br />
+          <h6>{{ mandat.autorisations.count }} démarche{{ mandat.autorisations.count | pluralize }}</h6>
+          <div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th class="th-40">Périmètre de la démarche</th>
+                  <th class="th-20">Date d'expiration</th>
+                  <th class="th-20">
+                    <span class="float-right">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for autorisation in mandat.autorisations.all %}
+                  <tr id="inactive-mandat-autorisation-row">
+                    <td>{{ autorisation.demarche }}</td>
+                    <td>
+                      {% if not autorisation.revocation_date %}
+                        <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
+                      {% else %}
+                        <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
+                      {% endif %}
+                    </td>
+                    <td></td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      {% endfor %}
     {% else %}
-      <div class="notification" role="alert">Vous n’avez pas de mandat avec cet usager.</div>
+      <div class="notification" role="alert">Vous n’avez pas de mandat expiré avec cet usager.</div>
     {% endif %}
   <div>
 </section>

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -21,67 +21,126 @@
         {% endfor %}
       </div>
     {% endif %}
-    <div class="tiles">
-      {% if active_autorisations or inactive_autorisations %}
-        <h2>Mandats en cours</h2>
-        {% if active_autorisations %}
-          <!-- <input class="table__filter" type="text" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)" disabled> -->
-          <table class="table">
-            <thead>
-              <tr>
-                <th class="th-40">Périmètre de la démarche</th>
-                <th class="th-20">Date de début</th>
-                <th class="th-20">Date de fin</th>
-                <th class="th-20">
-                  <span class="float-right">Actions</span>
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for autorisation in active_autorisations %}
-              <tr>
-                <td>{{ autorisation.demarche }}</td>
-                <td title="{{ autorisation.creation_date }}">{{ autorisation.creation_date | date:"d F Y" }}</td>
-                <td title="{{ autorisation.expiration_date }}">{{ autorisation.expiration_date | date:"d F Y" }}</td>
-                <td>
-                  <a href="{% url 'usagers_mandats_autorisations_cancel_confirm' usager_id=usager.id mandat_id=autorisation.mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right" title="Révoquer le mandat">&nbsp;🗑️</a>
-                </td>
-              </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% else %}
-          <div class="notification" role="alert">Vous n’avez pas d'autorisation en cours avec cet usager.</div>
-        {% endif %}
-        <br />
-        <h2>Mandats expirés</h2>
-        {% if inactive_autorisations %}
-          <!-- <input class="table__filter" type="text" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)" disabled> -->
-          <table class="table">
-            <thead>
-              <tr>
-                <th class="th-40">Périmètre de la démarche</th>
-                <th class="th-20">Date de début</th>
-                <th class="th-40">Date de fin</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for autorisation in inactive_autorisations %}
-                <tr>
-                  <td>{{ autorisation.demarche }}</td>
-                  <td title="{{ autorisation.creation_date }}">{{ autorisation.creation_date | date:"d F Y" }}</td>
-                  <td title="{{ autorisation.expiration_date }}">{{ autorisation.expiration_date | date:"d F Y" }}</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        {% else %}
-          <div class="notification" role="alert">Vous n’avez pas de mandat expiré avec cet usager.</div>
-        {% endif %}
+  </div>
+</section>
+
+<section class="section section-grey">
+  <div class="container">
+    {% if active_mandats or inactive_mandats %}
+      <h2>Mandats en cours</h2>
+      {% if active_mandats %}
+        {% for mandat in active_mandats %}
+          <div class="panel">
+            <div class="row">
+              <h4 class="margin-bottom-0">
+                📝&nbsp;Mandat valable encore {{ mandat.expiration_date | timeuntil }}
+                <small title="{{ mandat.expiration_date }}">(jusqu'au {{ mandat.expiration_date | date:"d F Y" }})</small>
+              </h4>
+              <div class="float-right">
+                <a id="view_mandat_attestation" class="button">🖨&nbsp;Voir l'attestation</a>
+                <a id="view_mandat_attestation" class="button-outline warning">🗑️&nbsp;Révoquer</a>
+              </div>
+            </div>
+            <ul class="label-list">
+              <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
+              <li class="label">{{ mandat.get_duree_keyword_display }}</li>
+              <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
+            </ul>
+            <br />
+            <h6>{{ mandat.autorisations.count }} démarches</h6>
+            <div>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th class="th-40">Périmètre de la démarche</th>
+                    <!-- <th class="th-20">Date de création</th> -->
+                    <th class="th-20">Date d'expiration</th>
+                    <th class="th-20">
+                      <span class="float-right">Actions</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for autorisation in mandat.autorisations.all %}
+                    <tr>
+                      <td>{{ autorisation.demarche }}</td>
+                      <td>
+                        {% if not autorisation.revocation_date %}
+                          <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
+                        {% else %}
+                          <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
+                        {% endif %}
+                      </td>
+                      <td>
+                        {% if not autorisation.revocation_date %}
+                          <a href="{% url 'usagers_mandats_autorisations_cancel_confirm' usager_id=usager.id mandat_id=mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right" title="Révoquer l'autorisation">&nbsp;🗑️</a>
+                        {% endif %}
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% endfor %}
       {% else %}
-        <div class="notification" role="alert">Vous n’avez pas de mandat avec cet usager.</div>
+        <div class="notification" role="alert">Vous n’avez pas de mandats en cours avec cet usager.</div>
       {% endif %}
-    </div>
+
+      <br >
+
+      <h2>Mandats expirés ou révoqués</h2>
+      {% if inactive_mandats %}
+        {% for mandat in inactive_mandats %}
+          <div class="panel">
+            <h4>
+              📝&nbsp;Mandat expiré depuis {{ mandat.expiration_date | timesince }}
+              <small title="{{ mandat.expiration_date }}">(le {{ mandat.expiration_date | date:"d F Y" }})</small>
+            </h4>
+            <ul class="label-list">
+              <li class="label">Réalisé le <span title="{{ mandat.creation_date }}">{{ mandat.creation_date | date:"d F Y" }}</span></li>
+              <li class="label">{{ mandat.get_duree_keyword_display }}</li>
+              <li class="label">Signé {% if mandat.is_remote %}<span>à distance</span>{% else %}<span>en présence</span>{% endif %}</li>
+            </ul>
+            <br />
+            <h6>{{ mandat.autorisations.count }} démarche{{ mandat.autorisations.count | pluralize }}</h6>
+            <div>
+              <table class="table">
+                <thead>
+                  <tr>
+                    <th class="th-40">Périmètre de la démarche</th>
+                    <!-- <th class="th-20">Date de création</th> -->
+                    <th class="th-20">Date d'expiration</th>
+                    <th class="th-20">
+                      <span class="float-right">Actions</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {% for autorisation in mandat.autorisations.all %}
+                    <tr>
+                      <td>{{ autorisation.demarche }}</td>
+                      <td>
+                        {% if not autorisation.revocation_date %}
+                          <span title="{{ mandat.expiration_date }}">{{ mandat.expiration_date | date:"d F Y" }}</span>
+                        {% else %}
+                          <span class="text-red">Révoqué le {{ autorisation.revocation_date }}</span>
+                        {% endif %}
+                      </td>
+                      <td></td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        {% endfor %}
+      {% else %}
+        <div class="notification" role="alert">Vous n’avez pas de mandat expiré avec cet usager.</div>
+      {% endif %}
+    {% else %}
+      <div class="notification" role="alert">Vous n’avez pas de mandat avec cet usager.</div>
+    {% endif %}
   <div>
 </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -13,7 +13,7 @@
   <div class="container">
     <div class="row">
       <h1 class="margin-bottom-0">Vos mandats</h1>
-      <a href="{% url 'new_mandat' %}" class="button float-right" id="add_usager">Ajouter un usager</a>
+      <a href="{% url 'new_mandat' %}" class="button float-right" id="add_usager">📝&nbsp;Ajouter un usager</a>
     </div>
     {% if messages %}
       <div class="notification success" role="alert">

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -51,36 +51,66 @@ class CancelAutorisationTests(FunctionalTestCase):
         )
         super().setUpClass()
 
-    def test_cancel_autorisation(self):
+    def test_cancel_autorisation_of_active_mandat(self):
         self.open_live_url(f"/usagers/{self.usager_josephine.id}/")
 
         login_aidant(self)
 
-        # See all autorisations of usager page
-        active_autorisations_before = self.selenium.find_elements_by_tag_name("table")[
-            0
-        ].find_elements_by_css_selector("tbody tr")
-        self.assertEqual(len(active_autorisations_before), 2)
-
-        # Click on cancel mandat button
-        cancel_mandat_button = active_autorisations_before[0].find_element_by_tag_name(
-            "a"
+        # See all mandats of usager page
+        active_mandats_before = self.selenium.find_elements_by_id("active-mandat-panel")
+        self.assertEqual(len(active_mandats_before), 1)
+        active_mandats_autorisations_before = self.selenium.find_elements_by_id(
+            "active-mandat-autorisation-row"
         )
-        cancel_mandat_button.click()
+        self.assertEqual(len(active_mandats_autorisations_before), 2)
 
-        # Click on confirm cancellation
+        # Cancel first autorisation
+        cancel_mandat_autorisation_button = active_mandats_autorisations_before[
+            0
+        ].find_element_by_tag_name("a")
+        cancel_mandat_autorisation_button.click()
+
+        # Confirm cancellation
         submit_button = self.selenium.find_elements_by_tag_name("input")[1]
         submit_button.click()
 
-        # See all autorisations of usager page
-        active_autorisations_after = self.selenium.find_elements_by_tag_name("table")[
-            0
-        ].find_elements_by_css_selector("tbody tr")
+        # See again all mandats of usager page
+        active_autorisations_after = self.selenium.find_elements_by_id(
+            "active-mandat-panel"
+        )
         self.assertEqual(len(active_autorisations_after), 1)
-        inactive_autorisations_after = self.selenium.find_elements_by_tag_name("table")[
-            1
-        ].find_elements_by_css_selector("tbody tr")
-        self.assertEqual(len(inactive_autorisations_after), 1)
+        active_mandats_autorisations_after = self.selenium.find_elements_by_id(
+            "active-mandat-autorisation-row"
+        )
+        self.assertEqual(len(active_mandats_autorisations_after), 2)
+        self.assertIn("Révoqué", active_mandats_autorisations_after[0].text)
 
+        # Check Journal
         last_journal_entry = Journal.objects.last()
         self.assertEqual(last_journal_entry.action, "cancel_autorisation")
+
+        # Cancel second autorisation
+        cancel_mandat_autorisation_button = active_mandats_autorisations_after[
+            1
+        ].find_element_by_tag_name("a")
+        cancel_mandat_autorisation_button.click()
+
+        # Confirm cancellation
+        submit_button = self.selenium.find_elements_by_tag_name("input")[1]
+        submit_button.click()
+
+        # See again all mandats of usager page
+        active_autorisations_after = self.selenium.find_elements_by_id(
+            "active-mandat-panel"
+        )
+        self.assertEqual(len(active_autorisations_after), 0)
+        inactive_autorisations_after = self.selenium.find_elements_by_id(
+            "inactive-mandat-panel"
+        )
+        self.assertEqual(len(inactive_autorisations_after), 1)
+        inactive_mandats_autorisations_after = self.selenium.find_elements_by_id(
+            "inactive-mandat-autorisation-row"
+        )
+        self.assertEqual(len(inactive_mandats_autorisations_after), 2)
+        self.assertIn("Révoqué", inactive_mandats_autorisations_after[0].text)
+        self.assertIn("Révoqué", inactive_mandats_autorisations_after[1].text)

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -140,7 +140,6 @@ class MandatModelTests(TestCase):
             duree_keyword="SHORT",
             expiration_date=timezone.now() + timedelta(days=1),
         )
-
         AutorisationFactory(
             mandat=self.mandat_1, demarche="justice",
         )
@@ -188,8 +187,10 @@ class MandatModelTests(TestCase):
             revocation_date=timezone.now() - timedelta(minutes=1),
         )
         active_mandats = Mandat.objects.active().count()
+        inactive_mandats = Mandat.objects.inactive().count()
 
         self.assertEqual(active_mandats, 2)
+        self.assertEqual(inactive_mandats, 1)
 
     def test_active_queryset_method_include_partially_revoked_mandat(self):
         partially_revoked_mandat = Mandat.objects.create(
@@ -208,8 +209,10 @@ class MandatModelTests(TestCase):
             mandat=partially_revoked_mandat, demarche="loisirs",
         )
         active_mandats = Mandat.objects.active().count()
+        inactive_mandats = Mandat.objects.inactive().count()
 
         self.assertEqual(active_mandats, 3)
+        self.assertEqual(inactive_mandats, 0)
 
     def test_active_queryset_method_excludes_expired_mandat(self):
         expired_mandat = Mandat.objects.create(
@@ -224,8 +227,10 @@ class MandatModelTests(TestCase):
         )
 
         active_mandats = Mandat.objects.active().count()
+        inactive_mandats = Mandat.objects.inactive().count()
 
         self.assertEqual(active_mandats, 2)
+        self.assertEqual(inactive_mandats, 1)
 
 
 @tag("models")

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -48,8 +48,6 @@ def usager_details(request, usager_id):
         .filter(organisation=aidant.organisation, usager=usager)
         .inactive()
     )
-    # active_autorisations = aidant.get_active_autorisations_for_usager(usager_id)
-    # inactive_autorisations = aidant.get_inactive_autorisations_for_usager(usager_id)
 
     return render(
         request,
@@ -59,8 +57,6 @@ def usager_details(request, usager_id):
             "usager": usager,
             "active_mandats": active_mandats,
             "inactive_mandats": inactive_mandats,
-            # "active_autorisations": active_autorisations,
-            # "inactive_autorisations": inactive_autorisations,
             "messages": messages,
         },
     )

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -6,7 +6,7 @@ from django.shortcuts import render, redirect
 from django.utils import timezone
 
 from aidants_connect_web.decorators import activity_required
-from aidants_connect_web.models import Journal
+from aidants_connect_web.models import Mandat, Journal
 
 
 logging.basicConfig(level=logging.INFO)
@@ -38,8 +38,18 @@ def usager_details(request, usager_id):
         django_messages.error(request, "Cet usager est introuvable ou inaccessible.")
         return redirect("dashboard")
 
-    active_autorisations = aidant.get_active_autorisations_for_usager(usager_id)
-    inactive_autorisations = aidant.get_inactive_autorisations_for_usager(usager_id)
+    active_mandats = (
+        Mandat.objects.prefetch_related("autorisations")
+        .filter(organisation=aidant.organisation, usager=usager)
+        .active()
+    )
+    inactive_mandats = (
+        Mandat.objects.prefetch_related("autorisations")
+        .filter(organisation=aidant.organisation, usager=usager)
+        .inactive()
+    )
+    # active_autorisations = aidant.get_active_autorisations_for_usager(usager_id)
+    # inactive_autorisations = aidant.get_inactive_autorisations_for_usager(usager_id)
 
     return render(
         request,
@@ -47,8 +57,10 @@ def usager_details(request, usager_id):
         {
             "aidant": aidant,
             "usager": usager,
-            "active_autorisations": active_autorisations,
-            "inactive_autorisations": inactive_autorisations,
+            "active_mandats": active_mandats,
+            "inactive_mandats": inactive_mandats,
+            # "active_autorisations": active_autorisations,
+            # "inactive_autorisations": inactive_autorisations,
             "messages": messages,
         },
     )


### PR DESCRIPTION
## 🌮 Objectif

Un aidant peut voir les mandats en cours ou expirés d'un usager donné

## 🔍 Implémentation

- récupérer les mandats actifs et inactifs de l'usager (filtré sur l'organisation de l'aidant)
- ajout d'un queryset Mandat.inactive()
- ajout de tests

## 🖼️ Images

avant
![Screenshot 2020-08-05 at 16 22 28](https://user-images.githubusercontent.com/7147385/89439585-b4daa080-d74a-11ea-8756-af0891366455.png)

après
![screenshot-localhost_3000-2020 08 05-18_40_19](https://user-images.githubusercontent.com/7147385/89440731-5adada80-d74c-11ea-8f6e-c916dbc0e22e.png)
