### PR TITLE
mise en place d'un petit correctif sur la vue de revocation d'un mandat

### DIFF
--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -157,8 +157,8 @@ def confirm_mandat_cancelation(request, mandat_id):
     except Mandat.DoesNotExist:
         django_messages.error(request, "Ce mandat est introuvable ou inaccessible.")
         return redirect("espace_aidant_home")
+    usager = mandat.usager
     if mandat.is_active:
-        usager = mandat.usager
         remaining_autorisations = (
             mandat.autorisations.all()
             .filter(revocation_date=None)
@@ -201,6 +201,6 @@ def confirm_mandat_cancelation(request, mandat_id):
             "usager_name": usager.get_full_name(),
             "usager_id": usager.id,
             "mandat": mandat,
-            "remaining_autorisations": remaining_autorisations,
+            "remaining_autorisations": [],
         },
     )


### PR DESCRIPTION
## 🌮 Objectif

Lorsque l'on arrive sur la page de révocation d'un mandat déjà révoqué, cela provoque une erreur 500. Cette manipulation est possible si par exemple, on fait précédent après avoir révoqué un mandat

## 🔍 Implémentation

ON modifie la vue de révocation pour qu'elle ne génère pas une erreur 500 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
