### PR TITLE
Correction de coquilles

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -144,7 +144,10 @@ class OTPForm(forms.Form):
         max_length=6,
         min_length=6,
         validators=[RegexValidator(r"^\d{6}$")],
-        label="Entrez le code à 6 chiffres généré par votre téléphone",
+        label=(
+            "Entrez le code à 6 chiffres généré par votre téléphone "
+            "ou votre carte OTP"
+        ),
         widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )
 

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -145,4 +145,4 @@ class ViewAutorisationsTests(TestCase):
 
         usager, autorisations = usagers.popitem(last=False)
         self.assertEqual(usager, self.usager_philomene)
-        self.assertEqual(autorisations, [("Aucun mandats valides", None)])
+        self.assertEqual(autorisations, [("Aucun mandat valide", None)])

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -55,7 +55,7 @@ def _get_usagers_dict_from_mandats(mandats):
                 usagers_without_mandats.add(mandat.usager)
 
     for usager in usagers_without_mandats:
-        usagers[usager] = [("Aucun mandats valides", None)]
+        usagers[usager] = [("Aucun mandat valide", None)]
     return usagers
 
 


### PR DESCRIPTION
## 🌮 Objectif

Corriger quelques coquilles vues sur la production pendant la démonstration lors de la commission d'homologation.

## 🔍 Implémentation

- "aucun mandats valides" -> "aucun mandat valide"
- "entrez le code à 6 chiffres généré par votre téléphone" -> ajout de "ou votre carte OTP"
