### PR TITLE
Suppression de la table des matières du readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,6 @@ Aidants Connect est construit sur les éléments suivants :
 - Python 3.7
 - Django 3.1
 - PostgreSQL
-
-## Sommaire
-[Installer et lancer l'application](#installer-et-lancer-lapplication)
-* [Installer la base de données (pour Mac OSX)](#installer-la-base-de-données-pour-mac-osx)
-* [Installer l'application](#installer-lapplication)
-* [Configurer les variables d'environnement](#configurer-les-variables-denvironnement)
-* [Peupler la base de données](#peupler-la-base-de-données)
-	* ⏩[Installation en local pour test : utiliser les _fixtures_](#installation-en-local-pour-test--utiliser-les-fixtures)
-	* [Installation sur un serveur : Créer un _superuser_](#installation-sur-un-serveur--créer-un-superuser)
-* [Lancer l'application](#lancer-lapplication)
-* [Se connecter à l'application](#se-connecter-à-lapplication)
-	* [Trouver la page d'admin](#trouver-la-page-dadmin)
-	* [Péréniser son authentification à double facteur (2FA)](#péréniser-son-authentification-à-double-facteur-2fa)
-* [Lancer les tests](#lancer-les-tests)
-* [Contribuer à l'application](#contribuer-à-lapplication)
-* [Annexes](#annexes)
-	* [Documentation de FranceConnect](#documentation-de-franceconnect)
-	* [Ré-initialiser la base de données](#ré-initialiser-la-base-de-données)
-		* ⏩[Avec les données de test (fixtures) : Utiliser le Makefile](#avec-les-données-de-test-fixtures--utiliser-le-makefile)
-		* [Avec des données existantes](#avec-des-données-existantes)
-	* [Purger les connexions expirées](#purger-les-connexions-expirées)
-	* [Calcul de `HASH_FC_AS_FI_SECRET` à partir de la valeur de `FC_AS_FI_SECRET`](#calcul-de-hash_fc_as_fi_secret-à-partir-de-la-valeur-de-fc_as_fi_secret)
    
 ## Installer et lancer l'application
 
@@ -162,7 +140,7 @@ python manage.py migrate
 
 Il existe plusieurs moyens de peupler la base de données.
 
-#### ⏩ Installation en local pour test : utiliser les _fixtures_
+#### Installation en local pour test : utiliser les _fixtures_
 
 Des données de test qui créent un environnement complet : 
   ```shell
@@ -297,7 +275,7 @@ pre-commit install
 
 ### Ré-initialiser la base de données
 
-#### ⏩ Avec les données de test (_fixtures_) : Utiliser le Makefile
+#### Avec les données de test (_fixtures_) : Utiliser le Makefile
 
 Pour simplifier le lancement de certaines commandes, un Makefile est disponible. Exemples de commandes :
 


### PR DESCRIPTION
## 🌮 Objectif

Avoir moins de choses à maintenir dans le readme.md tout en préservant la _developer experience_.

## 🔍 Implémentation

- Suppression de la table des matières, puisque Github la calcule tout seul maintenant

## 🏕 Amélioration continue

- J'ai supprimé des emoji dans les titres dont je ne voyais pas le sens ni l'utilité

## 🖼️ Images

Voici où est la table générée par Github, à côté du titre readme.md : 

![Emplacement de la table des matières sur l'interface de Github](https://user-images.githubusercontent.com/1035145/112864091-cb59b180-90b7-11eb-9df6-9a09d0e9b075.png)

