### PR TITLE
Retire la mention "urgence sanitaire" dans les différents documents

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20200511_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20200511_mandat.html
@@ -15,7 +15,7 @@
     {% endif %}
   </div>
   <h1 class="text-center">
-    Mandat pour réaliser des démarches en ligne avec le service  « Aidants Connect » pendant l’état d’urgence sanitaire
+    Mandat pour réaliser des démarches en ligne avec le service  « Aidants Connect »
   </h1>
   <p>Je m’appelle : <strong>{{ usager.get_full_name }}</strong> ( je suis le mandant)</p>
   <p>


### PR DESCRIPTION
## 🌮 Objectif

_Simplifier la compréhension du mandat
Aligner le mandat avec la situation actuelle - pas de date de fin d'état d'urgence sanitaire_

## 🔍 Implémentation

- _Retire la mention "urgence sanitaire" du titre des mandats_

## 🏕 Amélioration continue

- _(optionnel) _

## ⚠️ Informations supplémentaires

_(optionnel)_

## 🖼️ Images

_(optionnel)_
