### PR TITLE
Faire tenir l'attestation de mandat sur une seule page imprimée

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -273,7 +273,7 @@ DEMARCHES = {
     },
 }
 
-MANDAT_TEMPLATE_PATH = "aidants_connect_web/mandat_templates/20201209_mandat.html"
+MANDAT_TEMPLATE_PATH = "aidants_connect_web/mandat_templates/20210308_mandat.html"
 ATTESTATION_SALT = os.getenv("ATTESTATION_SALT", "")
 
 # Magic Auth

--- a/aidants_connect_web/static/css/attestation.css
+++ b/aidants_connect_web/static/css/attestation.css
@@ -4,7 +4,7 @@ main {
 
 .container {
   font-size: .75em;
-  line-height: 1.5em;
+  line-height: 1.4em;
   border: 1px solid grey;
   padding: 30px;
 }
@@ -14,14 +14,27 @@ main {
 }
 
 h1 {
-  margin-left: 75px;
-  margin-right: 75px;
+  margin: 0 2em .6em;
 }
 
+p, ul {
+    margin: 0;
+}
+
+p + p, ul + p {
+    margin-top: .7em;
+}
+
+.demarches {
+    font-size: .95em;
+}
+.demarches + p {
+    margin-top: .1em;
+}
 @media print {
   @page {
     size: auto; /* auto is the initial value */
-    margin: 0; /* this affects the margin in the printer settings */
+    margin: 1em; /* this affects the margin in the printer settings */
   }
   .no-print,
   .no-print * {
@@ -30,5 +43,7 @@ h1 {
   .container {
     border: 0;
     padding: 0;
+    margin: 1em;
+    width: auto;
   }
 }

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20210308_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_templates/20210308_mandat.html
@@ -1,0 +1,95 @@
+{% load static %}
+
+<section class="container">
+  <div class="navbar__home">
+    <img class="navbar__gouvfr" src="{% static 'images/Marianne_logo_1120.png' %}" alt=""/>
+    <img class="navbar__logo" src="{% static 'images/aidants-connect_logo.png' %}" alt="Aidants Connect"/>
+    {% if not final %}
+      <div class="navbar__gouvfr float-right">
+        <i>Projet de mandat</i>
+      </div>
+    {% else %}
+      <div class="navbar__gouvfr float-right">
+        <img alt="" class="navbar__gouvfr img-qrcode" src="{% url 'new_attestation_qrcode' %}"/>
+      </div>
+    {% endif %}
+  </div>
+  <h1 class="text-center">
+    Mandat pour réaliser des démarches en ligne avec le service « Aidants Connect »
+  </h1>
+  <p>Je m’appelle : <strong>{{ usager.get_full_name }}</strong> (je suis le mandant).</p>
+  <p>
+    J’autorise <strong>{{ aidant.organisation }}</strong> (c’est le mandataire) à réaliser à ma place les démarches
+    administratives suivantes :
+  </p>
+  <ul class="demarches">
+    {% for demarche in demarches %}
+      <li><strong>{{ demarche }}</strong></li>
+    {% endfor %}
+  </ul>
+  <p><strong>{{ duree }}.</strong></p>
+  <p>
+    Cette autorisation est conforme aux articles 1984 et suivants du Code civil. Les démarches seront accomplies sur
+    internet, sur des sites utilisant FranceConnect ou sur d’autres sites. Elles peuvent être aussi accomplies par tous
+    les moyens permis par l’administration (téléphone, papier, email…).
+  </p>
+  <p>
+    Je peux annuler mon autorisation à tout moment.
+  </p>
+  <p>
+    Pour que <strong>{{ aidant.organisation }}</strong> puisse agir à ma place :
+  </p>
+  <ul>
+    <li>
+      Je reconnais que l’aidant habilité par <strong>{{ aidant.organisation }}</strong> m’a rappelé l’objet de son
+      intervention, et m’a informé sur la nécessité et l’utilité des informations collectées ;
+    </li>
+    <li>
+      J’autorise les aidants habilités par <strong>{{ aidant.organisation }}</strong> à utiliser mes données
+      personnelles dans le cadre de ce mandat.
+      Je sais que j’ai des droits sur les informations me concernant : accès, rectification, suppression.
+    </li>
+  </ul>
+  <p>
+    Les aidants habilités par <strong>{{ aidant.organisation }}</strong> doivent :
+  </p>
+  <ul>
+    <li>
+      effectuer les démarches listées dans ce document à ma place, à partir des informations que je leur ai données ;
+    </li>
+    <li>
+      collecter et conserver, utiliser et communiquer seulement les informations nécessaires aux démarches listées
+      dans ce document ou à celles qui s’y rattachent ;
+    </li>
+    <li>
+      m’informer et demander mon autorisation avant d’effectuer d’autres démarches que celles listées dans ce document ;
+    </li>
+    <li>mettre à jour et supprimer l’ensemble de mes informations personnelles lorsqu’elles ne sont plus utiles ;</li>
+    <li>s’interdire de rendre publiques mes informations personnelles ;</li>
+    <li>prendre toutes les précautions pour assurer la sécurité de mes informations personnelles.</li>
+  </ul>
+  <p>
+    À partir du moment où un aidant habilité par <strong>{{ aidant.organisation }}</strong>
+    réalise à ma place une des démarches listées dans ce document,
+    il accepte de le faire dans les conditions décrites dans ce document.
+  </p>
+  <p>
+    Mon autorisation est donnée et acceptée <strong>{{ duree }}</strong>. Elle se termine avant si :
+  </p>
+  <ul>
+    <li>les démarches décrites ci-dessus sont réalisées ;</li>
+    <li>je décide de l’annuler ;</li>
+    <li>l’aidant habilité par <strong>{{ aidant.organisation }}</strong> décide de l’annuler ;</li>
+    <li>
+      je donne mon autorisation à une autre personne qu’un aidant habilité par
+      <strong>{{ aidant.organisation }}</strong>. Dans ce cas, je dois en informer le plus vite possible
+      <strong>{{ aidant.organisation }}</strong>.
+    </li>
+  </ul>
+  <p>
+    L'aidant habilité par <strong>{{ aidant.organisation }}</strong> doit accomplir à ma place les démarches listées
+    dans ce document tant que le mandat est valable. Il pourra être responsable s’il ne respecte pas les
+    conditions décrites dans ce document (article 1991 du Code civil).
+  </p>
+  <p>Fait à <strong>{{ aidant.organisation.address }}</strong>, le <strong>{{ date }}</strong></p>
+</section>


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux aidants d'imprimer l'attestation de mandat sur une seule page

## 🔍 Implémentation

- Diminuer les marges et les interlignes
- Fusionner certains points de listes à puces

## 🏕 Amélioration continue

- J'ai aussi corrigé quelques coquilles.

## ⚠️ Informations supplémentaires

- Testé et validé sur Chrome, Edge et Firefox.
- Sur IE11, il faut utiliser les options de mise en page pour diminuer manuellement les marges, et le QRCode n'est pas imprimé.

## 🖼️ Images

Sur Firefox : 

![Capture d’écran 2021-03-08 à 17 08 12](https://user-images.githubusercontent.com/1035145/110352019-b304f280-8035-11eb-9e9c-ef8872a446d1.png)

