### PR TITLE
Simplifie la signature de la vue de révocation des mandats

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -69,7 +69,7 @@
                     </td>
                     <td>
                       {% if not autorisation.revocation_date %}
-                        <a href="{% url 'confirm_autorisation_cancelation' usager_id=usager.id mandat_id=mandat.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right">
+                        <a href="{% url 'confirm_autorisation_cancelation' usager_id=usager.id autorisation_id=autorisation.id %}" class="button-outline warning small float-right">
                           Révoquer l’autorisation <span aria-hidden="true">&nbsp;🗑️</span>
                         </a>
                       {% endif %}

--- a/aidants_connect_web/tests/test_views/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant.py
@@ -5,6 +5,8 @@ from django.test.client import Client
 from django.urls import resolve
 from django.utils import timezone
 
+from aidants_connect_web.models import Autorisation
+
 from aidants_connect_web.tests.factories import (
     OrganisationFactory,
     AidantFactory,
@@ -119,13 +121,12 @@ class AutorisationCancelationConfirmPageTests(TestCase):
 
         self.good_combo = {
             "usager": self.our_usager.id,
-            "mandat": self.valid_autorisation.mandat.id,
             "autorisation": self.valid_autorisation.id,
         }
 
     def url_for_autorisation_cancelation_confimation(self, data):
         return (
-            f"/usagers/{data['usager']}/mandats/{data['mandat']}"
+            f"/usagers/{data['usager']}"
             f"/autorisations/{data['autorisation']}/cancel_confirm"
         )
 
@@ -177,48 +178,54 @@ class AutorisationCancelationConfirmPageTests(TestCase):
         self.assertRedirects(response, url, fetch_redirect_response=False)
 
     def test_non_existing_autorisation_triggers_redirect(self):
-        non_existing_autorisation = self.unrelated_autorisation.id + 1
+        non_existing_autorisation = Autorisation.objects.last().id + 1
 
-        bad_combo = self.good_combo.copy()
-        bad_combo["autorisation"] = non_existing_autorisation
+        bad_combo_for_our_aidant = {
+            "usager": self.our_usager.id,
+            "autorisation": non_existing_autorisation,
+        }
 
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)
 
     def test_expired_autorisation_triggers_redirect(self):
+        bad_combo_for_our_aidant = {
+            "usager": self.our_usager.id,
+            "autorisation": self.expired_autorisation.id,
+        }
 
-        bad_combo = self.good_combo.copy()
-        bad_combo["mandat"] = self.expired_autorisation.mandat.id
-        bad_combo["autorisation"] = self.expired_autorisation.id
-
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)
 
     def test_revoked_autorisation_triggers_redirect(self):
-        bad_combo = self.good_combo.copy()
-        bad_combo["mandat"] = self.revoked_autorisation.mandat.id
-        bad_combo["autorisation"] = self.revoked_autorisation.id
+        bad_combo_for_our_aidant = {
+            "usager": self.our_usager.id,
+            "autorisation": self.revoked_autorisation.id,
+        }
 
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)
 
     def test_non_existing_usager_triggers_redirect(self):
         non_existing_usager = self.unrelated_usager.id + 1
 
-        bad_combo = self.good_combo.copy()
-        bad_combo["usager"] = non_existing_usager
+        bad_combo_for_our_aidant = {
+            "usager": non_existing_usager,
+            "autorisation": self.valid_autorisation.id,
+        }
 
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)
 
     def test_wrong_usager_autorisation_triggers_redirect(self):
 
-        bad_combo = self.good_combo.copy()
-        bad_combo["mandat"] = self.unrelated_autorisation.mandat.id
-        bad_combo["autorisation"] = self.unrelated_autorisation.id
+        bad_combo_for_our_aidant = {
+            "usager": self.our_usager.id,
+            "autorisation": self.unrelated_autorisation.id,
+        }
 
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)
 
     def test_wrong_aidant_autorisation_triggers_redirect(self):
+        bad_combo_for_our_aidant = {
+            "usager": self.unrelated_usager.id,
+            "autorisation": self.unrelated_autorisation.id,
+        }
 
-        bad_combo = self.good_combo.copy()
-        bad_combo["usager"] = self.unrelated_usager.id
-        bad_combo["mandat"] = self.unrelated_autorisation.mandat.id
-        bad_combo["autorisation"] = self.unrelated_autorisation.id
-        self.error_case_tester(bad_combo)
+        self.error_case_tester(bad_combo_for_our_aidant)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
     path("usagers/", usagers.usagers_index, name="usagers"),
     path("usagers/<int:usager_id>/", usagers.usager_details, name="usager_details"),
     path(
-        "usagers/<int:usager_id>/mandats/<int:mandat_id>/autorisations/<int:autorisation_id>/cancel_confirm",  # noqa
+        "usagers/<int:usager_id>/autorisations/<int:autorisation_id>/cancel_confirm",  # noqa
         usagers.confirm_autorisation_cancelation,
         name="confirm_autorisation_cancelation",
     ),

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -61,7 +61,7 @@ def usager_details(request, usager_id):
 
 @login_required
 @activity_required
-def confirm_autorisation_cancelation(request, usager_id, mandat_id, autorisation_id):
+def confirm_autorisation_cancelation(request, usager_id, autorisation_id):
     aidant = request.user
 
     usager = aidant.get_usager(usager_id)


### PR DESCRIPTION
## 🌮 Objectif

Ne pas avoir d'éléments inutiles dans les signatures de vue, fonctions ou méthode

## 🔍 Implémentation

- Avoir 2 arguments plutôt que 3 dans la signature de la vue `confirm_autorisation_cancelation` : l'`usager` et l'`autorisation`. 

## ⚠️ Informations supplémentaires

**Cette PR est basée sur #281** Quand #281 sera mergée dans main, on pourra rebase et merge celle-ci
