### PR TITLE
Utiliser un lien HTTPS pour l'authentification dans l'email d'invitation

### DIFF
--- a/aidants_connect_web/templates/login/email_template.html
+++ b/aidants_connect_web/templates/login/email_template.html
@@ -309,7 +309,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td align="center"> <a href="http://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}">Connexion</a> </td>
+                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_view }}">Connexion</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>

--- a/aidants_connect_web/tests/test_templates.py
+++ b/aidants_connect_web/tests/test_templates.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.test import TestCase
+
+
+class EmailTemplateTests(TestCase):
+
+    def test_email_template_use_https(self):
+        context = {"token": {"key": "KEY"}}
+        rendered = render_to_string(settings.MAGICAUTH_EMAIL_HTML_TEMPLATE,
+                                    context=context)
+
+        assert '<td align="center"> <a href="https://' in rendered


### PR DESCRIPTION
## 🌮 Objectif

passer le lien de l'email de création de compte en HTTPS

## 🔍 Implémentation

- Modification du template utilisé pour générer l'email

