### PR TITLE
Espace responsable structure

### DIFF
--- a/aidants_connect_web/static/css/espace_aidant.css
+++ b/aidants_connect_web/static/css/espace_aidant.css
@@ -11,3 +11,10 @@
   line-height: 1.3;
   font-weight: bold;
 }
+.grid.structures .card:focus-within {
+  outline: 2px solid #0053b3;
+  outline-offset: 2px;
+}
+.grid.structures a:hover .card__meta {
+  color: #fff;
+}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -21,7 +21,7 @@
     <ul class="grid cards">
       {% for org in responsable.responsable_de.all %}
         <li class="card">
-          <a href="#" class="card__content">
+          <a href="{% url 'espace_responsable_organisation' organisation_id=org.id %}" class="card__content">
             <h3>{{ org.name }}</h3>
             <div class="card__meta">{{ org.address }}</div>
           </a>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -18,7 +18,7 @@
     {% endif %}
     <h1 class="section__title">Bienvenue sur votre Espace Responsable, {{ responsable.first_name }}&nbsp!</h1>
     <h2>Les structures dont vous êtes responsable</h2>
-    <ul class="grid cards">
+    <ul class="grid cards structures">
       {% for org in responsable.responsable_de.all %}
         <li class="card">
           <a href="{% url 'espace_responsable_organisation' organisation_id=org.id %}" class="card__content">

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -1,0 +1,33 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - Espace Responsable{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    {% if messages %}
+      {% for message in messages %}
+        <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+    <h1 class="section__title">Bienvenue sur votre Espace Responsable, {{ responsable.first_name }}&nbsp!</h1>
+    <h2>Les structures dont vous êtes responsable</h2>
+    <ul class="grid cards">
+      {% for org in responsable.responsable_de.all %}
+        <li class="card">
+          <a href="#" class="card__content">
+            <h3>{{ org.name }}</h3>
+            <div class="card__meta">{{ org.address }}</div>
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -5,29 +5,43 @@
 {% block title %}Aidants Connect - Espace Responsable{% endblock %}
 
 {% block extracss %}
-<link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
+  <link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
 {% block content %}
-<section class="section">
-  <div class="container">
-    {% if messages %}
-      {% for message in messages %}
-        <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
-    <h1 class="section__title">Bienvenue sur votre Espace Responsable, {{ responsable.first_name }}&nbsp!</h1>
-    <h2>Les structures dont vous êtes responsable</h2>
-    <ul class="grid cards structures">
-      {% for org in responsable.responsable_de.all %}
-        <li class="card">
-          <a href="{% url 'espace_responsable_organisation' organisation_id=org.id %}" class="card__content">
-            <h3>{{ org.name }}</h3>
-            <div class="card__meta">{{ org.address }}</div>
-          </a>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
-</section>
+  <section class="section">
+    <div class="container">
+      {% if messages %}
+        {% for message in messages %}
+          <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+      <h1 class="section__title">Bienvenue sur votre Espace Responsable, {{ responsable.first_name }}&nbsp!</h1>
+      <h2>Les structures dont vous êtes responsable</h2>
+      <ul class="grid cards structures">
+        {% for org in organisations %}
+          <li class="card">
+            <a href="{% url 'espace_responsable_organisation' organisation_id=org.id %}" class="card__content">
+              <h3>{{ org.name }}</h3>
+              <p>
+                <span aria-hidden="true">📍</span>
+                {{ org.address }}
+              </p>
+              <p>
+                <span aria-hidden="true">🏢</span>
+                SIRET : {{ org.siret }}</p>
+              <p>
+                <span aria-hidden="true">👩</span>
+                {% if org.aidants.count == 0 %}
+                  Aucun aidant
+                {% else %}
+                  {{ org.aidants.count }} aidant{{ org.aidants.count|pluralize }}
+                {% endif %}
+              </p>
+            </a>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  </section>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -1,0 +1,64 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - Mon organisation{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    {% if messages %}
+      {% for message in messages %}
+        <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+    <h1>Mon organisation : {{ organisation.name }}</h1>
+    <div class="tiles">
+      <div class="grid">
+        <div class="tile background-color-grey">
+          <h3>Adresse</h3>
+          <p>{{ organisation.address }}</p>
+        </div>
+        <div class="tile background-color-grey">
+          <h3>Aidants actifs</h3>
+          <h5>{{ organisation.num_active_aidants }}</h5>
+        </div>
+        <div class="tile background-color-grey">
+          <h3>Mandats créés</h3>
+          <h5>{{ organisation.num_mandats }}</h5>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section section-grey">
+  <div class="container">
+    <h2>Aidants actifs</h2>
+    {% if organisation_active_aidants %}
+      <table class="table">
+        <thead>
+          <tr>
+            <th scope="col" class="th-50">Nom</th>
+            <th scope="col">Email</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for aidant in organisation_active_aidants %}
+            <tr>
+              <td>{{ aidant.get_full_name }}</td>
+              <td>{{ aidant.email }}</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    {% else %}
+      <div class="notification" role="alert">L'organisation n'a pas encore d'aidants.</div>
+    {% endif %}
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/templates/layouts/nav.html
+++ b/aidants_connect_web/templates/layouts/nav.html
@@ -14,9 +14,18 @@
       <ul class="nav__links" id="top_menu">
         {% with view_name=request.resolver_match.view_name %}
           {% if request.user.is_authenticated %}
+            {%  if request.user.can_create_mandats %}
             <li class="nav__item">
-              <a {% if view_name in 'espace_aidant_home,espace_aidant_organisation,usagers,usager_details,confirm_autorisation_cancelation' %}class="font-weight-bold"{% endif %} href="{% url 'espace_aidant_home' %}">Mon Espace Aidant</a>
+              <a {% if "espace_aidant" in view_name or "usager" in view_name or "mandat" in view_name %}class="font-weight-bold"{% endif %} href="{% url 'espace_aidant_home' %}">Mon Espace Aidant</a>
             </li>
+            {% endif %}
+            {% if request.user.is_responsable_structure %}
+              <li class="nav__item">
+                <a href="{% url 'espace_responsable_home' %}" {% if "espace_responsable" in view_name %}class="font-weight-bold"{% endif %}>
+                  Mon espace Responsable
+                </a>
+              </li>
+            {% endif %}
             <li class="nav__item">
               <a {% if view_name == 'ressources' %}class="font-weight-bold"{% endif %} href="{% url 'ressources' %}">Ressources</a>
             </li>

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -13,8 +13,14 @@ from aidants_connect_web.views import espace_responsable
 class EspaceResponsableHomePageTests(TestCase):
     def setUp(self):
         self.client = Client()
+        # Tom is responsable of 2 structures
         self.responsable_tom = AidantFactory(username="georges@plop.net")
         self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+        self.responsable_tom.responsable_de.add(OrganisationFactory())
+        # Leia is responsable of only one structure
+        self.responsable_leia = AidantFactory(username="leia@resist.sw")
+        self.responsable_leia.responsable_de.add(self.responsable_leia.organisation)
+        # John is a simple aidant
         self.aidant_john = AidantFactory(username="john@doe.du")
 
     def test_anonymous_user_cannot_access_espace_aidant_view(self):
@@ -53,6 +59,14 @@ class EspaceResponsableHomePageTests(TestCase):
         response = self.client.get("/espace-responsable/")
         self.assertTemplateUsed(
             response, "aidants_connect_web/espace_responsable/home.html"
+        )
+
+    def test_responsable_is_redirected_if_has_only_one_structure(self):
+        self.client.force_login(self.responsable_leia)
+        response = self.client.get("/espace-responsable/")
+        self.assertRedirects(
+            response,
+            f"/espace-responsable/organisation/{self.responsable_leia.organisation.id}",
         )
 
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -17,9 +17,9 @@ class EspaceResponsableHomePageTests(TestCase):
         self.responsable_tom = AidantFactory(username="georges@plop.net")
         self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
         self.responsable_tom.responsable_de.add(OrganisationFactory())
-        # Leia is responsable of only one structure
-        self.responsable_leia = AidantFactory(username="leia@resist.sw")
-        self.responsable_leia.responsable_de.add(self.responsable_leia.organisation)
+        # Tim is responsable of only one structure
+        self.responsable_tim = AidantFactory(username="tim@tim.net")
+        self.responsable_tim.responsable_de.add(self.responsable_tim.organisation)
         # John is a simple aidant
         self.aidant_john = AidantFactory(username="john@doe.du")
 
@@ -62,11 +62,11 @@ class EspaceResponsableHomePageTests(TestCase):
         )
 
     def test_responsable_is_redirected_if_has_only_one_structure(self):
-        self.client.force_login(self.responsable_leia)
+        self.client.force_login(self.responsable_tim)
         response = self.client.get("/espace-responsable/")
         self.assertRedirects(
             response,
-            f"/espace-responsable/organisation/{self.responsable_leia.organisation.id}",
+            f"/espace-responsable/organisation/{self.responsable_tim.organisation.id}/",
         )
 
 
@@ -85,13 +85,13 @@ class EspaceResponsableOrganisationPage(TestCase):
 
     def test_espace_responsable_organisation_url_triggers_the_right_view(self):
         self.client.force_login(self.responsable_tom)
-        found = resolve(f"/espace-responsable/organisation/{self.id_organisation}")
+        found = resolve(f"/espace-responsable/organisation/{self.id_organisation}/")
         self.assertEqual(found.func, espace_responsable.organisation)
 
     def test_espace_responsable_organisation_url_triggers_the_right_template(self):
         self.client.force_login(self.responsable_tom)
         response = self.client.get(
-            f"/espace-responsable/organisation/{self.id_organisation}"
+            f"/espace-responsable/organisation/{self.id_organisation}/"
         )
         self.assertEqual(
             response.status_code,
@@ -106,6 +106,6 @@ class EspaceResponsableOrganisationPage(TestCase):
     def test_responsable_cannot_see_an_organisation_they_are_not_responsible_for(self):
         self.client.force_login(self.responsable_tom)
         response = self.client.get(
-            f"/espace-responsable/organisation/{self.autre_organisation.id}"
+            f"/espace-responsable/organisation/{self.autre_organisation.id}/"
         )
         self.assertEqual(response.status_code, 404)

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -15,10 +15,34 @@ class EspaceResponsableHomePageTests(TestCase):
         self.client = Client()
         self.responsable_tom = AidantFactory(username="georges@plop.net")
         self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+        self.aidant_john = AidantFactory(username="john@doe.du")
 
     def test_anonymous_user_cannot_access_espace_aidant_view(self):
         response = self.client.get("/espace-responsable/")
         self.assertRedirects(response, "/accounts/login/?next=/espace-responsable/")
+
+    def test_navigation_menu_contains_a_link_for_the_responsable_structure(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get("/")
+        response_content = response.content.decode("utf-8")
+        self.assertIn(
+            "Mon espace Responsable",
+            response_content,
+            (
+                "Link to espace responsable is invisible to a responsable, "
+                "it should be visible"
+            ),
+        )
+
+    def test_navigation_menu_does_not_contain_a_link_for_the_aidant(self):
+        self.client.force_login(self.aidant_john)
+        response = self.client.get("/")
+        response_content = response.content.decode("utf-8")
+        self.assertNotIn(
+            "Mon espace Responsable",
+            response_content,
+            "Link to espace responsable is visible to an aidant, it should not",
+        )
 
     def test_espace_responsable_home_url_triggers_the_right_view(self):
         found = resolve("/espace-responsable/")

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -1,0 +1,31 @@
+from django.test import tag, TestCase
+from django.test.client import Client
+from django.urls import resolve
+
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+)
+from aidants_connect_web.views import espace_responsable
+
+
+@tag("responsable-structure")
+class EspaceResponsableHomePageTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.responsable_tom = AidantFactory(username="georges@plop.net")
+        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+
+    def test_anonymous_user_cannot_access_espace_aidant_view(self):
+        response = self.client.get("/espace-responsable/")
+        self.assertRedirects(response, "/accounts/login/?next=/espace-responsable/")
+
+    def test_espace_aidant_home_url_triggers_the_right_view(self):
+        found = resolve("/espace-responsable/")
+        self.assertEqual(found.func, espace_responsable.home)
+
+    def test_espace_aidant_home_url_triggers_the_right_template(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get("/espace-responsable/")
+        self.assertTemplateUsed(
+            response, "aidants_connect_web/espace_responsable/home.html"
+        )

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -4,6 +4,7 @@ from django.urls import resolve
 
 from aidants_connect_web.tests.factories import (
     AidantFactory,
+    OrganisationFactory,
 )
 from aidants_connect_web.views import espace_responsable
 
@@ -19,13 +20,54 @@ class EspaceResponsableHomePageTests(TestCase):
         response = self.client.get("/espace-responsable/")
         self.assertRedirects(response, "/accounts/login/?next=/espace-responsable/")
 
-    def test_espace_aidant_home_url_triggers_the_right_view(self):
+    def test_espace_responsable_home_url_triggers_the_right_view(self):
         found = resolve("/espace-responsable/")
         self.assertEqual(found.func, espace_responsable.home)
 
-    def test_espace_aidant_home_url_triggers_the_right_template(self):
+    def test_espace_responsable_home_url_triggers_the_right_template(self):
         self.client.force_login(self.responsable_tom)
         response = self.client.get("/espace-responsable/")
         self.assertTemplateUsed(
             response, "aidants_connect_web/espace_responsable/home.html"
         )
+
+
+@tag("responsable-structure")
+class EspaceResponsableOrganisationPage(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.responsable_tom = AidantFactory(username="georges@plop.net")
+        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+        self.id_organisation = self.responsable_tom.organisation.id
+        self.autre_organisation = OrganisationFactory()
+
+    def test_anonymous_user_cannot_access_espace_responsable_view(self):
+        response = self.client.get("/espace-responsable/")
+        self.assertRedirects(response, "/accounts/login/?next=/espace-responsable/")
+
+    def test_espace_responsable_organisation_url_triggers_the_right_view(self):
+        self.client.force_login(self.responsable_tom)
+        found = resolve(f"/espace-responsable/organisation/{self.id_organisation}")
+        self.assertEqual(found.func, espace_responsable.organisation)
+
+    def test_espace_responsable_organisation_url_triggers_the_right_template(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get(
+            f"/espace-responsable/organisation/{self.id_organisation}"
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            "trying to get "
+            f"/espace-responsable/organisation/{self.id_organisation}/",
+        )
+        self.assertTemplateUsed(
+            response, "aidants_connect_web/espace_responsable/organisation.html"
+        )
+
+    def test_responsable_cannot_see_an_organisation_they_are_not_responsible_for(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get(
+            f"/espace-responsable/organisation/{self.autre_organisation.id}"
+        )
+        self.assertEqual(response.status_code, 404)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -9,6 +9,7 @@ from aidants_connect_web.views import (
     mandat,
     service,
     espace_aidant,
+    espace_responsable,
     usagers,
     datapass,
 )
@@ -80,6 +81,10 @@ urlpatterns = [
         "logout/",
         id_provider.end_session_endpoint,
         name="end_session_endpoint",
+    ),
+    # Espace responsable structure
+    path(
+        "espace-responsable/", espace_responsable.home, name="espace_responsable_home"
     ),
     # FC_as_FS
     path("fc_authorize/", FC_as_FS.fc_authorize, name="fc_authorize"),

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -86,6 +86,11 @@ urlpatterns = [
     path(
         "espace-responsable/", espace_responsable.home, name="espace_responsable_home"
     ),
+    path(
+        "espace-responsable/organisation/<int:organisation_id>",
+        espace_responsable.organisation,
+        name="espace_responsable_organisation",
+    ),
     # FC_as_FS
     path("fc_authorize/", FC_as_FS.fc_authorize, name="fc_authorize"),
     path("callback/", FC_as_FS.fc_callback, name="fc_callback"),

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -87,7 +87,7 @@ urlpatterns = [
         "espace-responsable/", espace_responsable.home, name="espace_responsable_home"
     ),
     path(
-        "espace-responsable/organisation/<int:organisation_id>",
+        "espace-responsable/organisation/<int:organisation_id>/",
         espace_responsable.organisation,
         name="espace_responsable_organisation",
     ),

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,7 +1,12 @@
+from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 
-from aidants_connect_web.decorators import user_is_responsable_structure
+from aidants_connect_web.models import Organisation
+from aidants_connect_web.decorators import (
+    user_is_responsable_structure,
+    activity_required,
+)
 
 
 @login_required
@@ -13,4 +18,26 @@ def home(request):
         request,
         "aidants_connect_web/espace_responsable/home.html",
         {"responsable": responsable},
+    )
+
+
+@login_required
+@user_is_responsable_structure
+@activity_required
+def organisation(request, organisation_id):
+    responsable = request.user
+    organisation = Organisation.objects.get(id=organisation_id)
+    if not organisation:
+        django_messages.error(request, "Vous n'êtes pas rattaché à une organisation.")
+        return redirect("espace_aidant_home")
+
+    organisation_active_aidants = organisation.aidants.active()
+    return render(
+        request,
+        "aidants_connect_web/espace_responsable/organisation.html",
+        {
+            "responsable": responsable,
+            "organisation": organisation,
+            "organisation_active_aidants": organisation_active_aidants,
+        },
     )

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,0 +1,16 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+
+from aidants_connect_web.decorators import user_is_responsable_structure
+
+
+@login_required
+@user_is_responsable_structure
+def home(request):
+    responsable = request.user
+
+    return render(
+        request,
+        "aidants_connect_web/espace_responsable/home.html",
+        {"responsable": responsable},
+    )

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -22,11 +22,16 @@ def check_organisation_and_responsable(responsable, organisation_id):
 @user_is_responsable_structure
 def home(request):
     responsable = request.user
+    organisations = (
+        Organisation.objects.filter(responsables=responsable)
+        .prefetch_related("aidants")
+        .order_by("name")
+    )
 
     return render(
         request,
         "aidants_connect_web/espace_responsable/home.html",
-        {"responsable": responsable},
+        {"responsable": responsable, "organisations": organisations},
     )
 
 

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.decorators import login_required
 from django.http import Http404
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 
 from aidants_connect_web.models import Organisation
 from aidants_connect_web.decorators import (
@@ -27,6 +27,12 @@ def home(request):
         .prefetch_related("aidants")
         .order_by("name")
     )
+
+    if organisations.count() == 1:
+        organisation = organisations[0]
+        return redirect(
+            "espace_responsable_organisation", organisation_id=organisation.id
+        )
 
     return render(
         request,

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,19 +1,15 @@
 from django.contrib.auth.decorators import login_required
 from django.http import Http404
-from django.shortcuts import render, redirect
+from django.shortcuts import render, redirect, get_object_or_404
 
-from aidants_connect_web.models import Organisation
+from aidants_connect_web.models import Aidant, Organisation
 from aidants_connect_web.decorators import (
     user_is_responsable_structure,
     activity_required,
 )
 
 
-def check_organisation_and_responsable(responsable, organisation_id):
-    try:
-        organisation = Organisation.objects.get(id=organisation_id)
-    except Organisation.DoesNotExist:
-        raise Http404
+def check_organisation_and_responsable(responsable: Aidant, organisation: Organisation):
     if responsable not in organisation.responsables.all():
         raise Http404
 
@@ -45,10 +41,10 @@ def home(request):
 @user_is_responsable_structure
 @activity_required
 def organisation(request, organisation_id):
-    responsable = request.user
-    check_organisation_and_responsable(responsable, organisation_id)
+    responsable: Aidant = request.user
+    organisation = get_object_or_404(Organisation, pk=organisation_id)
+    check_organisation_and_responsable(responsable, organisation)
 
-    organisation = Organisation.objects.get(id=organisation_id)
     organisation_active_aidants = organisation.aidants.active()
     return render(
         request,


### PR DESCRIPTION
## 🌮 Objectif

Poser les bases des vues de l'espace "responsable structure"

## 🔍 Implémentation

- Vues "accueil" et "structure (organisation)"
- Quelques tests pour vérifier qu'un responsable ne voit que _ses_ structures, qu'un aidant ne voit pas les vues de la responsable, etc.
- Si un responsable n'est responsable que d'une seule structure, il ne voit pas la vue "accueil" et il est redirigé vers la vue de la structure

## 🏕 Amélioration continue

- J'ai raccourci une ligne du template nav.html

## ⚠️ Informations supplémentaires

Pour donner à quelqu'un le rôle de "responsable structure" ça se passe comme ceci actuellement dans django admin : 

<img width="863" alt="Capture d’écran 2021-04-26 à 12 01 02" src="https://user-images.githubusercontent.com/1035145/116066021-e3592c80-a687-11eb-93b1-ac96f67a7020.png">

Pas sûr que ce soit viable sur la prod et ses centaines de structures…

## 🖼️ Images

Accueil pour un responsable de plusieurs structures : 

![Capture d’écran 2021-04-26 à 12 02 31-fullpage](https://user-images.githubusercontent.com/1035145/116065659-865d7680-a687-11eb-8887-8bb40f23b4c5.png)

Vue d'une page structure (copier-coller de la vue "aidant", sera modifiée dans un avenir proche) : 

![Capture d’écran 2021-04-26 à 12 02 19-fullpage](https://user-images.githubusercontent.com/1035145/116065765-a1c88180-a687-11eb-8340-3dd6932e68cd.png)

