### PR TITLE
Créer une attestation pour les mandats révoqués

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/mandat_cancellation_attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_cancellation_attestation.html
@@ -1,0 +1,22 @@
+{% load static %}
+
+<section class="container">
+  <div class="navbar__home">
+    <img class="navbar__logo" src="{% static 'images/logo-marianne.svg' %}" alt="aidantsconnect.beta.gouv.fr" />
+    <img class="navbar__gouvfr" src="{% static 'images/aidants-connect_logo.png' %}" alt="aidantsconnect.beta.gouv.fr" />
+  </div>
+
+  <h1 class="text-center">Révocation d'un mandat via le service « Aidants Connect »</h1>
+
+  <p>
+    Je soussigné(e), <strong>{{ usager_name }}</strong> souhaite révoquer le mandat « Aidants Connect » créé le {{ creation_date}} avec <strong>{{ organisation }}</strong>.
+  </p>
+
+  <p>
+    Fait à <strong>{{ aidant.organisation.address }}</strong>, le <strong>{{ date }}</strong>
+  </p>
+
+  <p class="margin-bottom-50">
+    <span>Le mandant</span>
+  </p>
+</section>

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -39,6 +39,11 @@ urlpatterns = [
         name="confirm_mandat_cancelation",
     ),
     path(
+        "mandats/<int:mandat_id>/attestation_de_revocation",
+        usagers.mandat_cancellation_attestation,
+        name="mandat_cancellation_attestation",
+    ),
+    path(
         "mandats/<int:mandat_id>/visualisation",
         mandat.attestation_visualisation,
         name="mandat_visualisation",

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -258,3 +258,29 @@ def confirm_mandat_cancelation(request, mandat_id):
             "remaining_autorisations": [],
         },
     )
+
+
+@login_required
+@activity_required
+def mandat_cancellation_attestation(request, mandat_id):
+    organisation = request.user.organisation
+    try:
+        mandat = Mandat.objects.get(pk=mandat_id, organisation=organisation)
+        if not mandat.autorisations.all().exclude(revocation_date=None):
+            return redirect("espace_aidant_home")
+
+    except Mandat.DoesNotExist:
+        django_messages.error(request, "Ce mandat est introuvable ou inaccessible.")
+        return redirect("espace_aidant_home")
+    usager = mandat.usager
+
+    return render(
+        request,
+        "aidants_connect_web/mandat_cancellation_attestation.html",
+        {
+            "organisation": organisation,
+            "usager_name": usager.get_full_name(),
+            "mandat": mandat,
+            "creation_date": mandat.creation_date.strftime("%d/%m/%Y à %Hh%M"),
+        },
+    )


### PR DESCRIPTION
Supsédée par #346

## 🌮 Objectif

Permettre aux usagers d'avoir des traces papiers des actions sur les mandats

## 🔍 Implémentation

- Création d'une vue pour l'attestation de révocation des mandats `mandat_cancellation_attestation`
- Création d'un template d'attestation
- Création de l'URL `mandats/<int:mandat_id>/attestation_de_revocation`

## ⚠️ Informations supplémentaires

Ce qu'il reste à faire : 
 - Vérifier le cas où un mandat avec 2 autorisations a une révoque en J-1 et l'autre en j-2 --> Comment cela s'affiche ?
 - Mettre le bouton d'accès à la révocation quelquepart. Vérifier qu'il ne s'affiche que pour les mandat qui corresponde au cas "révoqué" 
 - Mettre de la CSS dans l'attestation

## 🖼️ Images

ça ne ressemble pas à grand chose pour le moment
![Capture d’écran 2021-03-01 à 17 42 37](https://user-images.githubusercontent.com/13916213/109529049-9e64af80-7ab5-11eb-8829-1a69c8849963.png)
