### PR TITLE
Faire en sorte que la page de login honeypot ne genere plus d'erreur lors de la soumission du formulaire

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -19,6 +19,8 @@ from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.admin import TOTPDeviceAdmin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
+from admin_honeypot.models import LoginAttempt as HoneypotLoginAttempt
+from admin_honeypot.admin import LoginAttemptAdmin as HoneypotLoginAttemptAdmin
 from magicauth.models import MagicToken
 
 from nested_admin import NestedModelAdmin, NestedTabularInline
@@ -37,6 +39,8 @@ from aidants_connect_web.models import (
 
 
 admin_site = OTPAdminSite(OTPAdminSite.name)
+
+admin_site.register(HoneypotLoginAttempt, HoneypotLoginAttemptAdmin)
 
 
 class VisibleToStaff:

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -1,0 +1,16 @@
+from admin_honeypot.models import LoginAttempt
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+
+
+class LoginAttemptAdminPageTests(TestCase):
+
+    def test_honeypot_login_attempt_fails_gracefuly(self):
+        login_attempt_id = LoginAttempt.objects.create(username="test").pk
+        path = reverse('admin:admin_honeypot_loginattempt_change',
+                       args=(login_attempt_id,))
+        admin = settings.ADMIN_URL
+        admin_url = f"/{admin}admin_honeypot/loginattempt/{login_attempt_id}/change/"
+        self.assertEqual(admin_url, path)


### PR DESCRIPTION
## 🌮 Objectif

Un honeypot est mis en place sur certaines url de l'interface d'admin. Lorsque quelqu'un soumet le formulaire en essayant de se loguer sur les url en questions, cela enregistre la tentative et envoie un email aux administrateurs. Il y avait une erreur à ce moment là. Cette PR corrige le problème.

## 🔍 Implémentation

-  on enregistre manuellement le modèle LoginAttempt dans l'admin django du projet (l'app django-admin-honeypot le fait de son coté, mais pas dans le "bon" admin_site

## 🏕 Amélioration continue



## ⚠️ Informations supplémentaires

On utilise OTPAdminSite et non pas l'admin_site "classique" simple. Du coup l'enregistrement du modèle en interne par django-admin-honyepot ne se fait pas. Et le reverse qui est lancé pour donner un accès direct à l'instance de  LoginAttempt dans l'email d'alerte envoyé aux administrateurs échouait sur une erreur 'je trouve pas l'url'. 

## 🖼️ Images


