### PR TITLE
Sauvegarder le nom d'usage lorsqu'un nouvel usager est FranceConnecté

### DIFF
--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -296,6 +296,7 @@ class GetUserInfoTests(TestCase):
 
         self.assertEqual(usager.given_name, "Fabrice")
         self.assertEqual(usager.email, "test@test.com")
+        self.assertEqual(usager.preferred_username, "TROIS")
         self.assertIsNone(error)
 
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -36,6 +36,7 @@ def fc_authorize(request):
         "birthplace",
         "given_name",
         "family_name",
+        "preferred_username",
         "birthcountry",
     ]
 
@@ -165,6 +166,7 @@ def get_user_info(connection: Connection) -> tuple:
             usager = Usager.objects.create(
                 given_name=user_info.get("given_name"),
                 family_name=user_info.get("family_name"),
+                preferred_username=user_info.get("preferred_username"),
                 birthdate=user_info.get("birthdate"),
                 gender=user_info.get("gender"),
                 birthplace=user_info.get("birthplace"),


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir afficher le nom d'usage lorsqu'il est fourni par France Connect

## 🔍 Implémentation

- Modification de FC_AS_FS pour demander et sauvegarder le nom d'usage

## ⚠️ Informations supplémentaires

Les tests vérifiaient déjà que les modèles se comportaient bien avec un nom d'usage.

