### PR TITLE
Màj de pre-commmit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 20.8b0
     hooks:
     - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ gunicorn==20.0.4
 ipython==7.16.1
 mock==4.0.2
 Pillow==8.1.1
-pre-commit==2.5.1
+pre-commit==2.11.1
 psycopg2-binary==2.8.5
 ptpython==3.0.2
 pudb==2019.2


### PR DESCRIPTION
## 🌮 Objectif

Depuis le merge de #335, Black réclame, à chaque déclanchement du hook, une mise à jour de `pre-commit` à la version 2.9 minimum. `pre-commit` affiche aussi un warning concernant la branche `master` qui est une référence git mouvante. Cette PR change la référence dans le fichier `.pre-commit-config.yaml` pour un tag de version afin de silencer cet avertissement.

## 🔍 Implémentation

## 🏕 Amélioration continue

## ⚠️ Informations supplémentaires

## 🖼️ Images
