### PR TITLE
Résolution des bugs de rendu sur IE11 et Webkit

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -330,7 +330,7 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "'sha256-FUfFEwUd+ObSebyGDfkxyV7KwtyvBBwsE/VxIOfPD68='",  # tabbed_admin
     "'sha256-dzE1fiHF13yOIlSQf8CYbmucPoYAOHwQ70Y3OO70o+E='",  # main.html
-    "'sha256-qtDLNBeXbQEZ6BoCPDfxDpo3OOJsnlVc/NGAMBmfHq0='",  # new_mandat.html
+    "'sha256-DkGfInBE1PdVNgl1fcJGI5vAFLJWY82M/J2EaQVIsdc='",  # new_mandat.html
     "'sha256-ARvyo8AJ91wUvPfVqP2FfHuIHZJN3xaLI7Vgj2tQx18='",  # wait.html
 )
 CSP_STYLE_SRC = ("'self'",)

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -25,6 +25,9 @@ form {
   outline: 2px solid #003b80;
   outline-offset: 2px;
 }
+.tile input:focus {
+  outline: none; /* hidden because the tile itself has a visible focus */
+}
 .tile label {
   padding: 12px;
   width: 100%;

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -6,7 +6,12 @@ form {
   padding: 0;
   position: relative;
 }
-
+@media all and (-ms-high-contrast:none) {
+    /* ie11 specific */
+     .tile {
+         margin: 1em 0;
+     }
+}
 .tile h3 {
   font-size: 1.2em;
 }

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -54,7 +54,7 @@
             <div class="grid">
               {% for value, label in form.demarche.field.choices %}
                 <div id="{{ value }}" class="tile">
-                  <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
+                  <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" class="sr-only"/>
                   <label class="label-demarche" for="button-{{ value }}">
                     <img src="{{ label.icon }}" alt=""/>
                     <strong>{{ label.titre }}</strong>
@@ -83,7 +83,7 @@
             <div class="grid">
               {% for value, label in form.duree.field.choices %}
                 <div id="{{ value }}" class="tile">
-                  <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree"/>
+                  <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree" class="sr-only"/>
                   <label class="label-duree" for="button-{{ value }}">
                     <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
                     <span>{{ label.description }}</span>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -56,7 +56,7 @@
                 <div id="{{ value }}" class="tile">
                   <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
                   <label class="label-demarche" for="button-{{ value }}">
-                    <img src="{{ label.icon }}" alt="Icon {{ label.titre }}"/>
+                    <img src="{{ label.icon }}" alt=""/>
                     <strong>{{ label.titre }}</strong>
                     <p>
                       {{ label.description }}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -5,107 +5,118 @@
 {% block title %}Aidants Connect - Nouveau mandat{% endblock %}
 
 {% block extracss %}
-<link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
+  <link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
 {% block content %}
-<section id="engagement" class="section">
-  <div class="container container-small">
-    <h1 class="section__title">Créer ou renouveler un mandat</h1>
-    <h2>Mentions à lire à l'usager</h2>
-    <p>
-      Les aidants habilités par <strong>{{ aidant.organisation }}</strong> doivent :
+  <section id="engagement" class="section">
+    <div class="container container-small">
+      <h1 class="section__title">Créer ou renouveler un mandat</h1>
+      <h2>Mentions à lire à l'usager</h2>
+      <p>
+        Les aidants habilités par <strong>{{ aidant.organisation }}</strong> doivent :
       <ul>
-        <li>effectuer à votre place les démarches listées dans le mandat, à partir des informations que vous leur avez données ;</li>
-        <li>collecter et conserver seulement les informations nécessaires aux démarches listées dans le mandat ou à celles qui s’y rattachent ;</li>
-        <li>utiliser et communiquer seulement les informations nécessaires aux démarches listées dans le mandat ou à celles qui s’y rattachent ;</li>
-        <li>Vous informer et demander votre autorisation avant d’effectuer d’autres démarches que celles listées dans le mandat ;</li>
-        <li>mettre à jour et supprimer l’ensemble de vos informations personnelles lorsqu’elles ne sont plus utiles ;</li>
+        <li>effectuer à votre place les démarches listées dans le mandat, à partir des informations que vous leur avez
+          données ;
+        </li>
+        <li>collecter et conserver seulement les informations nécessaires aux démarches listées dans le mandat ou à
+          celles qui s’y rattachent ;
+        </li>
+        <li>utiliser et communiquer seulement les informations nécessaires aux démarches listées dans le mandat ou à
+          celles qui s’y rattachent ;
+        </li>
+        <li>Vous informer et demander votre autorisation avant d’effectuer d’autres démarches que celles listées dans le
+          mandat ;
+        </li>
+        <li>mettre à jour et supprimer l’ensemble de vos informations personnelles lorsqu’elles ne sont plus utiles ;
+        </li>
         <li>s’interdire de rendre publiques vos informations personnelles ;</li>
         <li>prendre toutes les précautions pour assurer la sécurité de vos informations personnelles.</li>
       </ul>
-    </p>
-    <p>
-      A partir du moment où un aidant habilité par <strong>{{ aidant.organisation }}</strong> réalise à votre place une des démarches listées dans le mandat,
-      il accepte de le faire dans les conditions décrites dans le mandat.
-    </p>
-  </div>
-</section>
-<section id="mandat_specifications" class="section section-grey">
-  <div class="container">
-    <form method="post">
-      {% if form.errors %}
-        <div class="notification error" role="alert">{{ form.errors }}</div>
-      {% endif %}
-      {% csrf_token %}
-      <div id="demarches" class="tiles">
-        <h2>Étape 1 : Sélectionnez la ou les démarche(s)</h2>
-        <fieldset id="demarches_list" class="grid">
-          <legend class="sr-only">Sélectionnez la ou les démarche(s)</legend>
-          {% for value, label in form.demarche.field.choices %}
-            <div id="{{ value }}" class="tile">
-              <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche" />
-              <label class="label-demarche" for="button-{{ value }}">
-                <img src="{{ label.icon }}" alt="Icon {{ label.titre }}" />
-                <strong>{{ label.titre }}</strong>
-                <p>
-                  {{ label.description }}
-                  {% if label.service_exemples %}
-                    <br />
-                    <small title="exemples de services publics">
-                      <i>Exemples :</i>
-                      {% for service in label.service_exemples %}
-                        <span class="label label-small">{{ service }}</span>
-                      {% endfor %}
-                    </small>
-                  {% endif %}
-                </p>
-              </label>
-            </div>
-          {% endfor %}
-        </fieldset>
-      </div>
-      <div id="duree" class="tiles">
-        <h2 class="step-title">Étape 2 : Choisissez la durée du mandat</h2>
-        <fieldset id="duree_list" class="grid">
+      </p>
+      <p>
+        A partir du moment où un aidant habilité par <strong>{{ aidant.organisation }}</strong> réalise à votre place
+        une des démarches listées dans le mandat,
+        il accepte de le faire dans les conditions décrites dans le mandat.
+      </p>
+    </div>
+  </section>
+  <section id="mandat_specifications" class="section section-grey">
+    <div class="container">
+      <form method="post">
+        {% if form.errors %}
+          <div class="notification error" role="alert">{{ form.errors }}</div>
+        {% endif %}
+        {% csrf_token %}
+        <div id="demarches" class="tiles">
+          <h2>Étape 1 : Sélectionnez la ou les démarche(s)</h2>
+          <fieldset id="demarches_list" class="grid">
+            <legend class="sr-only">Sélectionnez la ou les démarche(s)</legend>
+            {% for value, label in form.demarche.field.choices %}
+              <div id="{{ value }}" class="tile">
+                <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
+                <label class="label-demarche" for="button-{{ value }}">
+                  <img src="{{ label.icon }}" alt="Icon {{ label.titre }}"/>
+                  <strong>{{ label.titre }}</strong>
+                  <p>
+                    {{ label.description }}
+                    {% if label.service_exemples %}
+                      <br/>
+                      <small title="exemples de services publics">
+                        <i>Exemples :</i>
+                        {% for service in label.service_exemples %}
+                          <span class="label label-small">{{ service }}</span>
+                        {% endfor %}
+                      </small>
+                    {% endif %}
+                  </p>
+                </label>
+              </div>
+            {% endfor %}
+          </fieldset>
+        </div>
+        <div id="duree" class="tiles">
+          <h2 class="step-title">Étape 2 : Choisissez la durée du mandat</h2>
+          <fieldset id="duree_list" class="grid">
             <legend class="sr-only">Choisissez la durée du mandat</legend>
-          {% for value, label in form.duree.field.choices %}
-            <div id="{{ value }}" class="tile">
-              <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree" />
-              <label class="label-duree" for="button-{{ value }}">
-                <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
-                <span>{{ label.description }}</span>
-              </label>
-            </div>
-          {% endfor %}
-        </fieldset>
-        <label for="{{ form.is_remote.id_for_label }}" class="notification warning margin-top-1em">
+            {% for value, label in form.duree.field.choices %}
+              <div id="{{ value }}" class="tile">
+                <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree"/>
+                <label class="label-duree" for="button-{{ value }}">
+                  <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
+                  <span>{{ label.description }}</span>
+                </label>
+              </div>
+            {% endfor %}
+          </fieldset>
+          <label for="{{ form.is_remote.id_for_label }}" class="notification warning margin-top-1em">
             La signature du mandat se fait-elle à distance ? Si oui, cochez cette case
             {{ form.is_remote }}
-        </label>
-      </div>
-      <div id="france_connection" class="tiles">
-        <h2 class="step-title">Étape 3 : Connectez l'usager à FranceConnect</h2>
-        <input id="submit_button" type="image" src="{% static 'images/FCboutons-10.png'%}" alt="S’identifier avec FranceConnect" />
-      </div>
-    </form>
-  <div>
-</section>
+          </label>
+        </div>
+        <div id="france_connection" class="tiles">
+          <h2 class="step-title">Étape 3 : Connectez l'usager à FranceConnect</h2>
+          <input id="submit_button" type="image" src="{% static 'images/FCboutons-10.png' %}"
+                 alt="S’identifier avec FranceConnect"/>
+        </div>
+      </form>
+      <div>
+  </section>
 {% endblock content %}
 
 {% block extrajs %}
-<script>
-  // init
-  let mandat_is_remote_checkbox = document.getElementById("id_is_remote");
-  let mandat_duree_label_is_remote_span = document.getElementsByClassName("duree-label-is-remote");
-  for (var i = 0; i < mandat_duree_label_is_remote_span.length; i++) {
-      mandat_duree_label_is_remote_span[i].style.display = "none";
-    }
-  // toggle mandat_is_remote
-  mandat_is_remote_checkbox.addEventListener('change', function() {
-    for (var i = 0; i < mandat_duree_label_is_remote_span.length; i++) {
-      mandat_duree_label_is_remote_span[i].style.display = this.checked ? "initial" : "none";
-    }
-  });
-</script>
+  <script>
+      // init
+      let mandat_is_remote_checkbox = document.getElementById("id_is_remote");
+      let mandat_duree_label_is_remote_span = document.getElementsByClassName("duree-label-is-remote");
+      for (var i = 0; i < mandat_duree_label_is_remote_span.length; i++) {
+          mandat_duree_label_is_remote_span[i].style.display = "none";
+      }
+      // toggle mandat_is_remote
+      mandat_is_remote_checkbox.addEventListener('change', function () {
+          for (var i = 0; i < mandat_duree_label_is_remote_span.length; i++) {
+              mandat_duree_label_is_remote_span[i].style.display = this.checked ? "initial" : "none";
+          }
+      });
+  </script>
 {% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -49,44 +49,48 @@
         {% csrf_token %}
         <div id="demarches" class="tiles">
           <h2>Étape 1 : Sélectionnez la ou les démarche(s)</h2>
-          <fieldset id="demarches_list" class="grid">
+          <fieldset id="demarches_list">
             <legend class="sr-only">Sélectionnez la ou les démarche(s)</legend>
-            {% for value, label in form.demarche.field.choices %}
-              <div id="{{ value }}" class="tile">
-                <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
-                <label class="label-demarche" for="button-{{ value }}">
-                  <img src="{{ label.icon }}" alt="Icon {{ label.titre }}"/>
-                  <strong>{{ label.titre }}</strong>
-                  <p>
-                    {{ label.description }}
-                    {% if label.service_exemples %}
-                      <br/>
-                      <small title="exemples de services publics">
-                        <i>Exemples :</i>
-                        {% for service in label.service_exemples %}
-                          <span class="label label-small">{{ service }}</span>
-                        {% endfor %}
-                      </small>
-                    {% endif %}
-                  </p>
-                </label>
-              </div>
-            {% endfor %}
+            <div class="grid">
+              {% for value, label in form.demarche.field.choices %}
+                <div id="{{ value }}" class="tile">
+                  <input id="button-{{ value }}" type="checkbox" value="{{ value }}" name="demarche"/>
+                  <label class="label-demarche" for="button-{{ value }}">
+                    <img src="{{ label.icon }}" alt="Icon {{ label.titre }}"/>
+                    <strong>{{ label.titre }}</strong>
+                    <p>
+                      {{ label.description }}
+                      {% if label.service_exemples %}
+                        <br/>
+                        <small title="exemples de services publics">
+                          <i>Exemples :</i>
+                          {% for service in label.service_exemples %}
+                            <span class="label label-small">{{ service }}</span>
+                          {% endfor %}
+                        </small>
+                      {% endif %}
+                    </p>
+                  </label>
+                </div>
+              {% endfor %}
+            </div>
           </fieldset>
         </div>
         <div id="duree" class="tiles">
           <h2 class="step-title">Étape 2 : Choisissez la durée du mandat</h2>
-          <fieldset id="duree_list" class="grid">
+          <fieldset id="duree_list">
             <legend class="sr-only">Choisissez la durée du mandat</legend>
-            {% for value, label in form.duree.field.choices %}
-              <div id="{{ value }}" class="tile">
-                <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree"/>
-                <label class="label-duree" for="button-{{ value }}">
-                  <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
-                  <span>{{ label.description }}</span>
-                </label>
-              </div>
-            {% endfor %}
+            <div class="grid">
+              {% for value, label in form.duree.field.choices %}
+                <div id="{{ value }}" class="tile">
+                  <input id="button-{{ value }}" type="radio" value="{{ value }}" name="duree"/>
+                  <label class="label-duree" for="button-{{ value }}">
+                    <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>
+                    <span>{{ label.description }}</span>
+                  </label>
+                </div>
+              {% endfor %}
+            </div>
           </fieldset>
           <label for="{{ form.is_remote.id_for_label }}" class="notification warning margin-top-1em">
             La signature du mandat se fait-elle à distance ? Si oui, cochez cette case

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -15,6 +15,7 @@
       <h2>Mentions à lire à l'usager</h2>
       <p>
         Les aidants habilités par <strong>{{ aidant.organisation }}</strong> doivent :
+      </p>
       <ul>
         <li>effectuer à votre place les démarches listées dans le mandat, à partir des informations que vous leur avez
           données ;
@@ -33,11 +34,9 @@
         <li>s’interdire de rendre publiques vos informations personnelles ;</li>
         <li>prendre toutes les précautions pour assurer la sécurité de vos informations personnelles.</li>
       </ul>
-      </p>
       <p>
-        A partir du moment où un aidant habilité par <strong>{{ aidant.organisation }}</strong> réalise à votre place
-        une des démarches listées dans le mandat,
-        il accepte de le faire dans les conditions décrites dans le mandat.
+        À partir du moment où un aidant habilité par <strong>{{ aidant.organisation }}</strong> réalise à votre place
+        une des démarches listées dans le mandat, il accepte de le faire dans les conditions décrites dans le mandat.
       </p>
     </div>
   </section>


### PR DESCRIPTION
## 🌮 Objectif

Résoudre les bugs de rendu IE11 et Webkit qui avaient été signalés par le support sur la page de création de mandat.

## 🔍 Implémentation

- Webkit : faire porter le `display: grid` par un `<div>` plutôt que par un `<fieldset>`.
- IE / Edge : ajouter la classe `.sr-only` sur les input checkbox et sur les input radio.

## 🏕 Amélioration continue

- Accessibilité : j'ai supprimé des textes alternatifs inutiles sur les icônes d'illustration.
- J'ai supprimé l'outline sur les "vraies" checkbox dans les tuiles du formulaire, car ce sont les tuiles qui portent le style du focus.
- Ergonomie IE11 : j'ai ajouté une marge autour des blocs.
- Lisibilité : j'ai reformaté le template new_mandat.html

## ⚠️ Informations supplémentaires

Vous voudrez peut-être relire commit par commit, vu que j'ai commencé par un gros ctrl-maj-L sur un gros template, qui pollue le diff…

## 🖼️ Images

Sur webkit (Chrome/Edge) : le contenu est revenu sur deux colonnes et le bouton radio ne mange plus son libellé ! 

![Capture d’écran 2021-03-08 à 15 38 02](https://user-images.githubusercontent.com/1035145/110336311-06227980-8025-11eb-8773-861a9a278e50.png)
![Capture d’écran 2021-03-08 à 15 38 13](https://user-images.githubusercontent.com/1035145/110336317-07ec3d00-8025-11eb-84fc-302720484e8a.png)

Sur IE11 : les blocs sont mieux séparés, et on ne voit plus qu'une seule checkbox !

![Capture d’écran 2021-03-08 151639](https://user-images.githubusercontent.com/1035145/110336554-441f9d80-8025-11eb-9d9e-811b8d4c61dd.png)

![Capture d’écran 2021-03-08 151701](https://user-images.githubusercontent.com/1035145/110336552-43870700-8025-11eb-80b4-f7232bed3aa0.png)

