### PR TITLE
Création de la FAQ spéciale habilitation

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/_nav.html
+++ b/aidants_connect_web/templates/public_website/faq/_nav.html
@@ -1,0 +1,31 @@
+<nav class="side-menu" role="navigation" aria-label="Menu questions fréquentes">
+  <ul>
+    <li>
+      <a {% if active == "generale" %} class="active"
+        title="Le service Aidants Connect (rubrique active)"{% endif %}
+        href="{% url 'faq_generale' %}">
+        Le service Aidants Connect
+      </a>
+    </li>
+    <li>
+      <a {% if active == "mandat" %} class="active"
+           title="Le mandat (rubrique active)" {% endif %}
+           href="{% url 'faq_mandat' %}">
+        Le mandat
+    </a>
+    </li>
+    <li>
+      <a {% if active == "donnees_personnelles" %} class="active"
+         title="Les données personnelles (rubrique active)"{% endif %}
+         href="{% url 'faq_donnees_personnelles' %}">
+        Les données personnelles
+      </a>
+    </li>
+    <li>
+      <a {% if active == "habilitation" %} class="active"
+         title="L’habilitation (rubrique active)"{% endif %}
+         href="{% url 'faq_habilitation' %}">L’habilitation
+      </a>
+    </li>
+  </ul>
+</nav>

--- a/aidants_connect_web/templates/public_website/faq/_nav.html
+++ b/aidants_connect_web/templates/public_website/faq/_nav.html
@@ -2,28 +2,28 @@
   <ul>
     <li>
       <a {% if active == "generale" %} class="active"
-        title="Le service Aidants Connect (rubrique active)"{% endif %}
+        aria-label="Le service Aidants Connect (rubrique active)"{% endif %}
         href="{% url 'faq_generale' %}">
         Le service Aidants Connect
       </a>
     </li>
     <li>
       <a {% if active == "mandat" %} class="active"
-           title="Le mandat (rubrique active)" {% endif %}
+           aria-label="Le mandat (rubrique active)" {% endif %}
            href="{% url 'faq_mandat' %}">
         Le mandat
-    </a>
+      </a>
     </li>
     <li>
       <a {% if active == "donnees_personnelles" %} class="active"
-         title="Les données personnelles (rubrique active)"{% endif %}
+         aria-label="Les données personnelles (rubrique active)"{% endif %}
          href="{% url 'faq_donnees_personnelles' %}">
         Les données personnelles
       </a>
     </li>
     <li>
       <a {% if active == "habilitation" %} class="active"
-         title="L’habilitation (rubrique active)"{% endif %}
+         aria-label="L’habilitation (rubrique active)"{% endif %}
          href="{% url 'faq_habilitation' %}">L’habilitation
       </a>
     </li>

--- a/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
+++ b/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
@@ -15,13 +15,7 @@
     <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
   </div>
   <div class="dashboard" id="faq-content">
-    <aside class="side-menu" role="navigation">
-      <ul>
-        <li><a href="{% url 'faq_generale' %}">Le service Aidants Connect</a></li>
-        <li><a href="{% url 'faq_mandat' %}">Le mandat</a></li>
-        <li><a class="active" href="{% url 'faq_donnees_personnelles' %}">Les données personnelles</a></li>
-      </ul>
-    </aside>
+    {% include 'public_website/faq/_nav.html' with active="donnees_personnelles" %}
     <div class="main">
       <div class="panel">
         <h2 id="questions-RGPD">Questions sur la protection des données personnelles</h2>

--- a/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
+++ b/aidants_connect_web/templates/public_website/faq/donnees_personnelles.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - FAQ{% endblock %}
+{% block title %}Aidants Connect - FAQ données personnelles{% endblock %}
 
 {% block extracss %}
 <link href="{% static 'css/home.css' %}" rel="stylesheet">

--- a/aidants_connect_web/templates/public_website/faq/generale.html
+++ b/aidants_connect_web/templates/public_website/faq/generale.html
@@ -15,13 +15,7 @@
     <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
   </div>
   <div class="dashboard" id="faq-content">
-    <aside class="side-menu" role="navigation">
-      <ul>
-        <li><a class="active" href="{% url 'faq_generale' %}">Le service Aidants Connect</a></li>
-        <li><a href="{% url 'faq_mandat' %}">Le mandat</a></li>
-        <li><a href="{% url 'faq_donnees_personnelles' %}">Les données personnelles</a></li>
-      </ul>
-    </aside>
+    {% include 'public_website/faq/_nav.html' with active="generale" %}
     <div class="main">
       <div class="panel">
         <h2 id="questions-generales">Questions générales</h2>

--- a/aidants_connect_web/templates/public_website/faq/generale.html
+++ b/aidants_connect_web/templates/public_website/faq/generale.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - FAQ{% endblock %}
+{% block title %}Aidants Connect - FAQ Générale{% endblock %}
 
 {% block extracss %}
 <link href="{% static 'css/home.css' %}" rel="stylesheet">

--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -18,13 +18,7 @@
       </p>
     </div>
     <div class="dashboard" id="faq-content">
-      <aside class="side-menu" role="navigation">
-        <ul>
-          <li><a href="{% url 'faq_generale' %}">Le service Aidants Connect</a></li>
-          <li><a href="{% url 'faq_mandat' %}">Le mandat</a></li>
-          <li><a href="{% url 'faq_donnees_personnelles' %}">Les données personnelles</a></li>
-        </ul>
-      </aside>
+      {% include 'public_website/faq/_nav.html' with active="habilitation" %}
       <div class="main">
         <div class="panel">
           <h2>Questions sur l’habilitation</h2>

--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -43,6 +43,24 @@
               responsable de la structure).
             </li>
           </ul>
+          <h3>L'habilitation se fait-elle au nom d'une personne physique ou au nom de la structure ?</h3>
+          <p>L'habilitation est portée par la structure et se rapporte donc au nom de la structure. Tout changement relatif à la structure (adresse, responsable de structure)
+            doit être notifié à l'adresse mail suivante : contact@aidantsconnect.beta.gouv.fr.</p>
+          <h3>Dans le cadre d'une structure qui comporte plusieurs services d'accompagnement, est-il préférable de demander une seule habilitation pour la structure ou une habilitation par service ?</h3>
+          <p>Le responsable de structure étant chargé d'assurer la sécurité de l'outil et son suivi, il est conseillé de minimiser le nombre d'aidants par habilitation. 
+            Aidants Connect recommande une habilitation par lieu d'accueil.</p>
+          <h3>Quelles adresses e-mail renseigner dans le formulaire d'habilitation ?</h3>
+          <p>L'adresse e-mail de l'aidant à habiliter doit être une adresse e-mail professionnelle, nominative et individuelle. Elle doit être associée à une personne en particulier. Les adresses e-mail génériques de type contact@, direction@ ccas.ville@, mairie@ 
+            ne peuvent donc pas être utilisées pour une habilitation Aidants Connect.</p>
+          <p>Il s'agit d'un prérequis pour garantir la sécurité de l’outil et la fiabilité des traces de connexion. En cas de litige, 
+            Aidants Connect permet de retracer les données objectives (traces de connexion sur un site administratif) et de garantir la protection de l’aidant concerné si besoin - ce qui serait impossible avec une adresse mail générique.</p>
+          <h3>Les élus peuvent-ils être habilités Aidants Connect ?</h3>
+          <p>Pour les communes disposant d'un CCAS, les élus ne peuvent pas être habilités. 
+            Nous recommandons aux élus de faire habiliter le CCAS qui est la structure missionnée pour l'accompagnement social d'usagers.</p>
+          <p>Pour les communes ne disposant pas de CCAS (moins de 1 500 habitants), les élus sont éligibles.</p>
+          <h3>Qui doit remplir le formulaire d’habilitation au sein de la structure ?</h3>
+          <p>Nous recommandons que ce soit le responsable de structure, en charge de la mise en place d’Aidants Connect, de remplir le formulaire d’habilitation.
+            Néanmoins, il est possible qu’un aidant puisse remplir le formulaire d’habilitation si le responsable de structure lui en a donné l’autorisation.</p>
         </div>{# end div.panel #}
       </div>{# end div.main #}
     </div>{# end div.dashboard #}

--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -22,44 +22,44 @@
       <div class="main">
         <div class="panel">
           <h2>Questions sur l’habilitation</h2>
-          <h3>Pourquoi les bénévoles ne peuvent pas être habilités Aidants Connect ?</h3>
-          <p>Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :</p>
+          <h3>Pourquoi les bénévoles ne peuvent pas être habilités Aidants Connect&nbsp;?</h3>
+          <p>Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes&nbsp;:</p>
           <ul>
             <li>Les bénévoles n’ont pas de contrat de travail avec la structure dans laquelle ils se portent
-              volontaires. En cas de litige, aucun recours n’est donc possible ;
+              volontaires. En cas de litige, aucun recours n’est donc possible&nbsp;;
             </li>
             <li>L’aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c’est-à-dire le
               responsable de la structure).
             </li>
           </ul>
-          <h3>Pourquoi les services civiques ne peuvent pas être habilités Aidants Connect ?</h3>
-          <p>Les services civiques ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :</p>
+          <h3>Pourquoi les services civiques ne peuvent pas être habilités Aidants Connect&nbsp;?</h3>
+          <p>Les services civiques ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes&nbsp;:</p>
           <ul>
             <li>Le service Aidants Connect est accessible uniquement aux professionnels de l’accompagnement qui ont donc
-              de l’expérience dans l’accompagnement des publics isolés ;
+              de l’expérience dans l’accompagnement des publics isolés&nbsp;;
             </li>
-            <li>Chaque aidant professionnel doit suivre une formation avant d’utiliser le service Aidants Connect ;</li>
+            <li>Chaque aidant professionnel doit suivre une formation avant d’utiliser le service Aidants Connect&nbsp;;</li>
             <li>L’aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c’est-à-dire le
               responsable de la structure).
             </li>
           </ul>
-          <h3>L'habilitation se fait-elle au nom d'une personne physique ou au nom de la structure ?</h3>
-          <p>L'habilitation est portée par la structure et se rapporte donc au nom de la structure. Tout changement relatif à la structure (adresse, responsable de structure)
-            doit être notifié à l'adresse mail suivante : contact@aidantsconnect.beta.gouv.fr.</p>
-          <h3>Dans le cadre d'une structure qui comporte plusieurs services d'accompagnement, est-il préférable de demander une seule habilitation pour la structure ou une habilitation par service ?</h3>
-          <p>Le responsable de structure étant chargé d'assurer la sécurité de l'outil et son suivi, il est conseillé de minimiser le nombre d'aidants par habilitation. 
-            Aidants Connect recommande une habilitation par lieu d'accueil.</p>
-          <h3>Quelles adresses e-mail renseigner dans le formulaire d'habilitation ?</h3>
-          <p>L'adresse e-mail de l'aidant à habiliter doit être une adresse e-mail professionnelle, nominative et individuelle. Elle doit être associée à une personne en particulier. Les adresses e-mail génériques de type contact@, direction@ ccas.ville@, mairie@ 
+          <h3>L’habilitation se fait-elle au nom d’une personne physique ou au nom de la structure&nbsp;?</h3>
+          <p>L’habilitation est portée par la structure et se rapporte donc au nom de la structure. Tout changement relatif à la structure (adresse, responsable de structure)
+            doit être notifié à l’adresse mail suivante&nbsp;: contact@aidantsconnect.beta.gouv.fr.</p>
+          <h3>Dans le cadre d’une structure qui comporte plusieurs services d’accompagnement, est-il préférable de demander une seule habilitation pour la structure ou une habilitation par service&nbsp;?</h3>
+          <p>Le responsable de structure étant chargé d’assurer la sécurité de l’outil et son suivi, il est conseillé de minimiser le nombre d’aidants par habilitation.
+            Aidants Connect recommande une habilitation par lieu d’accueil.</p>
+          <h3>Quelles adresses e-mail renseigner dans le formulaire d’habilitation&nbsp;?</h3>
+          <p>L’adresse e-mail de l’aidant à habiliter doit être une adresse e-mail professionnelle, nominative et individuelle. Elle doit être associée à une personne en particulier. Les adresses e-mail génériques de type contact@, direction@ ccas.ville@, mairie@
             ne peuvent donc pas être utilisées pour une habilitation Aidants Connect.</p>
-          <p>Il s'agit d'un prérequis pour garantir la sécurité de l’outil et la fiabilité des traces de connexion. En cas de litige, 
+          <p>Il s’agit d’un prérequis pour garantir la sécurité de l’outil et la fiabilité des traces de connexion. En cas de litige,
             Aidants Connect permet de retracer les données objectives (traces de connexion sur un site administratif) et de garantir la protection de l’aidant concerné si besoin - ce qui serait impossible avec une adresse mail générique.</p>
-          <h3>Les élus peuvent-ils être habilités Aidants Connect ?</h3>
-          <p>Pour les communes disposant d'un CCAS, les élus ne peuvent pas être habilités. 
-            Nous recommandons aux élus de faire habiliter le CCAS qui est la structure missionnée pour l'accompagnement social d'usagers.</p>
-          <p>Pour les communes ne disposant pas de CCAS (moins de 1 500 habitants), les élus sont éligibles.</p>
-          <h3>Qui doit remplir le formulaire d’habilitation au sein de la structure ?</h3>
-          <p>Nous recommandons que ce soit le responsable de structure, en charge de la mise en place d’Aidants Connect, de remplir le formulaire d’habilitation.
+          <h3>Les élus peuvent-ils être habilités Aidants Connect&nbsp;?</h3>
+          <p>Pour les communes disposant d’un <abbr title="Centre Communal d’action sociale">CCAS</abbr>, les élus ne peuvent pas être habilités.
+            Nous recommandons aux élus de faire habiliter le CCAS qui est la structure missionnée pour l’accompagnement social d’usagers.</p>
+          <p>Pour les communes ne disposant pas de CCAS (moins de 1500 habitants), les élus sont éligibles.</p>
+          <h3>Qui doit remplir le formulaire d’habilitation au sein de la structure&nbsp;?</h3>
+          <p>Nous recommandons que ce soit le responsable de structure, en charge de la mise en place d’Aidants Connect, qui se charge de remplir le formulaire d’habilitation.
             Néanmoins, il est possible qu’un aidant puisse remplir le formulaire d’habilitation si le responsable de structure lui en a donné l’autorisation.</p>
         </div>{# end div.panel #}
       </div>{# end div.main #}

--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -1,0 +1,56 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - FAQ Habilitation{% endblock %}
+
+{% block extracss %}
+  <link href="{% static 'css/home.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+  <section class="section">
+    <div class="container container-small">
+      <h1 class="section__title">Foire aux questions</h1>
+      <p class="section__subtitle">
+        Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos
+        équipes.
+      </p>
+    </div>
+    <div class="dashboard" id="faq-content">
+      <aside class="side-menu" role="navigation">
+        <ul>
+          <li><a href="{% url 'faq_generale' %}">Le service Aidants Connect</a></li>
+          <li><a href="{% url 'faq_mandat' %}">Le mandat</a></li>
+          <li><a href="{% url 'faq_donnees_personnelles' %}">Les données personnelles</a></li>
+        </ul>
+      </aside>
+      <div class="main">
+        <div class="panel">
+          <h2>Questions sur l’habilitation</h2>
+          <h3>Pourquoi les bénévoles ne peuvent pas être habilités Aidants Connect ?</h3>
+          <p>Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :</p>
+          <ul>
+            <li>Les bénévoles n’ont pas de contrat de travail avec la structure dans laquelle ils se portent
+              volontaires. En cas de litige, aucun recours n’est donc possible ;
+            </li>
+            <li>L’aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c’est-à-dire le
+              responsable de la structure).
+            </li>
+          </ul>
+          <h3>Pourquoi les services civiques ne peuvent pas être habilités Aidants Connect ?</h3>
+          <p>Les services civiques ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes :</p>
+          <ul>
+            <li>Le service Aidants Connect est accessible uniquement aux professionnels de l’accompagnement qui ont donc
+              de l’expérience dans l’accompagnement des publics isolés ;
+            </li>
+            <li>Chaque aidant professionnel doit suivre une formation avant d’utiliser le service Aidants Connect ;</li>
+            <li>L’aidant professionnel engage sa responsabilité pénale comme celle de sa hiérarchie (c’est-à-dire le
+              responsable de la structure).
+            </li>
+          </ul>
+        </div>{# end div.panel #}
+      </div>{# end div.main #}
+    </div>{# end div.dashboard #}
+  </section>
+{% endblock content %}

--- a/aidants_connect_web/templates/public_website/faq/mandat.html
+++ b/aidants_connect_web/templates/public_website/faq/mandat.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - FAQ{% endblock %}
+{% block title %}Aidants Connect - FAQ Mandat{% endblock %}
 
 {% block extracss %}
 <link href="{% static 'css/home.css' %}" rel="stylesheet">

--- a/aidants_connect_web/templates/public_website/faq/mandat.html
+++ b/aidants_connect_web/templates/public_website/faq/mandat.html
@@ -15,13 +15,7 @@
     <p class="section__subtitle">Vous trouverez ici les réponses aux questions les plus fréquemment posées à nos équipes.</p>
   </div>
   <div class="dashboard" id="faq-content">
-    <aside class="side-menu" role="navigation">
-      <ul>
-        <li><a href="{% url 'faq_generale' %}">Le service Aidants Connect</a></li>
-        <li><a class="active" href="{% url 'faq_mandat' %}">Le mandat</a></li>
-        <li><a href="{% url 'faq_donnees_personnelles' %}">Les données personnelles</a></li>
-      </ul>
-    </aside>
+    {% include 'public_website/faq/_nav.html' with active="mandat" %}
     <div class="main">
       <div class="panel">
         <h2 id="questions-mandat">Questions sur le mandat</h2>

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -101,6 +101,11 @@ urlpatterns = [
         service.faq_donnees_personnelles,
         name="faq_donnees_personnelles",
     ),
+    path(
+        "faq/habilitation/",
+        service.faq_habilitation,
+        name="faq_habilitation",
+    ),
     # # Datapass
     path("datapass_receiver/", datapass.receiver, name="datapass_receiver"),
 ]

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -183,3 +183,7 @@ def faq_mandat(request):
 
 def faq_donnees_personnelles(request):
     return render(request, "public_website/faq/donnees_personnelles.html")
+
+
+def faq_habilitation(request):
+    return render(request, "public_website/faq/habilitation.html")


### PR DESCRIPTION
## 🌮 Objectif

Dédier une rubrique de FAQ à l'habilitation.

## 🔍 Implémentation

- Mise en place de la page `faq/habilitation`

## 🏕 Amélioration continue

- Refacto pour remettre la navigation FAQ dans un fichier dédié
- Amélioration de l'accessibilité de ce menu de navigation (un des points soulevés par l'audit qui n'avaient pas encore été traités)

## 🖼️ Images

![À quoi ressemble la page FAQ habilitation](https://user-images.githubusercontent.com/1035145/116205678-45746900-a73e-11eb-8612-79f46c2bee11.png)

