### PR TITLE
Facilite la validation de l'usager

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -166,7 +166,6 @@ class RecapMandatForm(OTPForm, forms.Form):
     personal_data = forms.BooleanField(
         label="J’autorise mon aidant à utiliser mes données à caractère personnel."
     )
-    brief = forms.BooleanField(label="brief")
 
 
 class DatapassForm(forms.Form):

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -60,9 +60,9 @@
               pour conclure le mandat et utiliser ses données à caractère personnel. 
             </label>
           </div>
-        <div><strong>Rappels</strong></div>
-        <div>🤝 Le mandat est révocable à tout moment par les deux parties.</div>
-        <div>🗣 L'usager a des droits d'accès, de rectification et de suppression sur ses données.</div>
+        <h3>Rappels</h3>
+        <p>🤝 Le mandat est révocable à tout moment par les deux parties.</p>
+        <p>🗣 L'usager a des droits d'accès, de rectification et de suppression sur ses données.</p>
         </div>
         <h2>Validation de l'aidant</h2>
         <div class="panel form__group">

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -50,21 +50,19 @@
             <input type="checkbox" id="id_personal_data" name="personal_data" required />
             <label class="label-inline" for="id_personal_data">
               Avoir communiqué à <strong>{{ usager }}</strong> les informations concernant l’objet de l’intervention,
-              la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données (accès, rectification, suppression…)
-            </label>
-          </div>
-          <div class="checkbox__group">
-            <input type="checkbox" id="id_brief" name="brief" required />
-            <label class="label-inline" for="id_brief">
+              la raison pour laquelle ses informations sont collectées et leur utilité ; les droits sur ses données 
+              ET avoir conservé son consentement écrit 
               {% if is_remote %}
-                Avoir obtenu et conservé un consentement écrit (capture d’écran d’email, SMS…) de la part de <strong> {{ usager }}</strong>
-                pour conclure le mandat Aidant Connect <strong>à distance</strong> et utiliser ses données à caractère personnel.
+              (signature du mandat après impression) 
               {% else %}
-                Avoir obtenu et conservé un consentement écrit (signature du mandat après impression) de la part de <strong> {{ usager }}</strong>
-                pour conclure le mandat Aidant Connect et utiliser ses données à caractère personnel.
+              (capture d'écran email, SMS...)
               {% endif %}
+              pour conclure le mandat et utiliser ses données à caractère personnel. 
             </label>
           </div>
+        <div><strong>Rappels</strong></div>
+        <div>🤝 Le mandat est révocable à tout moment par les deux parties.</div>
+        <div>🗣 L'usager a des droits d'accès, de rectification et de suppression sur ses données.</div>
         </div>
         <h2>Validation de l'aidant</h2>
         <div class="panel form__group">

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -97,10 +97,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         id_personal_data = checkboxes[1]
         self.assertEqual(id_personal_data.get_attribute("id"), "id_personal_data")
         id_personal_data.click()
-        id_brief = checkboxes[2]
-        self.assertEqual(id_brief.get_attribute("id"), "id_brief")
-        id_brief.click()
-        id_otp_token = checkboxes[3]
+        id_otp_token = checkboxes[2]
         self.assertEqual(id_otp_token.get_attribute("id"), "id_otp_token")
         id_otp_token.send_keys("123455")
         submit_button = checkboxes[-1]


### PR DESCRIPTION
## 🌮 Objectif

_Facilite le parcours aidant lors de la création du mandat, et notamment sur la partie "consentement" de l'usager_
_Rend le texte de la coche plus lisible_

## 🔍 Implémentation

- Mutualise les deux coches en une seule coche, afin de permettre en un seul clic la validation de l'aidant
- Suppression de la mention "obtenu" concernant le consentement car la conservation du consentement écrit implique l'obtention du consentement
- Intégration du texte "(accès, rectification, suppression)" en rappels

## 🖼️ Images

Avant - pour le mandat en présentiel

L'usager (ou l'aidant) coche deux cases afin d'officialiser la validation de l'usager.
![image](https://user-images.githubusercontent.com/72392344/108192099-204af500-7114-11eb-94d0-3f2aab8f250f.png)

Après - pour le mandat en présentiel

L'usager (ou l'aidant) coche une case afin d'officialiser la validation de l'usager.
![image](https://user-images.githubusercontent.com/72392344/108192243-538d8400-7114-11eb-8bf8-c7ac9746b4ad.png)

Avant - pour le mandat à distance 

L'aidant coche deux cases afin d'officialiser la validation de l'usager.
![image](https://user-images.githubusercontent.com/72392344/108192673-d9113400-7114-11eb-922e-6382dee66ab8.png)

Après - pour le mandat à distance 

L'aidant coche une case afin d'officialiser la validation de l'usager.
![image](https://user-images.githubusercontent.com/72392344/108192744-f0e8b800-7114-11eb-8b65-0de2d46cac5a.png)
