### PR TITLE
Ajout d'une table d'association entre les départements et leur région

### DIFF
--- a/aidants_connect_web/fixtures/departements_region.json
+++ b/aidants_connect_web/fixtures/departements_region.json
@@ -1,0 +1,507 @@
+[
+  {
+    "zipcode": "01",
+    "dep_name": "Ain",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": "02",
+    "dep_name": "Aisne",
+    "region_name": "Hauts-de-France"
+  },
+  {
+    "zipcode": "03",
+    "dep_name": "Allier",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": "04",
+    "dep_name": "Alpes-de-Haute-Provence",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": "05",
+    "dep_name": "Hautes-Alpes",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": "06",
+    "dep_name": "Alpes-Maritimes",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": "07",
+    "dep_name": "Ardèche",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": "08",
+    "dep_name": "Ardennes",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": "09",
+    "dep_name": "Ariège",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 10,
+    "dep_name": "Aube",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 11,
+    "dep_name": "Aude",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 12,
+    "dep_name": "Aveyron",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 13,
+    "dep_name": "Bouches-du-Rhône",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": 14,
+    "dep_name": "Calvados",
+    "region_name": "Normandie"
+  },
+  {
+    "zipcode": 15,
+    "dep_name": "Cantal",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 16,
+    "dep_name": "Charente",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 17,
+    "dep_name": "Charente-Maritime",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 18,
+    "dep_name": "Cher",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 19,
+    "dep_name": "Corrèze",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 21,
+    "dep_name": "Côte-d'Or",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 22,
+    "dep_name": "Côtes-d'Armor",
+    "region_name": "Bretagne"
+  },
+  {
+    "zipcode": 23,
+    "dep_name": "Creuse",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 24,
+    "dep_name": "Dordogne",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 25,
+    "dep_name": "Doubs",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 26,
+    "dep_name": "Drôme",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 27,
+    "dep_name": "Eure",
+    "region_name": "Normandie"
+  },
+  {
+    "zipcode": 28,
+    "dep_name": "Eure-et-Loir",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 29,
+    "dep_name": "Finistère",
+    "region_name": "Bretagne"
+  },
+  {
+    "zipcode": "2A",
+    "dep_name": "Corse-du-Sud",
+    "region_name": "Corse"
+  },
+  {
+    "zipcode": "2B",
+    "dep_name": "Haute-Corse",
+    "region_name": "Corse"
+  },
+  {
+    "zipcode": 30,
+    "dep_name": "Gard",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 31,
+    "dep_name": "Haute-Garonne",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 32,
+    "dep_name": "Gers",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 33,
+    "dep_name": "Gironde",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 34,
+    "dep_name": "Hérault",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 35,
+    "dep_name": "Ille-et-Vilaine",
+    "region_name": "Bretagne"
+  },
+  {
+    "zipcode": 36,
+    "dep_name": "Indre",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 37,
+    "dep_name": "Indre-et-Loire",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 38,
+    "dep_name": "Isère",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 39,
+    "dep_name": "Jura",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 40,
+    "dep_name": "Landes",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 41,
+    "dep_name": "Loir-et-Cher",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 42,
+    "dep_name": "Loire",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 43,
+    "dep_name": "Haute-Loire",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 44,
+    "dep_name": "Loire-Atlantique",
+    "region_name": "Pays de la Loire"
+  },
+  {
+    "zipcode": 45,
+    "dep_name": "Loiret",
+    "region_name": "Centre-Val de Loire"
+  },
+  {
+    "zipcode": 46,
+    "dep_name": "Lot",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 47,
+    "dep_name": "Lot-et-Garonne",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 48,
+    "dep_name": "Lozère",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 49,
+    "dep_name": "Maine-et-Loire",
+    "region_name": "Pays de la Loire"
+  },
+  {
+    "zipcode": 50,
+    "dep_name": "Manche",
+    "region_name": "Normandie"
+  },
+  {
+    "zipcode": 51,
+    "dep_name": "Marne",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 52,
+    "dep_name": "Haute-Marne",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 53,
+    "dep_name": "Mayenne",
+    "region_name": "Pays de la Loire"
+  },
+  {
+    "zipcode": 54,
+    "dep_name": "Meurthe-et-Moselle",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 55,
+    "dep_name": "Meuse",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 56,
+    "dep_name": "Morbihan",
+    "region_name": "Bretagne"
+  },
+  {
+    "zipcode": 57,
+    "dep_name": "Moselle",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 58,
+    "dep_name": "Nièvre",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 59,
+    "dep_name": "Nord",
+    "region_name": "Hauts-de-France"
+  },
+  {
+    "zipcode": 60,
+    "dep_name": "Oise",
+    "region_name": "Hauts-de-France"
+  },
+  {
+    "zipcode": 61,
+    "dep_name": "Orne",
+    "region_name": "Normandie"
+  },
+  {
+    "zipcode": 62,
+    "dep_name": "Pas-de-Calais",
+    "region_name": "Hauts-de-France"
+  },
+  {
+    "zipcode": 63,
+    "dep_name": "Puy-de-Dôme",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 64,
+    "dep_name": "Pyrénées-Atlantiques",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 65,
+    "dep_name": "Hautes-Pyrénées",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 66,
+    "dep_name": "Pyrénées-Orientales",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 67,
+    "dep_name": "Bas-Rhin",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 68,
+    "dep_name": "Haut-Rhin",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 69,
+    "dep_name": "Rhône",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 70,
+    "dep_name": "Haute-Saône",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 71,
+    "dep_name": "Saône-et-Loire",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 72,
+    "dep_name": "Sarthe",
+    "region_name": "Pays de la Loire"
+  },
+  {
+    "zipcode": 73,
+    "dep_name": "Savoie",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 74,
+    "dep_name": "Haute-Savoie",
+    "region_name": "Auvergne-Rhône-Alpes"
+  },
+  {
+    "zipcode": 75,
+    "dep_name": "Paris",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 76,
+    "dep_name": "Seine-Maritime",
+    "region_name": "Normandie"
+  },
+  {
+    "zipcode": 77,
+    "dep_name": "Seine-et-Marne",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 78,
+    "dep_name": "Yvelines",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 79,
+    "dep_name": "Deux-Sèvres",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 80,
+    "dep_name": "Somme",
+    "region_name": "Hauts-de-France"
+  },
+  {
+    "zipcode": 81,
+    "dep_name": "Tarn",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 82,
+    "dep_name": "Tarn-et-Garonne",
+    "region_name": "Occitanie"
+  },
+  {
+    "zipcode": 83,
+    "dep_name": "Var",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": 84,
+    "dep_name": "Vaucluse",
+    "region_name": "Provence-Alpes-Côte d'Azur"
+  },
+  {
+    "zipcode": 85,
+    "dep_name": "Vendée",
+    "region_name": "Pays de la Loire"
+  },
+  {
+    "zipcode": 86,
+    "dep_name": "Vienne",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 87,
+    "dep_name": "Haute-Vienne",
+    "region_name": "Nouvelle-Aquitaine"
+  },
+  {
+    "zipcode": 88,
+    "dep_name": "Vosges",
+    "region_name": "Grand Est"
+  },
+  {
+    "zipcode": 89,
+    "dep_name": "Yonne",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 90,
+    "dep_name": "Territoire de Belfort",
+    "region_name": "Bourgogne-Franche-Comté"
+  },
+  {
+    "zipcode": 91,
+    "dep_name": "Essonne",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 92,
+    "dep_name": "Hauts-de-Seine",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 93,
+    "dep_name": "Seine-Saint-Denis",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 94,
+    "dep_name": "Val-de-Marne",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 95,
+    "dep_name": "Val-d'Oise",
+    "region_name": "Île-de-France"
+  },
+  {
+    "zipcode": 971,
+    "dep_name": "Guadeloupe",
+    "region_name": "Guadeloupe"
+  },
+  {
+    "zipcode": 972,
+    "dep_name": "Martinique",
+    "region_name": "Martinique"
+  },
+  {
+    "zipcode": 973,
+    "dep_name": "Guyane",
+    "region_name": "Guyane"
+  },
+  {
+    "zipcode": 974,
+    "dep_name": "La Réunion",
+    "region_name": "La Réunion"
+  },
+  {
+    "zipcode": 976,
+    "dep_name": "Mayotte",
+    "region_name": "Mayotte"
+  }
+]

--- a/aidants_connect_web/migrations/0052_add_departements_to_region_table.py
+++ b/aidants_connect_web/migrations/0052_add_departements_to_region_table.py
@@ -1,0 +1,140 @@
+from os.path import dirname, join as path_join
+from json import loads as json_loads
+
+import django
+from django.db import migrations, models, transaction
+
+import aidants_connect_web
+
+
+@transaction.atomic
+def populate_departements_to_region_table(apps, _):
+    # noinspection PyPep8Naming
+    DatavizRegion = apps.get_model("aidants_connect_web", "DatavizRegion")
+    # noinspection PyPep8Naming
+    DatavizDepartment = apps.get_model("aidants_connect_web", "DatavizDepartment")
+    # noinspection PyPep8Naming
+    DatavizDepartmentsToRegion = apps.get_model(
+        "aidants_connect_web", "DatavizDepartmentsToRegion"
+    )
+
+    fixture = path_join(
+        dirname(aidants_connect_web.__file__), "fixtures", "departements_region.json"
+    )
+
+    with open(fixture) as f:
+        json = json_loads(f.read())
+        regions = sorted(set(item["region_name"] for item in json))
+
+        for region in regions:
+            DatavizRegion(name=region).save()
+
+        for item in json:
+            department = DatavizDepartment(
+                zipcode=item["zipcode"], dep_name=item["dep_name"]
+            )
+            department.save()
+
+            region = DatavizRegion.objects.get(name=item["region_name"])
+
+            DatavizDepartmentsToRegion(department=department, region=region).save()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("aidants_connect_web", "0051_mandat_template_path"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DatavizDepartment",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "zipcode",
+                    models.CharField(
+                        max_length=10, unique=True, verbose_name="Code Postal"
+                    ),
+                ),
+                (
+                    "dep_name",
+                    models.CharField(max_length=50, verbose_name="Nom de département"),
+                ),
+            ],
+            options={
+                "verbose_name": "Département",
+                "db_table": "dataviz_department",
+            },
+        ),
+        migrations.CreateModel(
+            name="DatavizRegion",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "name",
+                    models.CharField(
+                        max_length=50, unique=True, verbose_name="Nom de région"
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Région",
+                "db_table": "dataviz_region",
+            },
+        ),
+        migrations.CreateModel(
+            name="DatavizDepartmentsToRegion",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "department",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="aidants_connect_web.datavizdepartment",
+                    ),
+                ),
+                (
+                    "region",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="aidants_connect_web.datavizregion",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Assocation départments/région",
+                "verbose_name_plural": "Assocations départments/région",
+                "db_table": "dataviz_departements_to_region",
+            },
+        ),
+        migrations.RunPython(
+            populate_departements_to_region_table,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.auth.models import AbstractUser, UserManager
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
-from django.db.models import Q, QuerySet, SET_NULL
+from django.db.models import Q, QuerySet, SET_NULL, CASCADE
 from django.template import loader
 from django.urls import reverse
 from django.utils import timezone
@@ -797,3 +797,45 @@ class CarteTOTP(models.Model):
     class Meta:
         verbose_name = "carte TOTP"
         verbose_name_plural = "cartes TOTP"
+
+
+# The Dataviz* models represent metadata that are used for data display in Metabase.
+# Do not remove even if they are not used directly in the code.
+class DatavizDepartment(models.Model):
+    zipcode = models.CharField(
+        "Code Postal", max_length=10, null=False, blank=False, unique=True
+    )
+    dep_name = models.CharField(
+        "Nom de département", max_length=50, null=False, blank=False
+    )
+
+    class Meta:
+        db_table = "dataviz_department"
+        verbose_name = "Département"
+
+
+class DatavizRegion(models.Model):
+    name = models.CharField(
+        "Nom de région", max_length=50, null=False, blank=False, unique=True
+    )
+
+    class Meta:
+        db_table = "dataviz_region"
+        verbose_name = "Région"
+
+
+class DatavizDepartmentsToRegion(models.Model):
+    department = models.OneToOneField(
+        DatavizDepartment,
+        null=False,
+        blank=False,
+        on_delete=CASCADE,
+    )
+    region = models.ForeignKey(
+        DatavizRegion, null=False, blank=False, on_delete=CASCADE
+    )
+
+    class Meta:
+        db_table = "dataviz_departements_to_region"
+        verbose_name = "Assocation départments/région"
+        verbose_name_plural = "Assocations départments/région"


### PR DESCRIPTION
## 🌮 Objectif

Ajout d'une table d'association entre les départements et leur région d'appartenence pour la data-visualisation dans Metabase.

## 🔍 Implémentation

Ajout d'une migration Django. Les données proviennent de [data.gouv.fr](https://www.data.gouv.fr/fr/datasets/departements-et-leurs-regions/).

## 🏕 Amélioration continue

## ⚠️ Informations supplémentaires

## 🖼️ Images
