### PR TITLE
Changer le template d'attente de magicauth

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -330,6 +330,7 @@ CSP_SCRIPT_SRC = (
     "'sha256-FUfFEwUd+ObSebyGDfkxyV7KwtyvBBwsE/VxIOfPD68='",  # tabbed_admin
     "'sha256-dzE1fiHF13yOIlSQf8CYbmucPoYAOHwQ70Y3OO70o+E='",  # main.html
     "'sha256-qtDLNBeXbQEZ6BoCPDfxDpo3OOJsnlVc/NGAMBmfHq0='",  # new_mandat.html
+    "'sha256-ARvyo8AJ91wUvPfVqP2FfHuIHZJN3xaLI7Vgj2tQx18='",  # wait.html
 )
 CSP_STYLE_SRC = ("'self'",)
 CSP_OBJECT_SRC = ("'none'",)

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -283,6 +283,7 @@ MAGICAUTH_LOGIN_VIEW_TEMPLATE = "login/login.html"
 MAGICAUTH_EMAIL_SENT_VIEW_TEMPLATE = "login/email_sent.html"
 MAGICAUTH_EMAIL_HTML_TEMPLATE = "login/email_template.html"
 MAGICAUTH_EMAIL_TEXT_TEMPLATE = "login/email_template.txt"
+MAGICAUTH_WAIT_VIEW_TEMPLATE = "login/wait.html"
 MAGICAUTH_ENABLE_2FA = True
 
 # https://github.com/betagouv/django-magicauth/blob/8a8143388bb15fad2823528201e22a31817da243/magicauth/settings.py#L54  # noqa

--- a/aidants_connect_web/templates/login/wait.html
+++ b/aidants_connect_web/templates/login/wait.html
@@ -1,15 +1,25 @@
+{% load static %}
 <!doctype html>
 <html lang="fr" dir="ltr">
 <head>
   <title>Aidants Connect - Connexion en cours</title>
+  <meta charset="utf-8">
+  <link href="{% static 'css/template.min.css' %}" rel="stylesheet">
 </head>
 <body>
-<h1>Connexion en cours…</h1>
-<p>Veuillez patienter quelques instants.</p>
-<p>Si rien ne se passe, veuillez cliquer sur ce bouton :</p>
-<a id="connect_me" href="{{ next_step_url }}">Se connecter</a>
+<div class="section container">
+  <div class="navbar__home">
+      <img class="navbar__gouvfr" src="{% static 'images/Marianne_logo_1120.png' %}" alt="" />
+      <img class="navbar__logo" src="{% static 'images/aidants-connect_logo.png' %}"  alt="Aidants Connect" />
+  </div>
+  <h1>Connexion en cours…</h1>
+  <p>Veuillez patienter quelques instants.</p>
+  <p>Si rien ne se passe d'ici {{ WAIT_SECONDS }} seconde{{ WAIT_SECONDS|pluralize }}, veuillez cliquer sur ce bouton :</p>
+  <a class="button" id="connect_me" href="{{ next_step_url }}">Se connecter</a>
+</div>
+<input type="hidden" id="wait_time" value="{{ WAIT_SECONDS }}">
 <script>
-    var waitSeconds = {{ WAIT_SECONDS }};
+    var waitSeconds = parseInt(document.getElementById('wait_time').value);
     setTimeout(function () {
         url = document.getElementById('connect_me').href;
         window.location.replace(url);

--- a/aidants_connect_web/templates/login/wait.html
+++ b/aidants_connect_web/templates/login/wait.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="fr" dir="ltr">
+<head>
+  <title>Aidants Connect - Connexion en cours</title>
+</head>
+<body>
+<h1>Connexion en cours…</h1>
+<p>Veuillez patienter quelques instants.</p>
+<p>Si rien ne se passe, veuillez cliquer sur ce bouton :</p>
+<a id="connect_me" href="{{ next_step_url }}">Se connecter</a>
+<script>
+    var waitSeconds = {{ WAIT_SECONDS }};
+    setTimeout(function () {
+        url = document.getElementById('connect_me').href;
+        window.location.replace(url);
+    }, waitSeconds * 1000);
+</script>
+</body>
+</html>

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -1,0 +1,42 @@
+from django.test import tag
+
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+)
+from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
+from django.core import mail
+
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+@tag("functional")
+class CancelAutorisationTests(FunctionalTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.aidant_thierry = AidantFactory()
+        device = cls.aidant_thierry.staticdevice_set.create(id=cls.aidant_thierry.id)
+        device.token_set.create(token="123456")
+        super().setUpClass()
+
+    def test_aidant_can_login(self):
+        self.open_live_url("/accounts/login/")
+        login_field = self.selenium.find_element_by_id("id_email")
+        login_field.send_keys("thierry@thierry.com")
+        otp_field = self.selenium.find_element_by_id("id_otp_token")
+        otp_field.send_keys("123456")
+        submit_button = self.selenium.find_element_by_xpath("//button")
+        submit_button.click()
+        email_sent_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(
+            email_sent_title, "Un email vous a été envoyé pour vous connecter."
+        )
+        self.assertEqual(len(mail.outbox), 1)
+        token_email = mail.outbox[0].body
+        line_containing_magic_link = token_email.split("\n")[2]
+        magic_link_https = line_containing_magic_link.split()[-1]
+        magic_link_http = magic_link_https.replace("https", "http", 1)
+        self.selenium.get(magic_link_http)
+        WebDriverWait(self.selenium, 5).until(
+            lambda selenium: "chargement" not in selenium.current_url,
+            message="The magicauth wait JavaScript did not work - check CSP compliance",
+        )


### PR DESCRIPTION
## 🌮 Objectif

Faire fonctionner le "lien d'attente" Magicauth, cassé car il n'a pas été ajouté à la CSP (content security policy).

## 🔍 Implémentation

- Il faut un JS qui ne dépend pas du contexte utilisateur, afin de pouvoir mettre son hash dans la CSP : 
  - on met un lien standard (a href) que le JS va suivre au bout de x secondes ;
  - on cherche dans un input caché la durée d'attente plutôt que la mettre en dur dans le JS.
- La présence du lien permet aussi à l'internaute de suivre le lien même si le JS devait de nouveau casser à l'avenir.
- On ajoute un test selenium qui vérifie que le JS est bien exécuté (sur mon poste, selenium semble se conformer à la CSP).

## 🖼️ Images

![Aperçu de l'écran de redirection](https://user-images.githubusercontent.com/1035145/108974241-8f30cc80-7685-11eb-8b1a-b4ecb73bc484.png)

