### PR TITLE
Possibilité de régénérer une attestation passée (partie 1 : support pour les anciennes attestations)

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -273,7 +273,9 @@ DEMARCHES = {
     },
 }
 
-MANDAT_TEMPLATE_PATH = "aidants_connect_web/mandat_templates/20201209_mandat.html"
+MANDAT_TEMPLATE_DIR = "aidants_connect_web/mandat_templates"
+MANDAT_TEMPLATE_CURRENT_FILE = "20201209_mandat.html"
+MANDAT_TEMPLATE_PATH = os.path.join(MANDAT_TEMPLATE_DIR, MANDAT_TEMPLATE_CURRENT_FILE)
 ATTESTATION_SALT = os.getenv("ATTESTATION_SALT", "")
 
 # Magic Auth

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -4,9 +4,15 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, QuerySet
+from django.template import loader
 from django.utils import timezone
 from django.utils.functional import cached_property
+from typing import Union
+from os import walk as os_walk
+from os.path import join as path_join, dirname
+
+from aidants_connect_web.utilities import generate_attestation_hash
 
 
 class Organisation(models.Model):
@@ -338,6 +344,56 @@ class Mandat(models.Model):
         # at least one active `autorisation`.
         return self.autorisations.active().exists()
 
+    def get_template_path(self, aidant: Aidant) -> Union[None, str]:
+        """Returns the template file path of the consent document that was presented
+        to the user when the mandate was issued.
+
+        :return: the template file relative path as can be used on Django's
+        template engine (without `templates` prepended`) otherwise
+        """
+        return self._get_template_path_legacy(aidant)
+
+    def _get_template_path_legacy(self, aidant: Aidant) -> Union[None, str]:
+        """Legacy mode for `models.Mandat.text()`
+
+        This will search which template file was used using the hash login in
+        `models.Journal` entries and parse the template using it.
+
+        :return: None when:
+            - no log record could be found on this mandate
+            - the original template file could not be found
+        the template file relative path as can be used on Django's template engine
+        (without `templates` prepended`) otherwise
+        """
+
+        journal_entries = Journal.find_attestation_creation_entries(self, aidant)
+
+        if journal_entries.count() == 0:
+            return None
+
+        template_dir = dirname(
+            loader.get_template(settings.MANDAT_TEMPLATE_PATH).origin.name
+        )
+
+        demarches = [it.demarche for it in self.autorisations.all()]
+
+        for journal_entry in journal_entries:
+            for _, _, filenames in os_walk(template_dir):
+                for filename in filenames:
+                    file_hash = generate_attestation_hash(
+                        aidant,
+                        self.usager,
+                        demarches,
+                        self.expiration_date,
+                        journal_entry.creation_date.date().isoformat(),
+                        path_join(settings.MANDAT_TEMPLATE_DIR, filename),
+                    )
+
+                    if file_hash == journal_entry.attestation_hash:
+                        return path_join(settings.MANDAT_TEMPLATE_DIR, filename)
+
+        return None
+
     def admin_is_active(self):
         return self.is_active
 
@@ -665,6 +721,19 @@ class Journal(models.Model):
         message = f"{added} ajouts - {updated} modifications"
         return cls.objects.create(
             aidant=aidant, action="import_totp_cards", additional_information=message
+        )
+
+    @classmethod
+    def find_attestation_creation_entries(
+        cls, mandat: Mandat, aidant: Aidant
+    ) -> QuerySet["Journal"]:
+        start = mandat.creation_date.replace(hour=0, minute=0, second=0, microsecond=0)
+        end = start + timedelta(days=1)
+        return cls.objects.filter(
+            action="create_attestation",
+            usager=mandat.usager,
+            aidant=aidant,
+            creation_date__range=(start, end),
         )
 
 

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -651,6 +651,7 @@ class Journal(models.Model):
         is_remote_mandat: bool,
         access_token: str,
         attestation_hash: str,
+        mandat: Mandat,
     ):
         return cls.objects.create(
             aidant=aidant,
@@ -660,6 +661,7 @@ class Journal(models.Model):
             duree=duree,
             access_token=access_token,
             attestation_hash=attestation_hash,
+            mandat=mandat,
             is_remote_mandat=is_remote_mandat,
         )
 

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -34,10 +34,10 @@
               <small title="{{ mandat.expiration_date }}">(jusqu'au {{ mandat.expiration_date | date:"d F Y" }})</small>
             </h4>
             <div class="float-right text-right">
-              <a id="view_mandat_attestation" class="button"><span aria-hidden="true">🖨&nbsp;</span>Voir l’attestation (bientôt)</a>
+              <a id="view_mandat_attestation" class="button" href="{% url 'mandat_visualisation' mandat_id=mandat.id %}"><span aria-hidden="true">🖨&nbsp;</span>Voir l’attestation</a>
               <a id="cancel_mandat" class="button-outline warning" href="{% url 'confirm_mandat_cancelation' mandat_id=mandat.id %}">
-                          Révoquer le mandat <span aria-hidden="true">&nbsp;🗑️</span>
-                        </a>
+                Révoquer le mandat <span aria-hidden="true">&nbsp;🗑️</span>
+              </a>
             </div>
           </div>
           <ul class="label-list">
@@ -99,7 +99,7 @@
               <small title="{{ mandat.expiration_date }}">(le {{ mandat.expiration_date | date:"d F Y" }})</small>
             </h4>
             <div class="float-right">
-              <a id="view_mandat_attestation" class="button">🖨&nbsp;Voir l'attestation (bientôt)</a>
+              <a id="view_mandat_attestation" class="button" href="{% url 'mandat_visualisation' mandat_id=mandat.id %}"><span aria-hidden="true">🖨&nbsp;</span>Voir l’attestation</a>
             </div>
           </div>
           <ul class="label-list">

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -9,6 +9,7 @@ from aidants_connect_web.models import (
     Mandat,
     Organisation,
     Usager,
+    Journal,
 )
 
 
@@ -80,3 +81,23 @@ class LegacyAutorisationFactory(AutorisationFactory):
 class ConnectionFactory(factory.DjangoModelFactory):
     class Meta:
         model = Connection
+
+
+class JournalFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = Journal
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        creation_date = kwargs.pop("creation_date", None)
+        obj = super(JournalFactory, cls)._create(model_class, *args, **kwargs)
+        if creation_date is not None:
+            Journal.objects.filter(pk=obj.pk).update(creation_date=creation_date)
+        return obj
+
+
+class AttestationJournalFactory(JournalFactory):
+    action = "create_attestation"
+    is_remote_mandat = False
+    access_token = factory.Faker("md5")
+    duree = 6

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -931,6 +931,7 @@ class JournalModelTests(TestCase):
     def test_a_create_attestation_journal_entry_can_be_created(self):
         demarches = ["transports", "logement"]
         expiration_date = timezone.now() + timedelta(days=6)
+        mandat = MandatFactory()
         entry = Journal.log_attestation_creation(
             aidant=self.aidant_thierry,
             usager=self.usager_ned,
@@ -941,6 +942,7 @@ class JournalModelTests(TestCase):
             attestation_hash=generate_attestation_hash(
                 self.aidant_thierry, self.usager_ned, demarches, expiration_date
             ),
+            mandat=mandat,
         )
 
         self.assertEqual(len(Journal.objects.all()), 3)

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -18,7 +18,7 @@ from aidants_connect_web.tests.factories import (
     OrganisationFactory,
     UsagerFactory,
 )
-from aidants_connect_web.views import new_mandat
+from aidants_connect_web.views import mandat
 
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
@@ -32,7 +32,7 @@ class NewMandatTests(TestCase):
 
     def test_new_mandat_url_triggers_new_mandat_view(self):
         found = resolve("/creation_mandat/")
-        self.assertEqual(found.func, new_mandat.new_mandat)
+        self.assertEqual(found.func, mandat.new_mandat)
 
     def test_new_mandat_url_triggers_new_mandat_template(self):
         self.client.force_login(self.aidant_thierry)
@@ -102,7 +102,7 @@ class NewMandatRecapTests(TestCase):
 
     def test_recap_url_triggers_the_recap_view(self):
         found = resolve("/creation_mandat/recapitulatif/")
-        self.assertEqual(found.func, new_mandat.new_mandat_recap)
+        self.assertEqual(found.func, mandat.new_mandat_recap)
 
     def test_recap_url_triggers_the_recap_template(self):
         self.client.force_login(self.aidant_thierry)
@@ -520,15 +520,15 @@ class GenerateAttestationTests(TestCase):
 
     def test_attestation_projet_url_triggers_the_correct_view(self):
         found = resolve("/creation_mandat/visualisation/projet/")
-        self.assertEqual(found.func, new_mandat.attestation_projet)
+        self.assertEqual(found.func, mandat.attestation_projet)
 
     def test_attestation_final_url_triggers_the_correct_view(self):
         found = resolve("/creation_mandat/visualisation/final/")
-        self.assertEqual(found.func, new_mandat.attestation_final)
+        self.assertEqual(found.func, mandat.attestation_final)
 
     def test_autorisation_qrcode_url_triggers_the_correct_view(self):
         found = resolve("/creation_mandat/qrcode/")
-        self.assertEqual(found.func, new_mandat.attestation_qrcode)
+        self.assertEqual(found.func, mandat.attestation_qrcode)
 
     def test_response_is_the_print_page(self):
         self.client.force_login(self.aidant_thierry)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -6,7 +6,7 @@ from magicauth.urls import urlpatterns as magicauth_urls
 from aidants_connect_web.views import (
     FC_as_FS,
     id_provider,
-    new_mandat,
+    mandat,
     service,
     espace_aidant,
     usagers,
@@ -38,32 +38,37 @@ urlpatterns = [
         usagers.confirm_mandat_cancelation,
         name="confirm_mandat_cancelation",
     ),
+    path(
+        "mandats/<int:mandat_id>/visualisation",
+        mandat.attestation_visualisation,
+        name="mandat_visualisation",
+    ),
     # new mandat
-    path("creation_mandat/", new_mandat.new_mandat, name="new_mandat"),
+    path("creation_mandat/", mandat.new_mandat, name="new_mandat"),
     path(
         "creation_mandat/recapitulatif/",
-        new_mandat.new_mandat_recap,
+        mandat.new_mandat_recap,
         name="new_mandat_recap",
     ),
-    path("logout-callback/", new_mandat.new_mandat_recap, name="new_mandat_recap"),
+    path("logout-callback/", mandat.new_mandat_recap, name="new_mandat_recap"),
     path(
         "creation_mandat/visualisation/projet/",
-        new_mandat.attestation_projet,
+        mandat.attestation_projet,
         name="new_attestation_projet",
     ),
     path(
         "creation_mandat/succes/",
-        new_mandat.new_mandat_success,
+        mandat.new_mandat_success,
         name="new_mandat_success",
     ),
     path(
         "creation_mandat/visualisation/final/",
-        new_mandat.attestation_final,
+        mandat.attestation_final,
         name="new_attestation_final",
     ),
     path(
         "creation_mandat/qrcode/",
-        new_mandat.attestation_qrcode,
+        mandat.attestation_qrcode,
         name="new_attestation_qrcode",
     ),
     # id_provider

--- a/aidants_connect_web/utilities.py
+++ b/aidants_connect_web/utilities.py
@@ -1,5 +1,7 @@
 import io
 import hashlib
+from datetime import date
+
 import qrcode
 from pathlib import Path
 
@@ -45,3 +47,29 @@ def generate_qrcode_png(string: str):
     img = qrcode.make(string)
     img.save(stream, "PNG")
     return stream.getvalue()
+
+
+def generate_attestation_hash(
+    aidant,
+    usager,
+    demarches,
+    expiration_date,
+    creation_date=date.today().isoformat(),
+    mandat_template_path=settings.MANDAT_TEMPLATE_PATH,
+):
+    demarches.sort()
+    attestation_data = {
+        "aidant_id": aidant.id,
+        "creation_date": creation_date,
+        "demarches_list": ",".join(demarches),
+        "expiration_date": expiration_date.date().isoformat(),
+        "organisation_id": aidant.organisation.id,
+        "template_hash": generate_file_sha256_hash(f"templates/{mandat_template_path}"),
+        "usager_sub": usager.sub,
+    }
+    sorted_attestation_data = dict(sorted(attestation_data.items()))
+    attestation_string = ";".join(
+        str(x) for x in list(sorted_attestation_data.values())
+    )
+    attestation_string_with_salt = attestation_string + settings.ATTESTATION_SALT
+    return generate_sha256_hash(attestation_string_with_salt.encode("utf-8"))

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -14,35 +14,13 @@ from aidants_connect_web.forms import MandatForm, RecapMandatForm
 from aidants_connect_web.models import Autorisation, Connection, Journal, Mandat
 from aidants_connect_web.views.service import humanize_demarche_names
 from aidants_connect_web.utilities import (
-    generate_file_sha256_hash,
-    generate_sha256_hash,
+    generate_attestation_hash,
     generate_qrcode_png,
 )
 
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
-
-
-def generate_attestation_hash(aidant, usager, demarches, expiration_date):
-    demarches.sort()
-    attestation_data = {
-        "aidant_id": aidant.id,
-        "creation_date": date.today().isoformat(),
-        "demarches_list": ",".join(demarches),
-        "expiration_date": expiration_date.date().isoformat(),
-        "organisation_id": aidant.organisation.id,
-        "template_hash": generate_file_sha256_hash(
-            f"templates/{settings.MANDAT_TEMPLATE_PATH}"
-        ),
-        "usager_sub": usager.sub,
-    }
-    sorted_attestation_data = dict(sorted(attestation_data.items()))
-    attestation_string = ";".join(
-        str(x) for x in list(sorted_attestation_data.values())
-    )
-    attestation_string_with_salt = attestation_string + settings.ATTESTATION_SALT
-    return generate_sha256_hash(attestation_string_with_salt.encode("utf-8"))
 
 
 @login_required

--- a/aidants_connect_web/views/new_mandat.py
+++ b/aidants_connect_web/views/new_mandat.py
@@ -103,8 +103,18 @@ def new_mandat_recap(request):
             mandat_duree = days_before_expiration_date.get(connection.duree_keyword)
 
             try:
-                # Add a Journal 'create_attestation' action
                 connection.demarches.sort()
+
+                # Create a mandat
+                mandat = Mandat.objects.create(
+                    organisation=aidant.organisation,
+                    usager=usager,
+                    duree_keyword=connection.duree_keyword,
+                    expiration_date=mandat_expiration_date,
+                    is_remote=connection.mandat_is_remote,
+                )
+
+                # Add a Journal 'create_attestation' action
                 Journal.log_attestation_creation(
                     aidant=aidant,
                     usager=usager,
@@ -115,15 +125,7 @@ def new_mandat_recap(request):
                     attestation_hash=generate_attestation_hash(
                         aidant, usager, connection.demarches, mandat_expiration_date
                     ),
-                )
-
-                # Create a mandat
-                mandat = Mandat.objects.create(
-                    organisation=aidant.organisation,
-                    usager=usager,
-                    duree_keyword=connection.duree_keyword,
-                    expiration_date=mandat_expiration_date,
-                    is_remote=connection.mandat_is_remote,
+                    mandat=mandat,
                 )
 
                 # This loop creates one `autorisation` object per `démarche` in the form


### PR DESCRIPTION
## 🌮 Objectif

Ouvre la possibilité de régénérer une attestation qui a été accordée par le passé par un ou une usagère.

## 🔍 Implémentation

- Pour les attenstations antérieures à cette modification, elles seront retrouvées via le journal de log en comparant le hash de tous les templates du projet à celui dans l'entrée du journal.

## 🏕 Amélioration continue

## ⚠️ Informations supplémentaires

## 🖼️ Images
