### PR TITLE
Ajouter le lien livestorm sur page d'accueil

### DIFF
--- a/aidants_connect_web/templates/public_website/home_page.html
+++ b/aidants_connect_web/templates/public_website/home_page.html
@@ -35,6 +35,8 @@
           Travailleurs sociaux, agents publics d’accueil, médiateurs numériques...
         </p>
         <a class="button primary" href="{% url 'guide_utilisation' %}">Découvrir Aidants Connect</a>
+        &nbsp
+        <a class="button primary" href="{% url 'guide_utilisation' %}">Participer à une démo</a>
       </div>
     </div>
   </div>

--- a/aidants_connect_web/templates/public_website/home_page.html
+++ b/aidants_connect_web/templates/public_website/home_page.html
@@ -36,7 +36,7 @@
         </p>
         <a class="button primary" href="{% url 'guide_utilisation' %}">Découvrir Aidants Connect</a>
         &nbsp
-        <a class="button primary" href="{% url 'guide_utilisation' %}">Participer à une démo</a>
+        <a class="button primary" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">Participer à une démo</a>
       </div>
     </div>
   </div>

--- a/aidants_connect_web/templates/public_website/section_link_faq_partial.html
+++ b/aidants_connect_web/templates/public_website/section_link_faq_partial.html
@@ -7,6 +7,6 @@
       Comment fonctionne Aidants Connect ? etc.
     </p>
     <a class="button-outline" href="{% url 'faq_generale' %}">Consulter notre FAQ</a>
-    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">S'inscrire à une démo</a>
+    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">S'inscrire à une démo de l'outil</a>
   </div>
 </section>

--- a/aidants_connect_web/templates/public_website/section_link_faq_partial.html
+++ b/aidants_connect_web/templates/public_website/section_link_faq_partial.html
@@ -7,5 +7,6 @@
       Comment fonctionne Aidants Connect ? etc.
     </p>
     <a class="button-outline" href="{% url 'faq_generale' %}">Consultez notre FAQ</a>
+    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">Participez à une démo de l'outil Aidants Connect</a>
   </div>
 </section>

--- a/aidants_connect_web/templates/public_website/section_link_faq_partial.html
+++ b/aidants_connect_web/templates/public_website/section_link_faq_partial.html
@@ -6,7 +6,7 @@
       Qu'est-ce qu'un "aidant professionnel" ?
       Comment fonctionne Aidants Connect ? etc.
     </p>
-    <a class="button-outline" href="{% url 'faq_generale' %}">Consultez notre FAQ</a>
-    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">Participez à une démo de l'outil Aidants Connect</a>
+    <a class="button-outline" href="{% url 'faq_generale' %}">Consulter notre FAQ</a>
+    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">S'inscrire à une démo</a>
   </div>
 </section>

--- a/aidants_connect_web/templates/public_website/section_link_faq_partial.html
+++ b/aidants_connect_web/templates/public_website/section_link_faq_partial.html
@@ -7,6 +7,7 @@
       Comment fonctionne Aidants Connect ? etc.
     </p>
     <a class="button-outline" href="{% url 'faq_generale' %}">Consulter notre FAQ</a>
-    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">S'inscrire à une démo de l'outil</a>
+    &nbsp
+    <a class="button-outline" href="https://app.livestorm.co/incubateur-des-territoires/aidants-connect">Participer à une démo</a>
   </div>
 </section>


### PR DESCRIPTION
## 🌮 Objectif
Ajout de deux boutons sur la homepage AC menant vers la page d'inscription au Webinaire Livestorm démo.

- Premier bouton : à droite du bouton "Découvrir Aidants Connect" 
- Deuxième bouton : à droite du bouton "Consultez Notre FAQ"
- Mises à jour du texte des boutons existants afin d'avoir les mêmes éléments de langage sur la homepage

**Avant** : Il n'y a pas de bouton sur la page d'accueil redirigeant vers la page d'inscription livestorm. 
**Après** : Je peux cliquer sur deux boutons qui me redirigent vers la page d'inscription des webinaires hebdomadaires Aidants Connect

## 🔍 Implémentation

Modification du code HTML ; ajout de deux nouvelles ligne de code ; deux nouveaux boutons avec un hyperlien en direction de : https://app.livestorm.co/incubateur-des-territoires/aidants-connect

## 🖼️ Images

**Avant bouton 1**
![image](https://user-images.githubusercontent.com/72392344/102975051-c527c800-44ff-11eb-9d8e-b76daaa4a252.png)

**Après bouton 1**
![image](https://user-images.githubusercontent.com/72392344/102977532-66fce400-4503-11eb-8879-58f91dd5c925.png)

**Avant bouton 2** 
![image](https://user-images.githubusercontent.com/72392344/102976336-ab878000-4501-11eb-9773-081f7e653bbd.png)

**Après bouton 2**
![image](https://user-images.githubusercontent.com/72392344/102978924-990f4580-4505-11eb-87a4-6ce0f5cf2d4e.png)




