### PR TITLE
Modification des permissions pour les admin métiers

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -80,11 +80,11 @@ class VisibleToTechAdmin:
         return self.has_module_permission(request)
 
 
-class StaticDeviceStaffAdmin(VisibleToTechAdmin, StaticDeviceAdmin):
+class StaticDeviceStaffAdmin(VisibleToAdminMetier, StaticDeviceAdmin):
     pass
 
 
-class TOTPDeviceStaffAdmin(VisibleToTechAdmin, TOTPDeviceAdmin):
+class TOTPDeviceStaffAdmin(VisibleToAdminMetier, TOTPDeviceAdmin):
     pass
 
 
@@ -240,8 +240,8 @@ admin_site.register(Journal, JournalAdmin)
 admin_site.register(Connection, ConnectionAdmin)
 
 admin_site.register(MagicToken)
-admin_site.register(StaticDevice, StaticDeviceAdmin)
-admin_site.register(TOTPDevice, TOTPDeviceAdmin)
+admin_site.register(StaticDevice, StaticDeviceStaffAdmin)
+admin_site.register(TOTPDevice, TOTPDeviceStaffAdmin)
 
 # Also register the Django Celery Beat models
 admin_site.register(PeriodicTask, PeriodicTaskAdmin)

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -120,9 +120,9 @@ class VisibleToAdminMetierTests(TestCase):
 
 @tag("admin")
 class VisibilityAdminPageTests(TestCase):
-    only_by_atac_models = [StaticDevice, TOTPDevice, Mandat,
+    only_by_atac_models = [Mandat,
                            Usager, Connection, Journal]
-    amac_models = [Organisation, Aidant]
+    amac_models = [Organisation, Aidant, StaticDevice, TOTPDevice]
 
     def setUp(self):
         self.amac_user = AidantFactory(username="amac@email.com",


### PR DESCRIPTION
## 🌮 Objectif

Redonner aux admins métiers les droits sur la création des dispositif OTP

## 🔍 Implémentation

modification des classes gérant les droits par modèles dans l'admin

## 🏕 Amélioration continue



## ⚠️ Informations supplémentaires



## 🖼️ Images


