### PR TITLE
Annulation de la sauvegarde du nom d'usage

### DIFF
--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -296,7 +296,6 @@ class GetUserInfoTests(TestCase):
 
         self.assertEqual(usager.given_name, "Fabrice")
         self.assertEqual(usager.email, "test@test.com")
-        self.assertEqual(usager.preferred_username, "TROIS")
         self.assertIsNone(error)
 
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -36,7 +36,6 @@ def fc_authorize(request):
         "birthplace",
         "given_name",
         "family_name",
-        "preferred_username",
         "birthcountry",
     ]
 
@@ -166,7 +165,6 @@ def get_user_info(connection: Connection) -> tuple:
             usager = Usager.objects.create(
                 given_name=user_info.get("given_name"),
                 family_name=user_info.get("family_name"),
-                preferred_username=user_info.get("preferred_username"),
                 birthdate=user_info.get("birthdate"),
                 gender=user_info.get("gender"),
                 birthplace=user_info.get("birthplace"),


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir mettre nos dernières modifications en prod sans attendre l'action que nous attendons de la part des équipes FranceConnect.

## 🔍 Implémentation

Revert de la PR #299 (demander le nom d'usage à FC lors de la première FranceConnexion).
