### PR TITLE
Ajoute le suivi d'erreur dans Sentry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ FC_AS_FI_LOGOUT_REDIRECT_URI=https://...
 FC_AS_FI_HASH_SALT=""
 HASH_FC_AS_FI_SECRET=<insert_your_data>
 
+# SENTRY_DSN=https://....ingest.sentry.io/...
+# SENTRY_ENV=development
+
 FC_CONNECTION_AGE=300  # 5 minutes, in seconds
 
 # Number of minutes of inactivity before checking

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -16,6 +16,8 @@ import re
 from typing import Union
 
 from dotenv import load_dotenv
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
 
 from aidants_connect.postgres_url import turn_psql_url_into_param
 
@@ -104,6 +106,16 @@ DEBUG = getenv_bool("DEBUG", False)
 ENV_SEPARATOR = ","
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost").split(ENV_SEPARATOR)
 
+# Init Sentry if the DSN is defined
+SENTRY_DSN = os.getenv("SENTRY_DSN", None)
+
+if SENTRY_DSN:
+    SENTRY_ENV = os.getenv("SENTRY_ENV", "unknown")
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        environment=SENTRY_ENV,
+    )
 
 # Application definition
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ pytz==2020.1
 qrcode==6.1
 requests==2.24.0
 selenium==3.141.0
+sentry-sdk==1.0.0
 sqlparse==0.3.1
 whitenoise==5.1.0
 


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir suivre les erreurs qui arriveraient en prod/préprod de manière plus lisible que par la ML technique, dans un contexte où notre volume d'utilisateurs est en augmentation.

## 🔍 Implémentation

- Suivi des erreurs dans Sentry à l'aide du SDK fourni.
- Ça ressemble à ceci : https://sentry.io/organizations/betagouv-f7/issues/2321592237/?project=5707861

## ⚠️ Informations supplémentaires

- Il faudra renseigner les variables d'environnement `SENTRY_DSN` et `SENTRY_ENVIRONMENT` sur les trois environnements Scalingo.
- J'aimerais bien suivre les erreurs 404 et autres 400 en plus des erreurs 500, car ça peut parfois nous aider à détecter des liens morts qui peuvent être très gênants côté utilisateurs.
- Quid de suivre aussi là-dedans les tentatives d'entrée dans le honeypot ?