### PR TITLE
Amélioration de l'accessibilité

### DIFF
--- a/aidants_connect_web/static/css/resources.css
+++ b/aidants_connect_web/static/css/resources.css
@@ -1,7 +1,9 @@
 .hero img {
   max-width: 200px;
 }
-
+h2 .text-very-small::before {
+	content: '• ';
+}
 #videos .section__subtitle {
 	margin-bottom: 3em;
 }

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/organisation.html
@@ -43,14 +43,14 @@
       <table class="table">
         <thead>
           <tr>
-            <th class="th-50">Nom</th>
-            <th>Email</th>
+            <th scope="col" class="th-50">Nom</th>
+            <th scope="col">Email</th>
           </tr>
         </thead>
         <tbody>
           {% for aidant in organisation_active_aidants %}
             <tr>
-              <td>{{ aidant.get_full_name }}</a></td>
+              <td>{{ aidant.get_full_name }}</td>
               <td>{{ aidant.email }}</td>
             </tr>
           {% endfor %}

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -17,12 +17,14 @@
       <li><a href="https://incubateur.anct.gouv.fr/actions/startups-territoires/">Une startup d’État de l'Incubateur des Territoires</a></li>
       <li><a href="https://agence-cohesion-territoires.gouv.fr/">Agence Nationale de la Cohésion des Territoires</a></li>
     </ul>
-    <ul class="footer__links">
-      <li><a href="/cgu">Conditions d’utilisation</a></li>
-      <li><a href="/mentions-legales">Mentions légales</a></li>
-      <li><a href="/faq">Foire aux questions</a></li>
-      <li><a href="/stats">Statistiques</a></li>
-      <li><a href="/accessibilite">Accessibilité</a> (non conforme)</li>
-    </ul>
+    <nav role="navigation" aria-label="Menu pied de page">
+      <ul class="footer__links">
+        <li><a href="/cgu">Conditions d’utilisation</a></li>
+        <li><a href="/mentions-legales">Mentions légales</a></li>
+        <li><a href="/faq">Foire aux questions</a></li>
+        <li><a href="/stats">Statistiques</a></li>
+        <li><a href="/accessibilite">Accessibilité</a> (non conforme)</li>
+      </ul>
+    </nav>
   </div>
 </footer>

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -1,5 +1,5 @@
 {% load static %}
-<nav class="skip-links nav__links">
+<nav class="skip-links nav__links" role="navigation" aria-label="Accès rapide">
   <a href="#main">Aller au contenu principal</a>
   <a href="#top_menu">Aller au menu</a>
   <a href="#footer">Aller au pied de page</a>
@@ -10,7 +10,7 @@
       <img class="navbar__gouvfr" src="{% static 'images/Marianne_logo_1120.png' %}" alt="" />
       <img class="navbar__logo" src="{% static 'images/aidants-connect_logo.png' %}"  alt="Aidants Connect" />
     </a>
-    <nav role="navigation">
+    <nav role="navigation" aria-label="Menu principal">
       <ul class="nav__links" id="top_menu">
         {% with view_name=request.resolver_match.view_name %}
           {% if request.user.is_authenticated %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -6,7 +6,9 @@
 <link href="{% static 'css/home.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
-{% block title %}Aidants Connect - Connexion{% endblock %}
+{% block title %}
+  Connexion{% if form.errors|length > 0 %} (Erreur dans le formulaire){% endif %} - Aidants Connect
+{% endblock %}
 
 {% block content %}
 <div class="notification full-width" role="alert">Aidants Connect est pour le moment en phase d’expérimentation avec 13 structures.</div>
@@ -17,7 +19,7 @@
       <br>
       Connectez-vous
     </h1>
-    <p>Vous êtes un·e aidant·e professionnel·le et faites partie d’une structure habilitée Aidants Connect&nbsp;?</p>
+    <p>Vous êtes un ou une aidante professionnelle et faites partie d’une structure habilitée Aidants Connect&nbsp;?</p>
   </div>
 </div>
 <section class="section section-grey">
@@ -26,7 +28,7 @@
       {% csrf_token %}
       {% if user.is_authenticated %}
         <div class="notification" role="alert">
-          Vous êtes déjà connecté
+          Vous êtes déjà connecté.
         </div>
         <div class="text-center">
           <a href="{% url LOGGED_IN_REDIRECT_URL_NAME %}" class="btn btn-success">Accédez à l'accueil</a>

--- a/aidants_connect_web/templates/public_website/guide_utilisation.html
+++ b/aidants_connect_web/templates/public_website/guide_utilisation.html
@@ -13,7 +13,7 @@
   <div class="hero__container">
     <h1>Découvrir et utiliser Aidants Connect</h1>
     <p>Vous trouverez ici les ressources utiles pour comprendre et utiliser le service Aidants Connect.</p>
-    <img src="{% static 'images/aidantsconnect.png' %}" alt="Illustration de Aidants Connect" />
+    <img src="{% static 'images/aidantsconnect.png' %}" alt="" />
   </div>
 </div>
 
@@ -83,7 +83,7 @@
         </div>
         <div class="grid">
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">L'usager·ère a une démarche administrative à réaliser</h3>
             <div>
               <span>></span>
@@ -95,7 +95,7 @@
             </div>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Quel fournisseur d'identité choisir ?</h3>
             <span>
               <span>></span>
@@ -118,7 +118,7 @@
         </div>
         <div class="grid">
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">FranceConnect, c'est quoi ?</h3>
             <span>
               <span>></span>
@@ -130,7 +130,7 @@
             </span>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Se connecter avec FranceConnect</h3>
             <span>
               <span>></span>
@@ -142,7 +142,7 @@
             </span>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Pour les usager·ères qui ne peuvent pas se connecter via FranceConnect</h3>
             <span>
               <span>></span>
@@ -165,7 +165,7 @@
         </div>
         <div class="grid">
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Aidants Connect, c'est quoi ?</h3>
             <span>
               <span>></span>
@@ -177,7 +177,7 @@
             </span>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Expliquer la signature du mandat</h3>
             <span>
               <span>></span>
@@ -189,15 +189,15 @@
             </span>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Utiliser Aidants Connect : le tutoriel pas à pas</h3>
             <span>
               <span>></span>
               <a href="{% static 'guides_aidants_connect/Aidantsconnect_tutoriel.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ tutoriel.pdf"'>Télécharger en couleur</a>
             </span>
           </div>
-           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+          <div class="tile">
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Bilan de l'expérimentation Aidants Connect</h3>
             <span>
               <span>></span>
@@ -205,7 +205,7 @@
             </span>
           </div>
           <div class="tile">
-            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="Icon document" />
+            <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Exemple type de mandat</h3>
             <span>
               <span>></span>

--- a/aidants_connect_web/templates/public_website/guide_utilisation.html
+++ b/aidants_connect_web/templates/public_website/guide_utilisation.html
@@ -24,11 +24,11 @@
     <div class="row">
       <div class="card">
         <div class="card__cover">
-          <iframe width="560" height="250" src="https://www.youtube.com/embed/hATrqHG4zYQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Vidéo sur l'accompagnement des usagers à l'utilisation de FranceConnect" width="560" height="250" src="https://www.youtube.com/embed/hATrqHG4zYQ" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <div class="card__content">
           <h2>Comment accompagner un·e usager·ère à utiliser FranceConnect ?</h2>
-          <div class="card__meta"><a href="https://www.youtube.com/watch?v=hATrqHG4zYQ" title="">https://www.youtube.com/watch?v=hATrqHG4zYQ</a></div>
+          <div class="card__meta"><a href="https://www.youtube.com/watch?v=hATrqHG4zYQ">Voir sur Youtube</a></div>
           <p>
             <strong>Objectif :</strong> comprendre comment accompagner un usager·ère à la création d’une connexion FranceConnect<br />
             <strong>Conditions d’utilisation :</strong> à visionner en autonomie pour vous former
@@ -37,11 +37,11 @@
       </div>
       <div class="card">
         <div class="card__cover">
-          <iframe width="560" height="250" src="https://www.youtube.com/embed/WTHj_kQXnzs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Vidéo « Aidants Connect, comment ça fonctionne ? »" width="560" height="250" src="https://www.youtube.com/embed/WTHj_kQXnzs" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <div class="card__content">
           <h2>Aidants Connect, comment ça fonctionne ?</h2>
-          <div class="card__meta"><a href="https://www.youtube.com/watch?v=WTHj_kQXnzs" title="">https://www.youtube.com/watch?v=WTHj_kQXnzs</a></div>
+          <div class="card__meta"><a href="https://www.youtube.com/watch?v=WTHj_kQXnzs">Voir sur Youtube</a></div>
           <p>
             <strong>Objectif :</strong> comprendre le fonctionnement d'Aidants Connect<br />
             <strong>Conditions d’utilisation :</strong> à visionner en autonomie pour vous former
@@ -53,11 +53,11 @@
     <div class="row">
       <div class="card">
         <div class="card__cover">
-          <iframe width="560" height="250" src="https://www.youtube.com/embed/ihsm-36I-fE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          <iframe title="Vidéo « les aspects juridiques relatifs au tiers de confiance »" width="560" height="250" src="https://www.youtube.com/embed/ihsm-36I-fE" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
         </div>
         <div class="card__content">
           <h2>Les aspects juridiques relatifs au tiers de confiance</h2>
-          <div class="card__meta"><a href="https://www.youtube.com/watch?v=ihsm-36I-fE&t=13s" title="">https://www.youtube.com/watch?v=ihsm-36I-fE&t=13s</a></div>
+          <div class="card__meta"><a href="https://www.youtube.com/watch?v=ihsm-36I-fE&t=13s" title="">Voir sur Youtube</a></div>
           <p>
             <strong>Objectif :</strong> comprendre les enjeux juridiques du tiers de confiance et les conditions de résiliation du mandat<br />
             <strong>Conditions d’utilisation :</strong> à visionner en autonomie pour vous former

--- a/aidants_connect_web/templates/public_website/guide_utilisation.html
+++ b/aidants_connect_web/templates/public_website/guide_utilisation.html
@@ -78,7 +78,7 @@
         <div class="panel__header">
           <h2>
             Questionner son public
-            <small class="text-very-small">• 2 documents</small>
+            <small class="text-very-small">2 documents</small>
           </h2>
         </div>
         <div class="grid">
@@ -105,7 +105,7 @@
         <div class="panel__header">
           <h2>
             Expliquer ce qu'est FranceConnect
-            <small class="text-very-small">• 3 documents</small>
+            <small class="text-very-small">3 documents</small>
           </h2>
         </div>
         <div class="grid">
@@ -140,7 +140,7 @@
         <div class="panel__header">
           <h2>
             Comment fonctionne Aidants Connect ?
-            <small class="text-very-small">• 5 documents</small>
+            <small class="text-very-small">5 documents</small>
           </h2>
         </div>
         <div class="grid">

--- a/aidants_connect_web/templates/public_website/guide_utilisation.html
+++ b/aidants_connect_web/templates/public_website/guide_utilisation.html
@@ -85,26 +85,18 @@
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">L'usager·ère a une démarche administrative à réaliser</h3>
-            <div>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Démarche-administrative.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Démarche-administrative.pdf"'>Télécharger en couleur</a>
-            </div>
-            <div>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Démarche-administrative _ Impression noir et blanc.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Démarche-administrative _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </div>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Démarche-administrative.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Démarche-administrative _ Impression noir et blanc.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Quel fournisseur d'identité choisir ?</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Franceconnect_3.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Quel-fournisseur-identité-choisir.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Franceconnect_3_N_B.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Quel-fournisseur-identité-choisir _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Franceconnect_3.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Franceconnect_3_N_B.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
         </div>
       </div>
@@ -120,38 +112,26 @@
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">FranceConnect, c'est quoi ?</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Franceconnect_1.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Démarche-administrative.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Franceconnect_1_NB.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Démarche-administrative _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Franceconnect_1.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Franceconnect_1_NB.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Se connecter avec FranceConnect</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Se-connecter-à-FranceConnect.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Se-connecter-à-FranceConnect.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Se-connecter-à-FranceConnect _ Impression noir et blanc.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Se-connecter-à-FranceConnect _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Se-connecter-à-FranceConnect.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Se-connecter-à-FranceConnect _ Impression noir et blanc.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Pour les usager·ères qui ne peuvent pas se connecter via FranceConnect</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Usagers-sans-FranceConnexion.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Usagers-sans-FranceConnexion.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Usagers-sans-FranceConnexion _ Impression noir et blanc.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Usagers-sans-FranceConnexion _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Usagers-sans-FranceConnexion.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Usagers-sans-FranceConnexion _ Impression noir et blanc.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
         </div>
       </div>
@@ -167,54 +147,40 @@
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Aidants Connect, c'est quoi ?</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Aidants-Connect_c_est-quoi.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Aidants-Connect_c_est-quoi.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Aidants-Connect_c_est-quoi _ Impression noir et blanc.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Aidants-Connect_c_est-quoi _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Aidants-Connect_c_est-quoi.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Aidants-Connect_c_est-quoi _ Impression noir et blanc.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Expliquer la signature du mandat</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Je-signe-un-mandat.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Je-signe-un-mandat.pdf"'>Télécharger en couleur</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ Je-signe-un-mandat _ Impression noir et blanc.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ Je-signe-un-mandat _ Impression noir et blanc.pdf"'>Télécharger pour impression en noir et blanc</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Je-signe-un-mandat.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ Je-signe-un-mandat _ Impression noir et blanc.pdf' %}" target="_blank">Télécharger pour impression en noir et blanc</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Utiliser Aidants Connect : le tutoriel pas à pas</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidantsconnect_tutoriel.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ tutoriel.pdf"'>Télécharger en couleur</a>
-            </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Aidantsconnect_tutoriel.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+            </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Bilan de l'expérimentation Aidants Connect</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Aidants Connect _ BilanExperimentation.pdf' %}" target="_blank" title='Accéder au document "Aidants Connect _ BilanExperimentation.pdf"'>Télécharger en couleur</a>
-            </span>
+             <ul>
+               <li><a href="{% static 'guides_aidants_connect/Aidants Connect _ BilanExperimentation.pdf' %}" target="_blank">Télécharger en couleur</a></li>
+             </ul>
           </div>
           <div class="tile">
             <img class="tile__icon" src="{% static 'images/document.svg' %}" alt="" />
             <h3 class="text-center">Exemple type de mandat</h3>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Exemple de mandat Aidants Connect_french.pdf' %}" target="_blank" title='Accéder au document "Exemple de mandat Aidants Connect_french.pdf"'>Télécharger en français</a>
-            </span>
-            <span>
-              <span>></span>
-              <a href="{% static 'guides_aidants_connect/Mandat type Aidants Connect english.pdf' %}" target="_blank" title='Accéder au document "Mandat type Aidants Connect english.pdf"'>Télécharger en anglais</a>
-             </span>
+            <ul>
+              <li><a href="{% static 'guides_aidants_connect/Exemple de mandat Aidants Connect_french.pdf' %}" target="_blank">Télécharger en français</a></li>
+              <li><a href="{% static 'guides_aidants_connect/Mandat type Aidants Connect english.pdf' %}" target="_blank">Télécharger en anglais</a></li>
+            </ul>
           </div>
        </div>
       </div>

--- a/aidants_connect_web/templates/public_website/home_page.html
+++ b/aidants_connect_web/templates/public_website/home_page.html
@@ -26,12 +26,12 @@
   <div class="container">
     <div class="row">
       <div class="min-width-35">
-        <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="Deux personnes assises devant le même écran d’ordinateur" />
+        <img src="{% static 'images/aidantsconnect-illustration.svg' %}" alt="" />
       </div>
       <div>
         <h2>
           Vous accompagnez régulièrement des personnes en difficulté avec le numérique dans la réalisation de démarches en ligne ?<br />
-          <small class="font-weight-normal margin-top-10">→ Aidants Connect est fait pour vous !</small>
+          <small class="font-weight-normal margin-top-10"><span aria-hidden="true">→ </span>Aidants Connect est fait pour vous !</small>
         </h2>
         <p class="small__paragraph">
           <strong>Aidants Connect s’adresse à une diversité d’aidants professionnels</strong>


### PR DESCRIPTION
## 🌮 Objectif

Améliorer l'accessibilité d'Aidants Connect aux internautes et aidants utilisant des lecteurs d'écran ou navigant au clavier.

## 🔍 Implémentation

- Ajout de balises `<nav>` autour de tout ce qui ressemble à un menu de navigation (y compris dans le footer par ex), ajout d'un attribut `role="navigation"` sur icelles, ainsi que d'un `aria-label`.
- Affichage de la mention "erreur dans le formulaire" dans le titre de la page en cas d'erreur sur le formulaire de login.
- Suppression de textes alternatifs sur les images décoratives.
- Ajout de l'attribut `scope` sur les derniers en-têtes de tableaux qui n'en avaient pas
- Changement de `<span><span>></span><a href="">(...)</a></span>` successifs en listes `<ul>` (l'impact visuel est minime).
- Suppression de contenu décoratif du HTML (soit en le supprimant purement pour le passer en CSS, soit en le masquant avec `aria-hidden="true"`)
- Amélioration de l'accessibilité des vidéos sur le guide d'accessibilité (ajout d'un `title` sur les iframes, mise en place de liens mieux libellés).


## ⚠️ Informations supplémentaires

Pour finir de prendre en compte tous les rapports de l'audit, le dernier point qui manque, c'est la transcription des vidéos du guide d'utilisation.

## 🖼️ Images

L'impact visuel est minime, les modifications sont invisibles sauf à deux endroits : 

### Vidéos du guide d'utilisation

Avant : 
![Le lien de la vidéo contient l'URL complète vers Youtube](https://user-images.githubusercontent.com/1035145/113000585-42528100-9170-11eb-9d00-3500beedf812.png)

=> Le lecteur d'écran vocalisait "H T T P deux points slash slash youtube point com"... etc, malgré la présence de l'attribut title vide. :(

Après : 
![Le lien de la vidéo contient "voir sur Youtube"](https://user-images.githubusercontent.com/1035145/113000837-7ded4b00-9170-11eb-8a95-9143f437f5a7.png)

D'après ce que j'ai compris du RGAA, le contexte du lien (en l'occurrence le titre situé juste au-dessus) suffit à le rendre explicite et conforme.

### Liens documents

Les ">" étaient vocalisés par le lecteur d'écran et c'était difficile à comprendre. L'utilisation de `<ul> <li>` change les chevrons en puces, mais facilite++ la navigation au lecteur d'écran.

Avant : 

![Liste à puces contenant des chevrons](https://user-images.githubusercontent.com/1035145/113001163-d4f32000-9170-11eb-9d3f-d41d88348823.png)


Après : 

![Liste à puces contenant des puces](https://user-images.githubusercontent.com/1035145/113001137-cf95d580-9170-11eb-9d2e-9c955037803e.png)
