### PR TITLE
Améliorons l'accessibilité du formulaire de création de mandat

### DIFF
--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -55,6 +55,9 @@ form {
   cursor: pointer;
   transition: all 100ms ease-in;
 }
+.tile input[type=checkbox] ~ label::after {
+  border-radius: 4px;
+}
 
 .tile input:checked~label {
   color: white;

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -10,15 +10,20 @@ form {
   font-size: 1.2em;
 }
 
-.tile input {
+.tile input,
+.tile input[type="checkbox"]:checked {
   order: 1;
   z-index: 2;
   position: absolute;
-  transform: translateY(-50%);
+  transform: translateY(-90%);
   cursor: pointer;
-  visibility: hidden;
+  border-color: transparent;
 }
-
+.tile:focus-within {
+  transform: scale(1.03);
+  outline: 2px solid #003b80;
+  outline-offset: 2px;
+}
 .tile label {
   padding: 12px;
   width: 100%;

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -60,6 +60,10 @@ form {
   background-color: #003b80;
 }
 
+.tile input:checked~label .label {
+  color: #003b80;
+}
+
 .tile input:checked~label::after {
   background-color: #003b80;
   border-color: white;

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -82,13 +82,17 @@ form {
   flex-direction: column;
   align-items: center;
 }
-.label-demarche>h3 {
+.label-demarche>strong {
   text-transform: uppercase;
+  font-size: 1.2em;
 }
 
 .label-duree {
   display: flex;
   flex-direction: column;
+}
+.label-duree strong {
+  font-size: 1.2em;
 }
 
 #submit_button {

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -4,6 +4,7 @@ form {
 
 .tile {
   padding: 0;
+  position: relative;
 }
 
 .tile h3 {
@@ -15,7 +16,7 @@ form {
   order: 1;
   z-index: 2;
   position: absolute;
-  transform: translateY(-90%);
+  bottom: 0;
   cursor: pointer;
   border-color: transparent;
 }

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -20,7 +20,7 @@ form {
   cursor: pointer;
   border-color: transparent;
 }
-.tile:focus-within {
+.tile:focus-within, label:focus-within, input[type=image]:focus {
   transform: scale(1.03);
   outline: 2px solid #003b80;
   outline-offset: 2px;

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -77,10 +77,10 @@
             </div>
           {% endfor %}
         </div>
-        <div class="notification warning margin-top-1em" role="alert">
-          <span>La signature du mandat se fait-elle à distance ? Si oui, cochez cette case</span>
-          <span>{{ form.is_remote }}</span>
-        </div>
+        <label for="{{ form.is_remote.id_for_label }}" class="notification warning margin-top-1em">
+            La signature du mandat se fait-elle à distance ? Si oui, cochez cette case
+            {{ form.is_remote }}
+        </label>
       </div>
       <div id="france_connection" class="tiles">
         <h2 class="step-title">Étape 3 : Connectez l'usager à FranceConnect</h2>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -46,7 +46,7 @@
               <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" />
               <label class="label-demarche" for="button-{{ value }}">
                 <img src="{{ label.icon }}" alt="Icon {{ label.titre }}" />
-                <h3>{{ label.titre }}</h3>
+                <strong>{{ label.titre }}</strong>
                 <p>
                   {{ label.description }}
                   {% if label.service_exemples %}
@@ -71,7 +71,7 @@
             <div id="{{ value }}" class="tile">
               <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree" />
               <label class="label-duree" for="button-{{ value }}">
-                <h3>{{ label.title }} <span class="duree-label-is-remote">à distance</span></h3>
+                <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
                 <span>{{ label.description }}</span>
               </label>
             </div>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -40,7 +40,8 @@
       {% csrf_token %}
       <div id="demarches" class="tiles">
         <h2>Étape 1 : Sélectionnez la ou les démarche(s)</h2>
-        <div id="demarches_list" class="grid">
+        <fieldset id="demarches_list" class="grid">
+          <legend class="sr-only">Sélectionnez la ou les démarche(s)</legend>
           {% for value, label in form.demarche.field.choices %}
             <div id="{{ value }}" class="tile">
               <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" />
@@ -62,11 +63,12 @@
               </label>
             </div>
           {% endfor %}
-        </div>
+        </fieldset>
       </div>
       <div id="duree" class="tiles">
         <h2 class="step-title">Étape 2 : Choisissez la durée du mandat</h2>
-        <div id="duree_list" class="grid">
+        <fieldset id="duree_list" class="grid">
+            <legend class="sr-only">Choisissez la durée du mandat</legend>
           {% for value, label in form.duree.field.choices %}
             <div id="{{ value }}" class="tile">
               <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree" />
@@ -76,7 +78,7 @@
               </label>
             </div>
           {% endfor %}
-        </div>
+        </fieldset>
         <label for="{{ form.is_remote.id_for_label }}" class="notification warning margin-top-1em">
             La signature du mandat se fait-elle à distance ? Si oui, cochez cette case
             {{ form.is_remote }}


### PR DESCRIPTION
## 🌮 Objectif

Rendre le formulaire de création plus accessible aux personnes aveugles

## 🔍 Implémentation

- Suppression du `visibility:hidden` sur les checkbox et les radio (masqués différemment pour rester utilisables)
- Accentuation visuelle du focus clavier
- Consolidation du HTML (`<fieldset>`, `<label for="truc">`…)

## 🏕 Amélioration continue

- changement des cases rondes (type radio) en cases carrées (types checkbox) là où c'est pertinent
- amélioration du contraste dans les étiquettes d'exemples de démarche

## 🖼️ Images

Exemple du début du formulaire : la case famille est cochée, social-santé aussi. Le focus clavier est sur social-santé.

<img width="701" alt="Capture d’écran 2021-01-18 à 13 05 43" src="https://user-images.githubusercontent.com/1035145/104913908-98e05980-598e-11eb-8fd5-a0c6c918e977.png">

Ici la case social-santé n'est plus cochée mais il y a toujours le focus clavier, bien visible : 

<img width="756" alt="Capture d’écran 2021-01-18 à 13 05 35" src="https://user-images.githubusercontent.com/1035145/104914005-c200ea00-598e-11eb-80cd-244b732b8cc2.png">

NB. On ne voit pas la bordure bleue au survol par la souris.