### PR TITLE
[Dx] helper pour révoquer une autorisation

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -418,6 +418,16 @@ class Autorisation(models.Model):
         # and 0 for a computer.
         return duration_for_computer.days + 1
 
+    def revoke(self, aidant: Aidant, revocation_date=None):
+        """
+        revoke an autorisation and create the corresponding journal entry
+        """
+        if revocation_date is None:
+            revocation_date = timezone.now()
+        self.revocation_date = revocation_date
+        self.save(update_fields=["revocation_date"])
+        Journal.log_autorisation_cancel(self, aidant)
+
 
 class ConnectionQuerySet(models.QuerySet):
     def expired(self):

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -63,16 +63,11 @@ class CreateNewMandatTests(FunctionalTestCase):
         time.sleep(2)
 
         # Nouvelle mire dialog
-        try:
-            # temp_test_nouvelle_mire = self.selenium.find_element_by_id(
-            #     "message-on-login"
-            # )
+        if len(self.selenium.find_elements_by_id("message-on-login")) > 0:
             temp_test_nouvelle_mire_masquer = self.selenium.find_element_by_id(
                 "message-on-login-close"
             )
             temp_test_nouvelle_mire_masquer.click()
-        except self.selenium.common.exceptions.NoSuchElementException:
-            pass
 
         # Click on the 'Démonstration' identity provider
         demonstration_hex = self.selenium.find_element_by_id(

--- a/aidants_connect_web/tests/test_views/test_new_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_new_mandat.py
@@ -435,10 +435,9 @@ class NewMandatRecapTests(TestCase):
         )
 
         last_autorisation = Autorisation.objects.last()
-        last_autorisation.revocation_date = timezone.now()
-        last_autorisation.save(update_fields=["revocation_date"])
-
-        Journal.log_autorisation_cancel(last_autorisation, self.aidant_thierry)
+        last_autorisation.revoke(
+            aidant=self.aidant_thierry, revocation_date=timezone.now()
+        )
 
         # second session : 'updating' the autorisation
         self.client.force_login(self.aidant_thierry)

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -155,12 +155,8 @@ def new_mandat_recap(request):
                         demarche=demarche,
                     )
                     for similar_active_autorisation in similar_active_autorisations:
-                        similar_active_autorisation.revocation_date = now
-                        similar_active_autorisation.save(
-                            update_fields=["revocation_date"]
-                        )
-                        Journal.log_autorisation_cancel(
-                            similar_active_autorisation, aidant
+                        similar_active_autorisation.revoke(
+                            aidant=aidant, revocation_date=now
                         )
 
                     # Create new demarche autorisation


### PR DESCRIPTION
## 🌮 Objectif

Ajout d'un helper pour simplifier la révocation d'autorisations

## 🔍 Implémentation

- ~Autorisation.create_helper() class method pour créer une autorisation ainsi que l'entrée de journal associé~
- autorisation.revoke() instance method pour révoquer une autorisation donnée et créer l'entrée de journal associée


## ⚠️ Informations supplémentaires

Les tests ne passaient pas car FranceConnect a changé son interface, fix inclus dans cette PR #236

