### PR TITLE
Utiliser le hash du FC_AS_FI_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/opt/openssl/lib/
 Dupliquez le fichier `.env.example` à la racine du projet en tant que `.env` et ajoutez vos informations :
 - Les champs obligatoires sont indiqués par le préfixe `<insert_`
 - Les informations `FC_AS_FS` et `FC_AS_FI` sont à récupérer via des [habilitations FranceConnect](https://franceconnect.gouv.fr/partenaires)
+- Vous allez devoir calculer la valeur `HASH_FC_AS_FI_SECRET` à partir de la valeur de `FC_AS_FI_SECRET`  pour cela voir dans les annexes la procédure
 - Les valeur de sécurité sont issues de https://docs.djangoproject.com/fr/2.2/topics/security/ et de https://www.youtube.com/watch?v=gvQW1vVNohg
 
 Créez un répertoire `staticfiles` à la racine du projet :
@@ -270,4 +271,12 @@ Pour simplifier le lancement de certaines commandes, un Makefile est disponible.
 make shell
 make test
 make migrate
+```
+
+### Calcul de `HASH_FC_AS_FI_SECRET` à partir de la valeur de `FC_AS_FI_SECRET`    
+Il faut utiliser `generate_sha256_hash`.
+
+```python
+from aidants_connect_web.utilities import generate_sha256_hash
+generate_sha256_hash("VALUE_FC_AS_FI_SECRET".encode("utf-8"))
 ```

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -24,7 +24,7 @@ HOST = os.environ["HOST"]
 # FC as FI
 FC_AS_FI_CALLBACK_URL = os.environ["FC_AS_FI_CALLBACK_URL"]
 FC_AS_FI_ID = os.environ["FC_AS_FI_ID"]
-FC_AS_FI_SECRET = os.environ["FC_AS_FI_SECRET"]
+HASH_FC_AS_FI_SECRET = os.environ["HASH_FC_AS_FI_SECRET"]
 FC_AS_FI_HASH_SALT = os.environ["FC_AS_FI_HASH_SALT"]
 FC_AS_FI_LOGOUT_REDIRECT_URI = os.environ["FC_AS_FI_LOGOUT_REDIRECT_URI"]
 

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -386,7 +386,10 @@ class FISelectDemarcheTests(TestCase):
 @tag("id_provider")
 @override_settings(
     FC_AS_FI_ID="test_client_id",
-    FC_AS_FI_SECRET="test_client_secret",
+    # we don't need FC_AS_FI_SECRET's value.
+    # we use his hash instead.
+    HASH_FC_AS_FI_SECRET="e26ade3b37d31920d89e233c447b0d5e51accff2fdc51d1f377b0"
+                         "31b5d581e70",
     FC_AS_FI_CALLBACK_URL="test_url.test_url",
     HOST="localhost",
 )


### PR DESCRIPTION
## 🌮 Objectif

Utiliser le hash du FC_AS_FI_SECRET et donc ne plus sauvegarder sa valeur

## 🔍 Implémentation

- Ajout d'une nouvelle variable d'environnement ( HASH_FC_AS_FI_SECRET )
- Suppression d'une variable existante ( FC_AS_FI_SECRET )
- Modification de la vue "token"

## 🏕 Amélioration continue



## ⚠️ Informations supplémentaires



## 🖼️ Images


