### PR TITLE
Ne pas lister les usagers qui n'ont aucune autorisation active

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -171,7 +171,11 @@ class Aidant(AbstractUser):
 
 class UsagerQuerySet(models.QuerySet):
     def active(self):
-        return self.filter(mandats__expiration_date__gt=timezone.now()).distinct()
+        return (
+            self.filter(mandats__expiration_date__gt=timezone.now())
+            .filter(mandats__autorisations__revocation_date__isnull=True)
+            .distinct()
+        )
 
     def visible_by(self, aidant):
         """

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -98,7 +98,9 @@ class Aidant(AbstractUser):
         :return: a queryset of usagers who have an active autorisation
         with the aidant's organisation.
         """
-        return self.get_usagers().active()
+        active_mandats = Mandat.objects.filter(organisation=self.organisation).active()
+        user_list = active_mandats.values_list("usager", flat=True)
+        return Usager.objects.filter(pk__in=user_list)
 
     def get_autorisations(self):
         """

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -470,16 +470,26 @@ class AidantModelMethodsTests(TestCase):
             revocation_date=timezone.now(),
         )
 
+        # Mandat Patricia
+        cls.mandat_marge_lola = MandatFactory(
+            organisation=cls.aidant_patricia.organisation,
+            usager=cls.usager_lola,
+            expiration_date=timezone.now() + timedelta(days=6),
+        )
+        AutorisationFactory(
+            demarche="papiers", mandat=cls.mandat_marge_lola,
+        )
+
     def test_get_usagers(self):
         self.assertEqual(len(self.aidant_marge.get_usagers()), 4)
         self.assertEqual(len(self.aidant_lisa.get_usagers()), 4)
-        self.assertEqual(len(self.aidant_patricia.get_usagers()), 0)
+        self.assertEqual(len(self.aidant_patricia.get_usagers()), 1)
 
     def test_active_usagers(self):
         usagers = Usager.objects.all()
         self.assertEqual(len(usagers), 5)
         active_usagers = usagers.active()
-        self.assertEqual(len(active_usagers), 2)
+        self.assertEqual(len(active_usagers), 3)
 
     def test_get_usagers_with_active_autorisation(self):
         self.assertEqual(
@@ -489,7 +499,7 @@ class AidantModelMethodsTests(TestCase):
             len(self.aidant_lisa.get_usagers_with_active_autorisation()), 2
         )
         self.assertEqual(
-            len(self.aidant_patricia.get_usagers_with_active_autorisation()), 0
+            len(self.aidant_patricia.get_usagers_with_active_autorisation()), 1
         )
 
     def test_get_active_autorisations_for_usager(self):
@@ -522,6 +532,18 @@ class AidantModelMethodsTests(TestCase):
         self.assertEqual(
             len(self.aidant_lisa.get_active_autorisations_for_usager(self.usager_bart)),
             0,
+        )
+        self.assertEqual(
+            len(self.aidant_lisa.get_active_autorisations_for_usager(self.usager_lola)),
+            0,
+        )
+        self.assertEqual(
+            len(
+                self.aidant_patricia.get_active_autorisations_for_usager(
+                    self.usager_lola
+                )
+            ),
+            1,
         )
 
     def test_get_inactive_autorisations_for_usager(self):


### PR DESCRIPTION
## 🌮 Objectif

Simplifier l'interface lors de l'utilisation des mandats en vérifiant que les usagers proposés ont tous au moins une autorisation active avec l'organisation de l'aidant.


## 🔍 Implémentation

- la fonction `aidant.get_usagers_with_active_autorisation()` retrourne un Queryset d'usagers qui ont une ou plusieurs autorisations active avec l'organisation de l'aidant.

## 🏕 Amélioration continue
- un nouveau filtre est ajouté au query set d'un `Usager` : `.active()` retire maintenant les usagers dont les mandats sont révoqués.
- Ajouts de commentaires sur un test fleuve

## 🖼️ Images
Si un usager avait tous ses mandats révoqués (et non expirés) avec une organisation : 
<img width="1130" alt="Capture d’écran 2021-01-12 à 07 35 14" src="https://user-images.githubusercontent.com/13916213/104278394-d3d32080-54a8-11eb-859e-4ec0bebeb45b.png">

Avant : 
son nom apparaissait dans la liste des usagers avec un mandat (mais aucune autorisation n'était trouvée derrière): 
<img width="836" alt="Capture d’écran 2021-01-12 à 07 35 34" src="https://user-images.githubusercontent.com/13916213/104278429-e3526980-54a8-11eb-8621-e8642abdaf8c.png">

<img width="836" alt="Capture d’écran 2021-01-12 à 07 35 34" src="https://user-images.githubusercontent.com/13916213/104278520-04b35580-54a9-11eb-93db-91c0129493f3.png">

Après : 
Son nom n'apparait plus dans la liste 
![Capture d’écran 2021-01-12 à 07 42 00](https://user-images.githubusercontent.com/13916213/104278937-b783b380-54a9-11eb-8c72-43950520d337.png)
