### PR TITLE
Fix les tests pour la nouvelle mire FranceConnect

### DIFF
--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -62,6 +62,14 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.assertEqual("Connexion - choix du compte", fc_title)
         time.sleep(2)
 
+        # Nouvelle mire dialog
+        temp_test_nouvelle_mire = self.selenium.find_element_by_id("message-on-login")
+        if temp_test_nouvelle_mire:
+            temp_test_nouvelle_mire_masquer = self.selenium.find_element_by_id(
+                "message-on-login-close"
+            )
+            temp_test_nouvelle_mire_masquer.click()
+
         # Click on the 'Démonstration' identity provider
         demonstration_hex = self.selenium.find_element_by_id(
             "fi-identity-provider-example"


### PR DESCRIPTION
## 🌮 Objectif

L'interface FranceConnect affiche en ce moment un dialog qui couvre toute la page. Cela fait planter au moins 1 test fonctionnel

## 🔍 Implémentation

- Rajout d'une condition pour enlever le dialog si il apparait

## 🖼️ Images

<img width="1076" alt="Screenshot 2020-09-01 at 18 32 40" src="https://user-images.githubusercontent.com/7147385/91881295-8dabbc00-ec81-11ea-88ce-f539a9283f81.png">

