### PR TITLE
Modification de la façon de générer le QRcode en fonction des informations reçues

### DIFF
--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -15,6 +15,7 @@ from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.models import Autorisation, Connection, Journal, Usager
 from aidants_connect_web.tests.factories import (
     AidantFactory,
+    MandatFactory,
     OrganisationFactory,
     UsagerFactory,
 )
@@ -529,6 +530,39 @@ class GenerateAttestationTests(TestCase):
     def test_autorisation_qrcode_url_triggers_the_correct_view(self):
         found = resolve("/creation_mandat/qrcode/")
         self.assertEqual(found.func, mandat.attestation_qrcode)
+
+    def test_autorisation_qrcode_ok_with_connection_and_mandat_id(self):
+        mandat = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.test_usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+        )
+
+        self.client.force_login(self.aidant_thierry)
+
+        session = self.client.session
+        session["connection"] = 1
+        session["qr_code_mandat_id"] = mandat.pk
+        session.save()
+
+        response = self.client.get("/creation_mandat/qrcode/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_autorisation_qrcode_ok_with_mandat_id(self):
+        mandat = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.test_usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+        )
+
+        self.client.force_login(self.aidant_thierry)
+
+        session = self.client.session
+        session["qr_code_mandat_id"] = mandat.pk
+        session.save()
+
+        response = self.client.get("/creation_mandat/qrcode/")
+        self.assertEqual(response.status_code, 200)
 
     def test_response_is_the_print_page(self):
         self.client.force_login(self.aidant_thierry)


### PR DESCRIPTION
## 🌮 Objectif

Deux petit problème dans la vue attestation_qrcode. Dans le cas où un aidant lance une création de mandat sans la mener à son terme, on a une connexion de créé mais sans journal en rapport avec la création de mandat (vu que le mandat n'est pas créé). Du coup dans la view attestation_qrcode, on a bien l'info de la connexion mais on ne peut la relier a un journal (pour récupérer le hash de l'attestation) et cette éventualité n'étant pas prévu il y a émission d'une 500 (invisible pour l'utilisateur, il n'y a simplement pas de QR code sur le mandat)

Ensuite dans le cas d'une création de mandat compléte, les informations de connexion étant en session, il n'était plus possible d'afficher une attestation d'un autre mandat. 

## 🔍 Implémentation

l'ordre de traitement des paramètres possible est inversé, on commence par traiter l'id du mandat qui peut être passé puis ensuite seulement l'info de session. On gere le cas info de session sans info de journal.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
