### PR TITLE
Corriger une erreur apparaissant lors de la modification d'un usager dans l'admin

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -173,9 +173,8 @@ class UsagerAdmin(VisibleToTechAdmin, NestedModelAdmin, TabbedModelAdmin):
     list_display = ("__str__", "email", "creation_date")
     search_fields = ("given_name", "family_name", "email")
 
-    tab_infos = (None, {"fields": ("given_name", "family_name", "email")})
-
-    tab_mandats = UsagerMandatInline
+    tab_infos = (("Info", {"fields": ("given_name", "family_name", "email")}),)
+    tab_mandats = (UsagerMandatInline,)
 
     tabs = [("Informations", tab_infos), ("Mandats", tab_mandats)]
 


### PR DESCRIPTION
## 🌮 Objectif

La modification d'un usager était impossible dans l'admin django. Cette PR corrige les choses

## 🔍 Implémentation

La configuration de tabbed_admin n'était pas correcte, elle est corrigée avec cette PR. Ajout d'un test pour valider

## 🏕 Amélioration continue


## ⚠️ Informations supplémentaires


## 🖼️ Images

