### PR TITLE
Utiliser l'url d'attente de django-magicauth dans l'email envoyé pour la connexion par token

### DIFF
--- a/aidants_connect_web/templates/login/email_template.html
+++ b/aidants_connect_web/templates/login/email_template.html
@@ -309,7 +309,7 @@
                                 <table border="0" cellpadding="0" cellspacing="0">
                                   <tbody>
                                     <tr>
-                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_url|urlencode }}">Connexion</a> </td>
+                                      <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}">Connexion</a> </td>
                                     </tr>
                                   </tbody>
                                 </table>

--- a/aidants_connect_web/templates/login/email_template.txt
+++ b/aidants_connect_web/templates/login/email_template.txt
@@ -1,6 +1,6 @@
 Bonjour {{ user.first_name }} {{ user.last_name }},
 
-Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion:  https://{{ site.domain }}{% url 'magicauth-validate-token' token.key %}?next={{ next_url|urlencode }}
+Pour accéder à {{ site.domain }}, vous avez juste à cliquer sur ce lien de connexion :  https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}
 
 Ce lien n'est valable que {{ TOKEN_DURATION_MINUTES }} minutes. Il est à usage unique.
 

--- a/aidants_connect_web/tests/test_functional/utilities.py
+++ b/aidants_connect_web/tests/test_functional/utilities.py
@@ -17,4 +17,5 @@ def login_aidant(self):
     line_containing_magic_link = token_email.split("\n")[2]
     magic_link_https = line_containing_magic_link.split()[-1]
     magic_link_http = magic_link_https.replace("https", "http", 1)
-    self.selenium.get(magic_link_http)
+    magic_link_no_wait = magic_link_http.replace("chargement/code", "code", 1)
+    self.selenium.get(magic_link_no_wait)


### PR DESCRIPTION
## 🌮 Objectif

On peut éviter que les clients emails invalident le token de connexion en cliquant en avance sur le lien fourni par l'email. on utilise l'url d''attente fourni par django-magicauth pour éviter cela.

## 🔍 Implémentation

- modification des templates html et txt des emails de connexion pour qu'ils utilisent l'url d'attente
- modification des tests pour passer outre l'url d'attente.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
