### PR TITLE
Ajoute les liens d'évitement

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,13 @@ Par défaut, les tests d'intégration sont lancés en mode _headless_, c'est-à-
 
 Dans de rares cas (comportement observé à ce jour sur une seule machine de dev), les tests d'intégration échouent car _la première connexion_ à une URL via l'API Selenium plante de manière inexpliquée. Un contournement empirique a été mis en place ; si vous rencontrez ce problème vous pouvez l'activer en passant à `True` la variable d'environnement `BYPASS_FIRST_LIVESERVER_CONNECTION` dans votre fichier `.env`.
 
+Astuce : la plupart des cas de tests portent une directive `@tag` pour leur associer des tags décrivant des fonctionnalités ou des caractéristiques des tests. Par exemple, `functional` pour les tests fonctionnels, `create_mandat` pour ce qui implique une création de mandat, etc.
+Cela vous permet de lancer seulement certains tests, grâce à l'option --tag. Par exemple, pour lancer les tests portant le tag `parrot` :
+
+```
+python manage.py test --tag parrot
+```
+
 ### Lancer l'application
 
 Pour lancer l'application sur le port `3000` :

--- a/aidants_connect_web/static/css/main.css
+++ b/aidants_connect_web/static/css/main.css
@@ -284,7 +284,31 @@ input:focus, select:focus, textarea:focus {
     border-color: #0061c4;
     transition: border-color .2s ease-out;
 }
+:focus {
+  outline: 2px solid var(--theme-border-active);
+  outline-offset: 2px;
+}
 .notification a[href] {
   color: #000;
   color: var(--theme-dark-text);
+}
+
+.skip-links {
+  background: var(--theme-background-grey);
+  transition: transform 0.3s;
+  padding: .7em 1em .5em;
+  font-size: .9em;
+  position: absolute;
+  transform: translateY(-100%);
+}
+.skip-links:focus-within {
+  transform: translateY(0);
+  position: relative;
+}
+.skip-links a {
+  color: var(--theme-dark-text);
+  margin-right: 1em;
+}
+#top_menu {
+  padding: 3em 0; /* used to have top_menu visible on screen just after corresponding skiplink has been followed */
 }

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -1,5 +1,5 @@
 {% load static %}
-<footer class="footer" role="contentinfo">
+<footer id="footer" class="footer" role="contentinfo">
   <div class="container">
     <div class="footer__logo">
     <a href="https://agence-cohesion-territoires.gouv.fr">

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -84,7 +84,7 @@
     {% include 'layouts/nav.html' %}
   {% endblock nav %}
 
-  <main>
+  <main id="main">
   {% block content %}
   {% endblock %}
   </main>

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -1,4 +1,9 @@
 {% load static %}
+<nav class="skip-links nav__links">
+  <a href="#main">Aller au contenu principal</a>
+  <a href="#top_menu">Aller au menu</a>
+  <a href="#footer">Aller au pied de page</a>
+</nav>
 <header class="navbar">
   <div class="navbar__container">
     <a class="navbar__home" href="{% url 'home_page' %}">
@@ -6,7 +11,7 @@
       <img class="navbar__logo" src="{% static 'images/aidants-connect_logo.png' %}"  alt="Aidants Connect" />
     </a>
     <nav role="navigation">
-      <ul class="nav__links">
+      <ul class="nav__links" id="top_menu">
         {% with view_name=request.resolver_match.view_name %}
           {% if request.user.is_authenticated %}
             <li class="nav__item">

--- a/aidants_connect_web/tests/test_functional/test_a11y.py
+++ b/aidants_connect_web/tests/test_functional/test_a11y.py
@@ -1,0 +1,25 @@
+from django.test import tag
+
+from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
+from selenium.common.exceptions import NoSuchElementException
+
+
+@tag("functional", "a11y")  # nb: a11y stands for "accessibility"
+class Accessibility(FunctionalTestCase):
+    def test_skiplinks_are_valid(self):
+        self.open_live_url("/")
+
+        skip_links = self.selenium.find_elements_by_css_selector(".skip-links a[href]")
+
+        self.assertGreaterEqual(len(skip_links), 1, "No skip links were found")
+
+        for skip_link in skip_links:
+            url = skip_link.get_attribute("href")
+            id = url.split("#")[1]
+            try:
+                self.selenium.find_element_by_id(id)
+            except NoSuchElementException:
+                self.fail(
+                    f'Skiplink "{skip_link.get_attribute("textContent")}"'
+                    f"points to non-existing element #{id}"
+                )


### PR DESCRIPTION
## 🌮 Objectif

Ajout des liens d'évitement (_skip links_) pour faciliter la navigation au clavier et par lecteurs d'écran.

## 🔍 Implémentation

- Comme sur [le site du design numérique de l'état](https://design.numerique.gouv.fr/accessibilite-numerique/) on fait le choix de n'afficher ces liens d'évitement que lorsque l'un des liens porte le focus. C'est aussi ce qui est recommandé dans le futur design system de l'état.
- J'ai ajouté un petit test selenium qui vérifie qu'ils sont là et qu'on ne supprime pas les ID dont ils ont besoin pour fonctionner.

## 🏕 Amélioration continue

Je n'arrivais pas à voir où était mon focus quand je testais, alors j'ai supposé que d'autres plus myopes que moi auraient aussi du mal, donc j'ai aussi récupéré le styling du focus clavier de design.numerique.gouv.fr.

## ⚠️ Informations supplémentaires

À présent il y a un gros contour bleu qui apparaît sur les liens quand on clique dessus. Je trouvais ça surprenant au début mais en fait c'est assez courant (cf gouvernement.fr ou gov.co.uk) donc je pense que l'habitude sera vite prise.

## 🖼️ Images

![Les liens d'évitement en haut de page](https://user-images.githubusercontent.com/1035145/106579756-56e41580-6541-11eb-8e49-6f68dfaac38c.png)

