### PR TITLE
Retire lien vers un CSS non-existant

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -4,10 +4,6 @@
 
 {% block title %}Aidants Connect - Usagers{% endblock %}
 
-{% block extracss %}
-<link href="{% static 'css/usagers.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
 <section class="section">
   <div class="container">


### PR DESCRIPTION
## 🌮 Objectif

Ne pas avoir d'erreurs lors du chargement des pages

## 🔍 Implémentation

- Dans le template `usager.html`, j'ai enlevé le lien qui appelle un CSS qui n'existe pas (ou plus)
