### PR TITLE
Ajout de la déclaration d'accessibilité

### DIFF
--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -22,6 +22,7 @@
       <li><a href="/mentions-legales">Mentions légales</a></li>
       <li><a href="/faq">Foire aux questions</a></li>
       <li><a href="/stats">Statistiques</a></li>
+      <li><a href="/accessibilite">Accessibilité</a> (non conforme)</li>
     </ul>
   </div>
 </footer>

--- a/aidants_connect_web/templates/public_website/accessibilite.html
+++ b/aidants_connect_web/templates/public_website/accessibilite.html
@@ -1,0 +1,81 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - Accessibilité{% endblock %}
+
+{% block extracss %}
+{% endblock extracss %}
+
+{% block content %}
+  <section class="section">
+    <div class="container">
+      <h1 class="section__title">Déclaration d’accessibilité</h1>
+
+      <p><b>L’agence Nationale de la Cohésion des Territoires</b> s’engage à rendre son service accessible,
+        conformément à l’article 47 de la loi n° 2005-102 du 11 février 2005.</p>
+      <p>Cette déclaration d’accessibilité s’applique au site web Aidants Connect.</p>
+      <h2>État de conformité</h2>
+      <p>
+        <span>Aidants Connect</span> est
+        <b><span data-printfilter="lowercase">non conforme</span> avec le
+          <abbr title="Référentiel général d’accessibilité pour les Administrations">RGAA</abbr> 4.1</b>.
+        Non conforme veut dire que moins de 50 % des critères de contrôle du RGAA sont respectés,
+        ou que le site n’a pas été audité.
+      </p>
+      <h2>Résultats des tests</h2>
+      <p>
+        L’audit de conformité réalisé par évaluation externe le 13 août 2020 révèle que 38 % des critères
+        sont respectés.
+      </p>
+
+      <h2>Établissement de cette déclaration d’accessibilité</h2>
+      <p>Cette déclaration a été établie le <b>15 mars 2021</b>.</p>
+      <h3>Technologies utilisées</h3>
+      <p>L’accessibilité d’Aidants Connect s’appuie sur les technologies suivantes :</p>
+      <ul class="technical-information technologies-used">
+        <li>HTML</li>
+        <li>CSS</li>
+        <li>JavaScript</li>
+      </ul>
+
+      <h2>Amélioration et contact</h2>
+      <p>
+        Si vous n’arrivez pas à accéder à un contenu ou à un service, vous pouvez contacter le responsable d’Aidants
+        Connect pour être orienté vers une alternative accessible ou obtenir le contenu sous une autre forme.
+      </p>
+      <ul class="basic-information feedback h-card">
+        <li>
+          E-mail : <a href="mailto:contact@aidantsconnect.beta.gouv.fr">contact@aidantsconnect.beta.gouv.fr</a>
+        </li>
+        <li>
+          Adresse : <span>20 rue de Ségur, 75007 Paris</span>
+        </li>
+      </ul>
+
+      <h2>Voie de recours</h2>
+      <p>Cette procédure est à utiliser dans le cas suivant : vous avez signalé au responsable du site internet un
+        défaut d’accessibilité qui vous empêche d’accéder à un contenu ou à un des services du portail et vous n’avez
+        pas obtenu de réponse satisfaisante.</p>
+
+      <p>Vous pouvez :</p>
+      <ul>
+        <li>Écrire un message au <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a> ;</li>
+        <li>
+          Contacter <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits
+          dans votre région</a>
+        </li>
+        <li>Envoyer un courrier par la poste (gratuit, ne pas mettre de timbre) :<br>
+          Défenseur des droits<br>
+          Libre réponse 71120 75342 Paris CEDEX 07
+        </li>
+      </ul>
+      <p>
+        Cette déclaration d’accessibilité a été créée le 15 mars 2021 grâce au
+        <a href="https://betagouv.github.io/a11y-generateur-declaration/#create">
+          Générateur de Déclaration d’Accessibilité de BetaGouv
+        </a>.
+      </p>
+    </div>
+  </section>
+{% endblock content %}

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -87,6 +87,7 @@ urlpatterns = [
     path("guide_utilisation/", service.guide_utilisation, name="guide_utilisation"),
     path("habilitation", service.habilitation, name="habilitation"),
     path("ressources/", service.ressources, name="ressources"),
+    path("accessibilite/", service.accessibilite, name="accessibilite"),
     # # FAQ
     path("faq/", service.faq_generale, name="faq_generale"),
     path("faq/mandat/", service.faq_mandat, name="faq_mandat"),

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -165,6 +165,10 @@ def mentions_legales(request):
     return render(request, "public_website/mentions_legales.html")
 
 
+def accessibilite(request):
+    return render(request, "public_website/accessibilite.html")
+
+
 def ressources(request):
     return render(request, "public_website/ressource_page.html")
 


### PR DESCRIPTION
## 🌮 Objectif

Afficher le résultat de l'audit d'accessibilité pour remplir l'obligation légale sur ce point-là.

## 🔍 Implémentation

- Ajoute la page "déclaration d'accessibilité" accessible via un lien dans le footer.
- Le contenu de la page a été généré avec [le chouette générateur de betagouv](https://betagouv.github.io/a11y-generateur-declaration).


## ⚠️ Informations supplémentaires

On a normalement un meilleur score que ce qui est affiché, car on a pris en compte un bon nombre de retours de l'audit. Mais je n'ai pas refait un audit formel pour connaître au juste notre nouveau score, donc pour l'instant je laisse comme cela.

## 🖼️ Images

Lien dans le footer : 
![Lien dans le pied de page vers la page accessibilité](https://user-images.githubusercontent.com/1035145/111142640-31591b80-8585-11eb-8743-1ab0ba2d0c5e.png)

La page elle-même : 
![Page accessibilité](https://user-images.githubusercontent.com/1035145/111142687-3e760a80-8585-11eb-988e-34af0772c342.png)


