### PR TITLE
Simplifie le titre du mandat

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20200511_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20200511_mandat.html
@@ -15,7 +15,7 @@
     {% endif %}
   </div>
   <h1 class="text-center">
-    Mandat pour réaliser des démarches en ligne avec le service  « Aidants Connect » pendant l’état d’urgence sanitaire
+    Mandat pour réaliser des démarches en ligne avec le service  « Aidants Connect »
   </h1>
   <p>Je m’appelle : <strong>{{ usager.get_full_name }}</strong> ( je suis le mandant)</p>
   <p>

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_templates/mandat_template.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_templates/mandat_template.html
@@ -15,7 +15,7 @@
     {% endif %}
   </div>
 
-  <h1 class="text-center">Mandat pour réaliser des démarches administratives en ligne au bénéfice d’un usager via le service « Aidants Connect » pendant l’état d’urgence sanitaire déclaré par l’article 4 de la loi du 23 mars 2020.</h1>
+  <h1 class="text-center">Mandat pour réaliser des démarches administratives en ligne au bénéfice d’un usager via le service « Aidants Connect ».</h1>
 
   <p>
     Je soussigné(e), <strong>{{ usager.get_full_name }}</strong> autorise <strong>{{ aidant.organisation }}</strong>, dont seuls les agents habilités peuvent faire à la place de, à


### PR DESCRIPTION
## 🌮 Objectif

_Simplifier le titre du mandat_

## 🔍 Implémentation

- Enlever la mention "pendant l'état d'urgence sanitaire" dans les mandats_

## 🏕 Amélioration continue

## ⚠️ Informations supplémentaires


## 🖼️ Images
