### PR TITLE
Ajout bénévoles et services civiques dans la FAQ

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/mandat.html
+++ b/aidants_connect_web/templates/public_website/faq/mandat.html
@@ -44,29 +44,23 @@
         </p>
         <h3> 
           Pourquoi les bénévoles et les services civiques ne peuvent pas utiliser Aidants Connect ?
-          </h3>
-        <p>
-        <h4 id="Les-bénévoles-ne-peuvent-pas-utiliser-le-service-Aidants-Connect-pour-les-raisons-suivantes-:">
+        </h3>
+        <h4 id="benevoles">
           1. Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :
         </h4>
-        <p>
         <ul>
           <li>Les bénévoles n’ont pas de contrat de travail avec la structure dans laquelle ils se portent volontaires. En cas de litige, aucun recours n'est donc possible ;</li>
           <li>L'aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c'est-à-dire le responsable de la structure) ;</li>
           <li>Pour utiliser le service Aidants Connect il faut que la structure soit habilitée Aidants Connect.</li>
         </ul>
-        </p>
-        <h4 id="Les-services-civiques-ne-peuvent-pas-utiliser-le-service-Aidants-Connect-pour-les-raisons-suivantes-:">
+        <h4 id="services-civiques">
           2. Les services civiques ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :
         </h4>
-        <p>
         <ul>
           <li>Le service Aidants Connect est accessible uniquement aux professionnels de l’accompagnement qui ont donc de l'expérience dans l'accompagnement des publics isolés ;</li>
           <li>Chaque aidant professionnel doit suivre une formation avant d’utiliser le service Aidants Connect ;</li>
           <li>L'aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c'est-à-dire le responsable de la structure).</li>
         </ul>
-        </p>
-    
         <p>
         De plus, pendant la période d’expérimentation, Aidants Connect n’est ouvert qu’à un nombre limité de structures.
         </p>

--- a/aidants_connect_web/templates/public_website/faq/mandat.html
+++ b/aidants_connect_web/templates/public_website/faq/mandat.html
@@ -42,6 +42,31 @@
           personnes ayant un statut professionnel (Fonctionnaire, CDD ou CDI) tel que travailleur·ses sociaux·ales, agents publics
           d’accueil ou médiateur·ices numériques salarié·es d’une structure de droit privé.
         </p>
+        <h3> 
+          Pourquoi les bénévoles et les services civiques ne peuvent pas utiliser Aidants Connect ?
+          </h3>
+        <p>
+        <h4 id="Les-bénévoles-ne-peuvent-pas-utiliser-le-service-Aidants-Connect-pour-les-raisons-suivantes-:">
+          1. Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :
+        </h4>
+        <p>
+        <ul>
+          <li>Les bénévoles n’ont pas de contrat de travail avec la structure dans laquelle ils se portent volontaires. En cas de litige, aucun recours n'est donc possible ;</li>
+          <li>L'aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c'est-à-dire le responsable de la structure) ;</li>
+          <li>Pour utiliser le service Aidants Connect il faut que la structure soit habilitée Aidants Connect.</li>
+        </ul>
+        </p>
+        <h4 id="Les-services-civiques-ne-peuvent-pas-utiliser-le-service-Aidants-Connect-pour-les-raisons-suivantes-:">
+          2. Les services civiques ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :
+        </h4>
+        <p>
+        <ul>
+          <li>Le service Aidants Connect est accessible uniquement aux professionnels de l’accompagnement qui ont donc de l'expérience dans l'accompagnement des publics isolés ;</li>
+          <li>Chaque aidant professionnel doit suivre une formation avant d’utiliser le service Aidants Connect ;</li>
+          <li>L'aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c'est-à-dire le responsable de la structure).</li>
+        </ul>
+        </p>
+    
         <p>
         De plus, pendant la période d’expérimentation, Aidants Connect n’est ouvert qu’à un nombre limité de structures.
         </p>


### PR DESCRIPTION
Mise à jour de la FAQ pour clarifier les raisons juridiques de l'utilisation du service Aidants Connect par les bénévoles et les services civiques.  Nous avons eu beaucoup de questions lors des démos de l'outil le mardi matin j'ai donc rédigé un contenu juridique à ce sujet qui a été validé par notre juriste.

## 🌮 Objectif
Mise à jour de la FAQ pour clarifier les raisons juridiques de l'utilisation du service Aidants Connect par les bénévoles et les services civiques

## 🔍 Implémentation
Ajout des raisons juridiques en deux points : pour les bénévoles et pour les services civiques

## 🖼️ Images

![Capture d’écran 2021-03-09 à 16 04 34](https://user-images.githubusercontent.com/1035145/110491230-5bc45800-80f1-11eb-9e68-3493a2aa6e3b.png)

