### PR TITLE
Séparation des utilisateurs avec mandat actif de ceux sans mandat actif

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -8,8 +8,8 @@
   <section class="section">
     <div class="container">
       <div class="row">
-        <h1 class="margin-bottom-0">Vos usagers</h1>
-        <a href="{% url 'new_mandat' %}" class="button float-right" id="add_usager">📝&nbsp;Ajouter un usager</a>
+        <h1 class="margin-bottom-0">Vos usagères et usagers</h1>
+        <a href="{% url 'new_mandat' %}" class="button float-right" id="add_usager"><span aria-hidden="true">📝&nbsp;</span>Ajouter une usagère ou un usager</a>
       </div>
       {% if messages %}
         <div class="notification success" role="alert">
@@ -19,9 +19,12 @@
         </div>
       {% endif %}
       <div class="tiles">
-        <h2>Les usagers avec qui vous avez un mandat</h2>
-        {% if usagers %}
+        {% if usagers_dict.total == 0 %}
+        <div class="notification" role="alert">Il n'y a encore personne avec qui vous avez un mandat.</div>
+        {% else %}
+          {% if usagers_dict.with_valid_mandate_count > 0 %}
           {# <input class="table__filter" type="text" name="input_val" placeholder="Trouver un usager (à venir)" aria-label="Trouver les usagers (à venir)"> #}
+          <h2>Les usagères et usagers avec qui vous avez un mandat actif</h2>
           <table class="table">
             <thead>
             <tr>
@@ -32,7 +35,7 @@
             </tr>
             </thead>
             <tbody>
-            {% for usager, autorisations in usagers.items %}
+            {% for usager, autorisations in usagers_dict.with_valid_mandate.items %}
               <tr>
                 <td>
                   <a href="{% url 'usager_details' usager_id=usager.id %}">
@@ -44,14 +47,14 @@
                   </a>
                 </td>
                 <td>{{ usager.given_name }}</td>
-                <td>{{ usager.birthdate | date:"d F" }}</td>
+                <td>{{ usager.birthdate|date:"d F" }}</td>
                 <td>
                   <ul>
                     {% for autorisation, expired_soon in autorisations %}
                       <li>
                         {{ autorisation }}
                         {% if expired_soon %}
-                          <span title="expire le {{ expired_soon| date:"d F" }}">⏳</span>
+                          <span title="expire le {{ expired_soon|date:"d F" }}">⏳</span>
                         {% endif %}
                       </li>
                     {% endfor %}
@@ -61,11 +64,39 @@
             {% endfor %}
             </tbody>
           </table>
-        {% else %}
-          <div class="notification" role="alert">Vous n’avez pas d'usagers avec un mandat.</div>
-        {% endif %}
+          {% endif %}
+          {% if usagers_dict.without_valid_mandate_count > 0 %}
+          <h2>Les usagères et usagers avec qui vous avez un mandat passé</h2>
+          <table class="table">
+            <thead>
+            <tr>
+              <th scope="col">Nom</th>
+              <th scope="col">Prénom</th>
+              <th scope="col">Date de naissance</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for usager in usagers_dict.without_valid_mandate %}
+              <tr>
+                <td>
+                  <a href="{% url 'usager_details' usager_id=usager.id %}">
+                    {% if usager.preferred_username %}
+                      {{ usager.preferred_username }}<br/>
+                      Né(e)
+                    {% endif %}
+                    {{ usager.family_name }}
+                  </a>
+                </td>
+                <td>{{ usager.given_name }}</td>
+                <td>{{ usager.birthdate |date:"d F" }}</td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+          {% endif %}
 
+        {% endif %}
       </div>
-      <div>
+    <div>
   </section>
 {% endblock content %}

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -26,7 +26,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         login_aidant(self)
 
         welcome_aidant = self.selenium.find_element_by_tag_name("h1").text
-        self.assertEqual(welcome_aidant, "Vos usagers")
+        self.assertEqual(welcome_aidant, "Vos usagères et usagers")
 
         usagers_before = self.selenium.find_elements_by_tag_name("tr")
         self.assertEqual(len(usagers_before), 0)

--- a/aidants_connect_web/tests/test_functional/test_view_autorisations.py
+++ b/aidants_connect_web/tests/test_functional/test_view_autorisations.py
@@ -77,12 +77,10 @@ class ViewAutorisationsTests(FunctionalTestCase):
         # Espace Aidant home
         self.selenium.find_element_by_id("view_mandats").click()
 
+        results = []
+        for el in self.selenium.find_elements_by_tag_name("table"):
+            for tr in el.find_elements_by_css_selector("tbody tr"):
+                results.append(tr)
+
         # autorisation List
-        self.assertEqual(
-            len(
-                self.selenium.find_element_by_tag_name(
-                    "table"
-                ).find_elements_by_css_selector("tbody tr")
-            ),
-            3,
-        )
+        self.assertEqual(len(results), 3)

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -120,8 +120,10 @@ class ViewAutorisationsTests(TestCase):
     def test__get_usagers_dict_from_mandats(self):
         mandats = _get_mandats_for_usagers_index(self.aidant)
         usagers = _get_usagers_dict_from_mandats(mandats)
-        self.assertEqual(4, len(usagers))
-        usager, autorisations = usagers.popitem(last=False)
+        self.assertEqual(4, usagers["total"])
+        self.assertEqual(2, usagers["with_valid_mandate_count"])
+        self.assertEqual(2, usagers["without_valid_mandate_count"])
+        usager, autorisations = usagers["with_valid_mandate"].popitem(last=False)
         self.assertEqual(usager, self.usager_corentin)
         self.assertEqual(
             autorisations,
@@ -130,7 +132,7 @@ class ViewAutorisationsTests(TestCase):
             ],
         )
 
-        usager, autorisations = usagers.popitem(last=False)
+        usager, autorisations = usagers["with_valid_mandate"].popitem(last=False)
         self.assertEqual(usager, self.usager_josephine)
         self.assertEqual(
             autorisations,
@@ -140,13 +142,9 @@ class ViewAutorisationsTests(TestCase):
             ],
         )
 
-        usager, autorisations = usagers.popitem(last=False)
-        self.assertEqual(usager, self.usager_alice)
-        self.assertEqual(autorisations, [])
-
-        usager, autorisations = usagers.popitem(last=False)
-        self.assertEqual(usager, self.usager_philomene)
-        self.assertEqual(autorisations, [("Aucun mandat valide", None)])
+        self.assertSetEqual(
+            usagers["without_valid_mandate"], {self.usager_alice, self.usager_philomene}
+        )
 
 
 @tag("usagers")


### PR DESCRIPTION
## 🌮 Objectif

Dans la la vue des utilisateurs, celles et ceux qui n'ont pas de mandats actifs sont désormais séparés de celles et ceux qui ont un mandat actif. Lorsque la liste est vide, le titre de niveau 2 a été supprimé pour éviter la redondance.



## 🔍 Implémentation

## 🏕 Amélioration continue

- modification de certaines phrases pour les rendre neure sur le plan du genre (utilisation de la double flexion)
- accessibilité : utilisation de `aria-hidden` sur les icônes.

## ⚠️ Informations supplémentaires

## 🖼️ Image

![](https://user-images.githubusercontent.com/22097904/114044136-390b9780-9887-11eb-91f7-80c4b40b8869.png)

![](https://user-images.githubusercontent.com/22097904/114019374-9c3d0000-986e-11eb-9eee-f4bc28d30c13.png)