### PR TITLE
Unification de l'extraction des valeurs booléennes depuis les variables d'environnement dans les settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/ambv/black
-    rev: stable
+  - repo: https://github.com/psf/black
+    rev: master
     hooks:
     - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/aidants_connect_web/tests/test_settings.py
+++ b/aidants_connect_web/tests/test_settings.py
@@ -1,0 +1,50 @@
+from unittest import TestCase
+import os
+import uuid
+
+from aidants_connect.settings import getenv_bool
+
+
+class Test(TestCase):
+    env_key = str(uuid.uuid4())
+
+    def setUp(self) -> None:
+        try:
+            del os.environ[self.env_key]
+        except KeyError:
+            pass
+
+    def test_getenv_bool_env_is_not_set(self):
+        self.assertRaises(ValueError, getenv_bool, self.env_key)
+
+    def test_getenv_bool_env_is_not_set_default_value(self):
+        self.assertIs(True, getenv_bool(self.env_key, True))
+
+    def test_getenv_bool_env_integer_value(self):
+        os.environ[self.env_key] = "0"
+        self.assertIs(False, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "1"
+        self.assertIs(True, getenv_bool(self.env_key))
+
+    def test_getenv_bool_env_bool_value(self):
+        os.environ[self.env_key] = "false"
+        self.assertIs(False, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "False"
+        self.assertIs(False, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "FALSE"
+        self.assertIs(False, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "no"
+        self.assertIs(False, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "true"
+        self.assertIs(True, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "True"
+        self.assertIs(True, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "TRUE"
+        self.assertIs(True, getenv_bool(self.env_key))
+        os.environ[self.env_key] = "yes"
+        self.assertIs(True, getenv_bool(self.env_key))
+
+    def test_getenv_bool_env_invalid_value(self):
+        os.environ[self.env_key] = "-1"
+        self.assertRaises(ValueError, getenv_bool, self.env_key)
+        self.assertIs(True, getenv_bool(self.env_key, True))


### PR DESCRIPTION
## 🌮 Objectif

#327 a changé la façon d'extraire les valeurs booléennes depuis les variables d'environnement pour la variable `DEBUG`. Cette PR généralise cette méthodes pour toutes les valeurs booléennes du `settings.py` avec des tests pour valider que tout tient bien.

## 🔍 Implémentation

Les valeurs possibles deviennent n'importe quel entier positif (*0* pour *faux* et n'importe quel entier non-nul pour *vrai*), *yes*, *true*, *no et *false* dans n'importe quelle capitalisation. Un exception sera jetée si la variable d'environnement n'existe pas ou qu'une valeur invalide est donnée et qu'aucune valeur par défaut n'est passée.

## 🏕 Amélioration continue

Changement du dépôt et de la branche principale de Black dans le fichier `.pre-commit-config.yaml`.

## ⚠️ Informations supplémentaires

## 🖼️ Images
