### PR TITLE
Ajout d'un script pour faciliter les releases

### DIFF
--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -6,23 +6,31 @@ from django.core.management.base import BaseCommand
 class Command(BaseCommand):
     help = "Generate a new tag using provided version number"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Only display changelog, do not tag-push anything",
+        )
+
     def handle(self, *args, **options):
-        self.version = self.ask_for_new_version()
+        if not options["dry_run"]:
+            self.version = self.ask_for_new_version()
 
-        if not self.confirm_if_ok():
-            self.stdout.write(
-                "You’re right, there’s no rush. Try again when you are ready."
-            )
-            return
-        self.stdout.write("OK, let’s tag this then!")
+            if not self.confirm_if_ok():
+                self.stdout.write(
+                    "You’re right, there’s no rush. Try again when you are ready."
+                )
+                return
+            self.stdout.write("OK, let’s tag this then!")
+            self.tag_and_push_on_origin(self.version)
 
-        self.tag_and_push_on_origin(self.version)
         self.changelog = self.display_and_get_changelog()
 
     def ask_for_new_version(self):
         self.stdout.write("Here are the latest versions:")
-        os.system("git tag -l | tail")
-        version = input("Which version number will you give to the new version? ")
+        os.system("git tag -l | tail -5")
+        version = input("How will you name this new version? ")
         return version
 
     def confirm_if_ok(self):

--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -14,7 +14,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        if not options["dry_run"]:
+        dry_run = options["dry_run"]
+        if not dry_run:
             self.version = self.ask_for_new_version()
 
             if not self.confirm_if_ok():
@@ -22,10 +23,12 @@ class Command(BaseCommand):
                     "You’re right, there’s no rush. Try again when you are ready."
                 )
                 return
-            self.stdout.write("OK, let’s tag this then!")
-            self.tag_and_push_on_origin(self.version)
+            self.stdout.write("OK, let’s release aidants-connect, then!")
 
         self.changelog = self.display_and_get_changelog()
+
+        if not dry_run:
+            self.tag_and_push_on_origin(self.version, self.changelog)
 
     def ask_for_new_version(self):
         self.stdout.write("Here are the latest versions:")
@@ -54,8 +57,9 @@ class Command(BaseCommand):
         self.write_horizontal_line()
         return changelog
 
-    def tag_and_push_on_origin(self, version):
-        os.system(f'git tag -a {version} -m ""')
+    def tag_and_push_on_origin(self, version, message):
+        cleaned_message = message.replace("'", "’")
+        os.system(f"git tag -a {version} -m '{cleaned_message}'")
         os.system("git push --tags")
         self.stdout.write(
             self.style.SUCCESS(f"Tag {version} was pushed to git origin!")

--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -17,6 +17,7 @@ class Command(BaseCommand):
         self.stdout.write("OK, let’s tag this then!")
 
         self.tag_and_push_on_origin(self.version)
+        self.changelog = self.display_and_get_changelog()
 
     def ask_for_new_version(self):
         self.stdout.write("Here are the latest versions:")
@@ -30,9 +31,27 @@ class Command(BaseCommand):
         )
         return are_they_sure.lower().strip() == "y"
 
+    def display_and_get_changelog(self):
+        previous_version = os.popen("git tag | tail -1").read().strip()
+        command = (
+            f"git log --pretty='format:%s' --first-parent main {previous_version}..main"
+        )
+        changelog = os.popen(command).read()
+        self.stdout.write(
+            f"\nHere is the changelog since {previous_version},"
+            "you may want to use it for production log:"
+        )
+        self.write_horizontal_line()
+        self.stdout.write(changelog)
+        self.write_horizontal_line()
+        return changelog
+
     def tag_and_push_on_origin(self, version):
         os.system(f'git tag -a {version} -m ""')
         os.system("git push --tags")
         self.stdout.write(
             self.style.SUCCESS(f"Tag {version} was pushed to git origin!")
         )
+
+    def write_horizontal_line(self):
+        self.stdout.write("-" * 15)

--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -1,4 +1,5 @@
 import os
+
 from django.core.management.base import BaseCommand
 
 
@@ -6,22 +7,32 @@ class Command(BaseCommand):
     help = "Generate a new tag using provided version number"
 
     def handle(self, *args, **options):
-        self.stdout.write("Here are the latest versions:")
-        os.system("git tag -l | tail")
-        version = input("Which version number will you give to the new version? ")
-        are_they_sure = input(
-            self.style.WARNING(f"Version {version}, are you sure? (y/N) ")
-        )
-        if are_they_sure.lower().strip() != "y":
+        self.version = self.ask_for_new_version()
+
+        if not self.confirm_if_ok():
             self.stdout.write(
                 "You’re right, there’s no rush. Try again when you are ready."
             )
             return
         self.stdout.write("OK, let’s tag this then!")
 
+        self.tag_and_push_on_origin(self.version)
+
+    def ask_for_new_version(self):
+        self.stdout.write("Here are the latest versions:")
+        os.system("git tag -l | tail")
+        version = input("Which version number will you give to the new version? ")
+        return version
+
+    def confirm_if_ok(self):
+        are_they_sure = input(
+            self.style.WARNING(f"Version {self.version}, are you sure? (y/N) ")
+        )
+        return are_they_sure.lower().strip() == "y"
+
+    def tag_and_push_on_origin(self, version):
         os.system(f'git tag -a {version} -m ""')
         os.system("git push --tags")
-
         self.stdout.write(
             self.style.SUCCESS(f"Tag {version} was pushed to git origin!")
         )

--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -1,6 +1,6 @@
 import os
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):
@@ -16,6 +16,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         if not dry_run:
+            self.check_current_branch()
             self.version = self.ask_for_new_version()
 
             if not self.confirm_if_ok():
@@ -29,6 +30,14 @@ class Command(BaseCommand):
 
         if not dry_run:
             self.tag_and_push_on_origin(self.version, self.changelog)
+
+    def check_current_branch(self):
+        current_branch = os.popen("git rev-parse --abbrev-ref HEAD")
+        if current_branch != "main":
+            raise CommandError(
+                "This script is intended to work ONLY on branch 'main'.\n"
+                "You can use it with the option --dry-run on any branch, though."
+            )
 
     def ask_for_new_version(self):
         self.stdout.write("Here are the latest versions:")

--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -1,0 +1,27 @@
+import os
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Generate a new tag using provided version number"
+
+    def handle(self, *args, **options):
+        self.stdout.write("Here are the latest versions:")
+        os.system("git tag -l | tail")
+        version = input("Which version number will you give to the new version? ")
+        are_they_sure = input(
+            self.style.WARNING(f"Version {version}, are you sure? (y/N) ")
+        )
+        if are_they_sure.lower().strip() != "y":
+            self.stdout.write(
+                "You’re right, there’s no rush. Try again when you are ready."
+            )
+            return
+        self.stdout.write("OK, let’s tag this then!")
+
+        os.system(f'git tag -a {version} -m ""')
+        os.system("git push --tags")
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Tag {version} was pushed to git origin!")
+        )


### PR DESCRIPTION
## 🌮 Objectif

Limiter le risque d'erreur et la charge mentale lors des mises en prod.

## 🔍 Implémentation

Ajout d'une commande `python manage.py release` qui : 
- affiche la liste des derniers tags et demande le suivant
- crée et push le tag annoté avec le changelog
- affiche le changelog pour exploitation dans le journal des actions dans la prod

## 🖼️ Images

Un tag créé par le script : 
![Un tag](https://user-images.githubusercontent.com/1035145/114406661-01169400-9ba8-11eb-86d6-d0fcb6ab7db8.png)

Le script quand on le lance ailleurs que sur `main` : 
<img width="1118" alt="Capture d’écran 2021-04-12 à 15 54 44" src="https://user-images.githubusercontent.com/1035145/114406771-17bceb00-9ba8-11eb-98c4-d0ceba686121.png">

Je vois encore pas mal d'améliorations, mais mine de rien ça fait déjà pas mal de code…