### PR TITLE
Créé une commande rapide pour ré-initialiser la BDD de développement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,11 @@ ds-preprod: ## Open a Django shell on the preproduction platform
 ds-inte: ## Open a Django shell on the integration platform
 	scalingo run --region osc-secnum-fr1 --app aidants-connect-integ python manage.py shell_plus
 ds-integ: ds-inte
+
+destroy-rebuild-dev-db:
+	psql -c 'DROP DATABASE aidants_connect;'
+	psql -c 'CREATE DATABASE aidants_connect OWNER aidants_connect_team;'
+	psql -c 'ALTER USER aidants_connect_team CREATEDB;'
+	python manage.py migrate
+	python manage.py loaddata admin.json
+	python manage.py loaddata usager_autorisation.json


### PR DESCRIPTION
## 🌮 Objectif

Faciliter la remise à zéro de la BDD pendant le développement

## 🔍 Implémentation

- une série de commande dans le makefile (tirées du README)

## 🖼️ Images

Avant : 
```
psql -c 'DROP DATABASE aidants_connect;'
psql -c 'CREATE DATABASE aidants_connect OWNER aidants_connect_team;'
psql -c 'ALTER USER aidants_connect_team CREATEDB;'
python manage.py migrate
python manage.py loaddata admin.json
python manage.py loaddata usager_autorisation.json
```
Après : 
```
make destroy-rebuild-dev-db
```