### PR TITLE
Refacto des tests de la révocation des autorisations

### DIFF
--- a/aidants_connect_web/tests/test_views/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant.py
@@ -88,41 +88,39 @@ class AutorisationCancelationConfirmPageTests(TestCase):
         self.our_aidant = AidantFactory(organisation=self.our_organisation)
         self.our_usager = UsagerFactory()
 
-        mandat_valid = MandatFactory(
+        valid_mandat = MandatFactory(
             organisation=self.our_organisation, usager=self.our_usager,
         )
-        self.autorisation_valid = AutorisationFactory(
-            mandat=mandat_valid, demarche="Revenus"
+        self.valid_autorisation = AutorisationFactory(
+            mandat=valid_mandat, demarche="Revenus"
         )
-        self.autorisation_revoked = AutorisationFactory(
-            mandat=mandat_valid, demarche="Papiers", revocation_date=timezone.now()
+        self.revoked_autorisation = AutorisationFactory(
+            mandat=valid_mandat, demarche="Papiers", revocation_date=timezone.now()
         )
 
-        mandat_expired = MandatFactory(
+        expired_mandat = MandatFactory(
             organisation=self.our_organisation,
             usager=self.our_usager,
             expiration_date=timezone.now() - timedelta(days=6),
         )
-        self.autorisation_expired = AutorisationFactory(
-            mandat=mandat_expired, demarche="Logement"
+        self.expired_autorisation = AutorisationFactory(
+            mandat=expired_mandat, demarche="Logement"
         )
 
         self.other_organisation = OrganisationFactory(name="Other Organisation")
         self.unrelated_usager = UsagerFactory()
 
-        mandat_other_org_with_unrelated_usager = MandatFactory(
-            organisation=self.other_organisation,
-            usager=self.unrelated_usager,
-            expiration_date=timezone.now() + timedelta(days=6),
+        unrelated_mandat = MandatFactory(
+            organisation=self.other_organisation, usager=self.unrelated_usager,
         )
-        self.autorisation_other_orga_with_unrelated_usager = AutorisationFactory(
-            mandat=mandat_other_org_with_unrelated_usager, demarche="Revenus"
+        self.unrelated_autorisation = AutorisationFactory(
+            mandat=unrelated_mandat, demarche="Revenus"
         )
 
         self.good_combo = {
             "usager": self.our_usager.id,
-            "mandat": self.autorisation_valid.mandat.id,
-            "autorisation": self.autorisation_valid.id,
+            "mandat": self.valid_autorisation.mandat.id,
+            "autorisation": self.valid_autorisation.id,
         }
 
     def url_for_autorisation_cancelation_confimation(self, data):
@@ -179,9 +177,7 @@ class AutorisationCancelationConfirmPageTests(TestCase):
         self.assertRedirects(response, url, fetch_redirect_response=False)
 
     def test_non_existing_autorisation_triggers_redirect(self):
-        non_existing_autorisation = (
-            self.autorisation_other_orga_with_unrelated_usager.id + 1
-        )
+        non_existing_autorisation = self.unrelated_autorisation.id + 1
 
         bad_combo = self.good_combo.copy()
         bad_combo["autorisation"] = non_existing_autorisation
@@ -191,15 +187,15 @@ class AutorisationCancelationConfirmPageTests(TestCase):
     def test_expired_autorisation_triggers_redirect(self):
 
         bad_combo = self.good_combo.copy()
-        bad_combo["mandat"] = self.autorisation_expired.mandat.id
-        bad_combo["autorisation"] = self.autorisation_expired.id
+        bad_combo["mandat"] = self.expired_autorisation.mandat.id
+        bad_combo["autorisation"] = self.expired_autorisation.id
 
         self.error_case_tester(bad_combo)
 
     def test_revoked_autorisation_triggers_redirect(self):
         bad_combo = self.good_combo.copy()
-        bad_combo["mandat"] = self.autorisation_revoked.mandat.id
-        bad_combo["autorisation"] = self.autorisation_revoked.id
+        bad_combo["mandat"] = self.revoked_autorisation.mandat.id
+        bad_combo["autorisation"] = self.revoked_autorisation.id
 
         self.error_case_tester(bad_combo)
 
@@ -214,12 +210,8 @@ class AutorisationCancelationConfirmPageTests(TestCase):
     def test_wrong_usager_autorisation_triggers_redirect(self):
 
         bad_combo = self.good_combo.copy()
-        bad_combo[
-            "mandat"
-        ] = self.autorisation_other_orga_with_unrelated_usager.mandat.id
-        bad_combo[
-            "autorisation"
-        ] = self.autorisation_other_orga_with_unrelated_usager.id
+        bad_combo["mandat"] = self.unrelated_autorisation.mandat.id
+        bad_combo["autorisation"] = self.unrelated_autorisation.id
 
         self.error_case_tester(bad_combo)
 
@@ -227,10 +219,6 @@ class AutorisationCancelationConfirmPageTests(TestCase):
 
         bad_combo = self.good_combo.copy()
         bad_combo["usager"] = self.unrelated_usager.id
-        bad_combo[
-            "mandat"
-        ] = self.autorisation_other_orga_with_unrelated_usager.mandat.id
-        bad_combo[
-            "autorisation"
-        ] = self.autorisation_other_orga_with_unrelated_usager.id
+        bad_combo["mandat"] = self.unrelated_autorisation.mandat.id
+        bad_combo["autorisation"] = self.unrelated_autorisation.id
         self.error_case_tester(bad_combo)

--- a/aidants_connect_web/tests/test_views/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant.py
@@ -119,30 +119,26 @@ class AutorisationCancelationConfirmPageTests(TestCase):
             mandat=mandat_other_org_with_unrelated_usager, demarche="Revenus"
         )
 
+    def url_for_autorisation_cancelation_confimation(self, data):
+        return (
+            f"/usagers/{data['usager']}/mandats/{data['mandat']}"
+            f"/autorisations/{data['autorisation']}/cancel_confirm"
+        )
+
     def test_url_triggers_the_correct_view(self):
         found = resolve(
-            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
-            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm"  # noqa
+            self.url_for_autorisation_cancelation_confimation(self.good_combo)
         )
         self.assertEqual(found.func, usagers.confirm_autorisation_cancelation)
 
-        response = self.client.get(
-            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
-            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm"
-        )
-        self.assertTemplateUsed(
-            response, "aidants_connect_web/confirm_autorisation_cancelation.html",
-        )
     def test_get_triggers_the_correct_template(self):
         self.client.force_login(self.our_aidant)
 
-        response_incorrect_confirm_form = self.client.post(
-            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
-            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm",
-            data={},
+        response_to_get_request = self.client.get(
+            self.url_for_autorisation_cancelation_confimation(self.good_combo)
         )
         self.assertTemplateUsed(
-            response_incorrect_confirm_form,
+            response_to_get_request,
             "aidants_connect_web/confirm_autorisation_cancelation.html",
         )
 
@@ -150,8 +146,7 @@ class AutorisationCancelationConfirmPageTests(TestCase):
         self.client.force_login(self.our_aidant)
 
         response_correct_confirm_form = self.client.post(
-            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
-            f"/autorisations/{self.autorisation_1_1.id}/cancel_confirm",
+            self.url_for_autorisation_cancelation_confimation(self.good_combo),
             data={"csrfmiddlewaretoken": "coucou"},
         )
         url = f"/usagers/{self.our_usager.id}/"
@@ -159,14 +154,15 @@ class AutorisationCancelationConfirmPageTests(TestCase):
             response_correct_confirm_form, url, fetch_redirect_response=False
         )
 
-        response = self.client.get(
-            f"/usagers/{self.usager_1.id}/mandats/{self.autorisation_1_1.mandat.id}"
-            f"/autorisations/{self.autorisation_3_1.id + 1}/cancel_confirm"
     def test_incomplete_post_triggers_error(self):
         self.client.force_login(self.our_aidant)
+        response_incorrect_confirm_form = self.client.post(
+            self.url_for_autorisation_cancelation_confimation(self.good_combo), data={},
         )
-        url = "/espace-aidant/"
-        self.assertRedirects(response, url, fetch_redirect_response=False)
+        self.assertTemplateUsed(
+            response_incorrect_confirm_form,
+            "aidants_connect_web/confirm_autorisation_cancelation.html",
+        )
 
     def test_expired_autorisation_triggers_redirect(self):
         self.client.force_login(self.aidant_1)


### PR DESCRIPTION
## 🌮 Objectif
Rendre plus lisible les tests sur la révocation d'une autorisation.

## 🔍 Implémentation

- Partir d'un cas nominal (`our_`) qui lie une Organisation, un aidant, un usager, un mandat valide et une autorisation valide.
- Proposer des variation(`revoked_`, `unrelated_`) pour créer des cas de tests
- Refacto les tests d'erreur grâce à la fonction `error_case_tester` pour éviter la répétition de code.

## ⚠️ Informations supplémentaires

**Cette PR est basée sur #280** Il faudra la _rebase_ sur `main` après que #280 ait été mergée. 

