### PR TITLE
Supprimer la navbar sur l'ecran de login d'admin

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -34,6 +34,7 @@ from aidants_connect_web.models import (
 )
 
 admin_site = OTPAdminSite(OTPAdminSite.name)
+admin_site.login_template = "aidants_connect_web/admin/login.html"
 
 admin_site.register(HoneypotLoginAttempt, HoneypotLoginAttemptAdmin)
 

--- a/aidants_connect_web/templates/aidants_connect_web/admin/login.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/login.html
@@ -1,0 +1,4 @@
+{% extends "otp/admin111/login.html" %}
+
+
+{% block nav-sidebar %}{% endblock %}

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -35,6 +35,13 @@ class LoginAttemptAdminPageTests(TestCase):
         admin_url = f"/{admin}admin_honeypot/loginattempt/{login_attempt_id}/change/"
         self.assertEqual(admin_url, path)
 
+    def test_sidebar_is_not_in_login_admin_page(self):
+        admin = settings.ADMIN_URL
+        amac_client = Client()
+        response = amac_client.get(f"/{admin}login", follow=True)
+        self.assertTemplateUsed(response, "aidants_connect_web/admin/login.html")
+        self.assertNotContains(response, "nav-sidebar")
+
 
 @tag("admin")
 class VisibleToTechAdminTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Supprimer la navbar inutile  et dérangeante sur l'ecran de login d'admin

## 🔍 Implémentation

Le template pour l’écran de login fournit par django-otdp est un template datant de l'époque django 1.11.  Ce template ne supprime pas la navbar fournit par django, vu que la dite navbar n'était pas présente à l'époque django 1.11.  Elle apparaît donc alors qu'elle ne devrait pas. 

Cette PR proposer une nouvelle version de l'écran de login qui vide le block de navbar

## 🏕 Amélioration continue



## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

### Ancienne page de login 

![Screenshot_2021-02-02 Connexion Site d’administration de Django](https://user-images.githubusercontent.com/354064/106570434-264aae80-6536-11eb-8c87-2cbcb5067b7c.png)

![Screenshot_2021-02-02 Connexion Site d’administration de Django(1)](https://user-images.githubusercontent.com/354064/106570444-2a76cc00-6536-11eb-90d6-40d09bb2ab3f.png)

### Page de login proposée par la PR 

![Screenshot_2021-02-02 Connexion Site d’administration de Django(2)](https://user-images.githubusercontent.com/354064/106570474-35c9f780-6536-11eb-856b-240b848949e4.png)

