### PR TITLE
Quick fix: calcule correctement le nombre d'aidants sur la page de statistiques

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/generale.html
+++ b/aidants_connect_web/templates/public_website/faq/generale.html
@@ -60,7 +60,7 @@
 
         <h3 id="AC-ouvert-a-tous-les-aidant·es-">Quand est-ce que Aidants Connect sera disponible pour tou·tes les aidant·es ?</h3>
         <p>
-          Aidants Connect est pour le moment en phase de test avec 13 structures.
+          Aidants Connect est pour le moment en phase de test avec 16 structures.
           Si le service démontre un impact positif sur la sécurisation de la relation entre aidant·e et usager·ère, il pourra
           être ouvert à un plus grand nombre de structures et à une autre typologie d’aidant·es.
         </p>
@@ -68,12 +68,15 @@
         <h3 id="structures-testeuses-">Quelles sont les structures expérimentatrices ?</h3>
         <p>Voici la liste des structures expérimentatrices :</p>
         <ul>
-          <li>Faitout Connecté&nbsp;(Communauté de communes Champagne-Picarde – Hauts-de-France)&nbsp;- structure labellisée France Services ;</li>
-          <li>L’Association des Centres Sociaux de Douai (Hauts-de-France)&nbsp;;</li>
+          <li>Faitout Connecté&nbsp;(Communauté de communes Champagne-Picarde – Hauts-de-France)&nbsp;- structure labellisée France Services&nbsp;;</li>
+          <li>L’association des Centres Sociaux de Douai (Hauts-de-France)&nbsp;;</li>
           <li>L’association de médiation numérique Net Solidaire (Charente-Maritime)&nbsp;;</li>
           <li>La mairie de Préguillac (Charente-Maritime)&nbsp;;</li>
           <li>La mairie de Rioux (Charente-Maritime)&nbsp;;</li>
           <li>La Fabrique citoyenne de Floirac (Gironde)&nbsp;;</li>
+          <li>La structure France Services de Chalonnes-sur-Loire (Maine-et-Loire)&nbsp;;</li>
+          <li>La structure France Services de Vic-sur-Seille (Moselle)&nbsp;;</li>
+          <li>La structure France Services de Ligny-en-Barrois (Meuse)&nbsp;;</li>
           <li>La Maison des Solidarités de Castanet-Tolosan (Communauté d’agglomération du SICOVAL – Haute-Garonne)&nbsp;;</li>
           <li>La médiathèque Simone de Beauvoir (Valence Romans Agglomération – Drôme)&nbsp;;</li>
           <li>Le tiers-lieu «&nbsp;La Palette&nbsp;» (Creuse) - structure labellisée France Services &nbsp;;</li>
@@ -81,7 +84,7 @@
           <li>Le CCAS d’Anglet (Pyrénées-Atlantiques)&nbsp;;</li>
           <li>Le PIMMS de Blois (Centre-Val-de-Loire) - structure labellisée France Services &nbsp;;</li>
           <li>Un service d’action sociale du département d’Eure-et-Loir (Centre-Val-de-Loire).</li>
-        </ul>
+        </ul> 
 
         <h3 id="combien-coûte-AC">Combien coûte Aidants Connect ?</h3>
         <p>

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -243,6 +243,11 @@ class StatistiquesTests(TestCase):
         response = self.client.get("/stats/")
         self.assertTemplateUsed(response, "public_website/statistiques.html")
 
+    def test_stats_show_the_correct_number_of_aidants_non_staff_organisation(self):
+        # aidants should be non-staff_organisation
+        response = self.client.get("/stats/")
+        self.assertEqual(response.context["aidants_count"], 1)
+
     def test_stats_show_the_correct_number_of_mandats_non_staff_organisation(self):
         # mandats should be non-staff_organisation and active
         response = self.client.get("/stats/")

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -57,7 +57,7 @@ def statistiques(request):
         return [query_set_item.usager_id for query_set_item in query_set]
 
     organisations_count = Organisation.objects.exclude(name=stafforg).count()
-    aidants_count = Aidant.objects.exclude(is_staff=True).count()
+    aidants_count = Aidant.objects.exclude(organisation__name=stafforg).count()
 
     # mandats
     # # mandats prep


### PR DESCRIPTION
## 🌮 Objectif

Certains aidants de l'organisation 'STAFF' ne sont pas pour autant superuser, donc le calcul était erroné.

