### PR TITLE
delete link formulaire d'habilitation

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -18,8 +18,7 @@
       <h2>Comment se passe l’habilitation ?</h2>
       <ol>
         <li>
-          Le responsable de structure complète <a href="https://datapass.api.gouv.fr/aidants-connect">le formulaire
-          d’habilitation Aidants Connect.</a>.
+          Le responsable de structure complète le formulaire d’habilitation Aidants Connect qui sera mis en ligne très prochainement.
         </li>
         <li>Aidants Connect valide la demande.</li>
         <li>Dans un délai de deux mois, les aidants suivent gratuitement une formation en deux parties :


### PR DESCRIPTION
## 🌮 Objectif

Supprimer le lien vers le formulaire d'habilitation. On le mettra en ligne à nouveau après la campagne de communication de Cédric O. 

## 🔍 Implémentation

Suppression du lien HTML

## 🖼️ Images

Avant : 
![image](https://user-images.githubusercontent.com/49979357/107251862-16026a00-6a35-11eb-9c8b-bb0dad0b5ecd.png)

![image](https://user-images.githubusercontent.com/49979357/107252225-6aa5e500-6a35-11eb-95c4-aca9987c8597.png)


