### PR TITLE
Correction de la liste des usagers dans le cas d'un usage avec en même temps un mandat expiré et valide

### DIFF
--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -101,6 +101,12 @@ class ViewAutorisationsTests(TestCase):
             demarche="famille",
         )
 
+        cls.mandat_sans_autorisations_aidant_corentin = MandatFactory(
+            organisation=cls.aidant.organisation,
+            usager=cls.usager_corentin,
+            expiration_date=timezone.now() + timedelta(days=366),
+        )
+
         super().setUpClass()
 
     def test__get_mandats_for_usagers_index(self):
@@ -110,6 +116,7 @@ class ViewAutorisationsTests(TestCase):
             [
                 self.mandat_inactif_aidant_corentin,
                 self.mandat_aidant_corentin_365,
+                self.mandat_sans_autorisations_aidant_corentin,
                 self.mandat_aidant_josephine_1,
                 self.mandat_aidant_josephine_6,
                 self.mandat_aidant_alice_no_autorisation,

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -79,9 +79,6 @@ def _get_usagers_dict_from_mandats(mandats: Mandat) -> dict:
             usagers_without_mandats.add(mandat.usager)
             continue
 
-        if mandat.usager not in usagers:
-            usagers[mandat.usager] = list()
-
         expired_soon = (
             mandat.expiration_date
             if mandat.expiration_date - timedelta(days=delta) < now()
@@ -93,12 +90,15 @@ def _get_usagers_dict_from_mandats(mandats: Mandat) -> dict:
         )
 
         if autorisations.count() == 0:
-            usagers_without_mandats.add(mandat.usager)
-            usagers.pop(mandat.usager, mandat.usager)
+            if mandat.usager not in usagers:
+                usagers_without_mandats.add(mandat.usager)
         else:
+            if mandat.usager not in usagers:
+                usagers[mandat.usager] = list()
+            if mandat.usager in usagers_without_mandats:
+                usagers_without_mandats.remove(mandat.usager)
+
             for autorisation in autorisations:
-                if mandat.usager in usagers_without_mandats:
-                    usagers_without_mandats.remove(mandat.usager)
                 usagers[mandat.usager].append((autorisation.demarche, expired_soon))
 
     with_valid_mandate_count = len(usagers)


### PR DESCRIPTION


## 🌮 Objectif

Dans le cas où un usage a à la fois des mandats valides et "expirés" (sans autorisation) et que le mandat en question est le dernier a être traité,  les mandats valides vont disparaître de la liste des usagers

## 🔍 Implémentation

modification de la function _get_usagers_dict_from_mandats 


