### PR TITLE
delete link formulaire habilitation home page

### DIFF
--- a/aidants_connect_web/templates/public_website/home_page.html
+++ b/aidants_connect_web/templates/public_website/home_page.html
@@ -8,8 +8,7 @@
 
 {% block content %}
   <div class="notification full-width" role="alert">
-    Vous êtes une structure qui souhaite utiliser Aidants Connect ? Nous vous invitons à remplir
-    <a href="{% url 'habilitation' %}">notre formulaire d'habilitation</a>.
+    Vous êtes une structure qui souhaite utiliser Aidants Connect ? Notre formulaire d'habilitation sera très prochainement mis en ligne !
   </div>
 {% if messages %}
   {% for message in messages %}


### PR DESCRIPTION
## 🌮 Objectif

Suppression du lien vers le formulaire d'habilitation présent sur la home page. 

## 🔍 Implémentation

Suppression du lien HTML sur la home page.

## 🖼️ Images

Avant : 
![image](https://user-images.githubusercontent.com/49979357/107254174-582cab00-6a37-11eb-9cca-0e0a7cab95f5.png)

Après : 
![image](https://user-images.githubusercontent.com/49979357/107254122-4945f880-6a37-11eb-8828-fe8b6f56018d.png)
