### PR TITLE
Mise en place d'un renouvellement de mandat

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -656,6 +656,7 @@ class Journal(models.Model):
         ("use_autorisation", "Utilisation d'une autorisation"),
         ("cancel_autorisation", "Révocation d'une autorisation"),
         ("import_totp_cards", "Importation de cartes TOTP"),
+        ("init_renew_mandat", "Lancement d'une procédure de renouvellement"),
     )
 
     INFO_REMOTE_MANDAT = "Mandat conclu à distance pendant l'état d'urgence sanitaire (23 mars 2020)"  # noqa
@@ -730,6 +731,26 @@ class Journal(models.Model):
             aidant=aidant,
             usager=usager,
             action="update_phone_usager",
+        )
+
+    @classmethod
+    def log_init_renew_mandat(
+        cls,
+        aidant: Aidant,
+        usager: Usager,
+        demarches: list,
+        duree: int,
+        is_remote_mandat: bool,
+        access_token: str,
+    ):
+        return cls.objects.create(
+            aidant=aidant,
+            usager=usager,
+            action="init_renew_mandat",
+            demarche=",".join(demarches),
+            duree=duree,
+            access_token=access_token,
+            is_remote_mandat=is_remote_mandat,
         )
 
     @classmethod

--- a/aidants_connect_web/static/css/new_mandat.css
+++ b/aidants_connect_web/static/css/new_mandat.css
@@ -113,6 +113,10 @@ form {
   max-width: 250px;
 }
 
+#submit_renew_button {
+  padding: 10;
+  max-width: 250px;
+}
 
 @supports not (display: grid) {
   .tile+.tile {

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -132,6 +132,7 @@
             />
           </div>
         </div>
+      {% block input_submit_form %}
         <div id="france_connection" class="tiles">
           <h2 class="step-title">Étape 3 : Connectez l'usager à FranceConnect</h2>
           <input
@@ -140,6 +141,7 @@
             src="{% static 'images/FCboutons-10.png' %}"
             alt="S’identifier avec FranceConnect"/>
         </div>
+      {% endblock input_submit_form %}
       </form>
     </div>
   </section>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/renew_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/renew_mandat.html
@@ -1,0 +1,12 @@
+{% extends 'aidants_connect_web/new_mandat/new_mandat.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - Renouveler un mandat{% endblock %}
+
+      {% block input_submit_form %}
+        <div id="renew_mandat" class="tiles">
+          <h2 class="step-title">Étape 3 : Renouveler le  mandat</h2>
+          <input id="submit_renew_button" type="submit" class="button" value="Renouveler le  mandat" />
+        </div>
+      {% endblock input_submit_form %}

--- a/aidants_connect_web/templates/aidants_connect_web/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers.html
@@ -32,6 +32,7 @@
               <th scope="col">Prénom</th>
               <th scope="col">Date de naissance</th>
               <th scope="col">Autorisations</th>
+              <th scope="col">Action</th>
             </tr>
             </thead>
             <tbody>
@@ -60,6 +61,7 @@
                     {% endfor %}
                   </ul>
                 </td>
+              <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>
               </tr>
             {% endfor %}
             </tbody>
@@ -73,6 +75,7 @@
               <th scope="col">Nom</th>
               <th scope="col">Prénom</th>
               <th scope="col">Date de naissance</th>
+              <th scope="col">Action</th>
             </tr>
             </thead>
             <tbody>
@@ -89,6 +92,7 @@
                 </td>
                 <td>{{ usager.given_name }}</td>
                 <td>{{ usager.birthdate |date:"d F" }}</td>
+                <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>
               </tr>
             {% endfor %}
             </tbody>

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -1,0 +1,85 @@
+from datetime import timedelta
+
+from django.test import tag
+
+from django.utils import timezone
+from aidants_connect_web.models import Mandat
+
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    MandatFactory,
+    UsagerFactory,
+)
+from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
+from aidants_connect_web.tests.test_functional.utilities import login_aidant
+
+
+@tag("functional", "renew_mandat")
+class RenewMandatTests(FunctionalTestCase):
+    def test_renew_mandat(self):
+        self.aidant = AidantFactory()
+        device = self.aidant.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+        device.token_set.create(token="123455")
+
+        self.usager = UsagerFactory(given_name="Fabrice")
+        MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+        )
+        self.assertEqual(Mandat.objects.filter(usager=self.usager).count(), 1)
+
+        self.open_live_url(f"/renew_mandat/{self.usager.pk}")
+
+        login_aidant(self)
+
+        demarches_section = self.selenium.find_element_by_id("demarches")
+        demarche_title = demarches_section.find_element_by_tag_name("h2").text
+        self.assertEqual(demarche_title, "Étape 1 : Sélectionnez la ou les démarche(s)")
+
+        demarches_grid = self.selenium.find_element_by_id("demarches_list")
+        demarches = demarches_grid.find_elements_by_tag_name("input")
+        self.assertEqual(len(demarches), 10)
+
+        demarches_section.find_element_by_id("argent").find_element_by_tag_name(
+            "label"
+        ).click()
+        demarches_section.find_element_by_id("famille").find_element_by_tag_name(
+            "label"
+        ).click()
+
+        duree_section = self.selenium.find_element_by_id("duree")
+        duree_section.find_element_by_id("SHORT").find_element_by_tag_name(
+            "label"
+        ).click()
+
+        # Renew Mandat
+        fc_button = self.selenium.find_element_by_id("submit_renew_button")
+        fc_button.click()
+
+        # Recap all the information for the Mandat
+        recap_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(recap_title, "Récapitulatif du mandat")
+        recap_text = self.selenium.find_element_by_id("recap_text").text
+        self.assertIn("Fabrice Simpson ", recap_text)
+        checkboxes = self.selenium.find_elements_by_tag_name("input")
+        id_personal_data = checkboxes[1]
+        self.assertEqual(id_personal_data.get_attribute("id"), "id_personal_data")
+        id_personal_data.click()
+        id_otp_token = checkboxes[2]
+        self.assertEqual(id_otp_token.get_attribute("id"), "id_otp_token")
+        id_otp_token.send_keys("123455")
+        submit_button = checkboxes[-1]
+        self.assertEqual(submit_button.get_attribute("type"), "submit")
+        submit_button.click()
+
+        # Success page
+        success_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(success_title, "Le mandat a été créé avec succès !")
+        go_to_usager_button = self.selenium.find_element_by_class_name(
+            "tiles"
+        ).find_elements_by_tag_name("a")[1]
+        go_to_usager_button.click()
+
+        self.assertEqual(Mandat.objects.filter(usager=self.usager).count(), 2)

--- a/aidants_connect_web/tests/test_views/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_renew_mandat.py
@@ -1,0 +1,65 @@
+from datetime import timedelta
+
+from django.test import tag, TestCase
+from django.test.client import Client
+from django.urls import reverse
+from django.utils import timezone
+
+from aidants_connect_web.models import Connection, Mandat, Journal
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    MandatFactory,
+    OrganisationFactory,
+    UsagerFactory,
+)
+
+
+@tag("renew_mandat")
+class RenewMandatTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.organisation = OrganisationFactory()
+        self.aidant_thierry = AidantFactory(organisation=self.organisation)
+        device = self.aidant_thierry.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+        device.token_set.create(token="223456")
+
+        self.usager = UsagerFactory(given_name="Fabrice")
+
+    def test_renew_mandat_ok(self):
+        MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+        )
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Mandat.objects.count(), 1)
+        self.assertEqual(Connection.objects.count(), 0)
+        data = {"demarche": ["papiers", "logement"], "duree": "SHORT"}
+        response = self.client.post(
+            reverse("renew_mandat", args=(self.usager.pk,)), data=data
+        )
+        self.assertRedirects(response, reverse("new_mandat_recap"))
+        self.assertEqual(Connection.objects.count(), 1)
+        self.assertEqual(Mandat.objects.count(), 1)
+
+    def test_renew_mandat_expired_ok(self):
+        MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() - timedelta(days=5),
+        )
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Mandat.objects.count(), 1)
+        self.assertEqual(Connection.objects.count(), 0)
+        data = {"demarche": ["papiers", "logement"], "duree": "SHORT"}
+        response = self.client.post(
+            reverse("renew_mandat", args=(self.usager.pk,)), data=data
+        )
+        self.assertRedirects(response, reverse("new_mandat_recap"))
+        self.assertEqual(Connection.objects.count(), 1)
+        self.assertEqual(Mandat.objects.count(), 1)
+        journals = Journal.objects.filter(action="init_renew_mandat")
+        self.assertEqual(journals.count(), 1)
+        self.assertEqual(journals[0].aidant, self.aidant_thierry)
+        self.assertEqual(journals[0].usager, self.usager)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -7,6 +7,7 @@ from aidants_connect_web.views import (
     FC_as_FS,
     id_provider,
     mandat,
+    renew_mandat,
     service,
     espace_aidant,
     espace_responsable,
@@ -53,6 +54,10 @@ urlpatterns = [
         "mandats/<int:mandat_id>/visualisation",
         mandat.attestation_visualisation,
         name="mandat_visualisation",
+    ),
+    # renew mandat
+    path(
+        "renew_mandat/<int:usager_id>", renew_mandat.renew_mandat, name="renew_mandat"
     ),
     # new mandat
     path("creation_mandat/", mandat.new_mandat, name="new_mandat"),

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -1,0 +1,68 @@
+from secrets import token_urlsafe
+
+
+from django.conf import settings
+from django.contrib import messages as django_messages
+from django.contrib.auth.decorators import login_required
+from django.contrib.auth.hashers import make_password
+from django.shortcuts import render, redirect
+
+
+from aidants_connect_web.decorators import activity_required, user_is_aidant
+from aidants_connect_web.forms import MandatForm
+from aidants_connect_web.models import Connection, Journal
+
+
+@login_required
+@user_is_aidant
+@activity_required
+def renew_mandat(request, usager_id):
+    aidant = request.user
+    usager = aidant.get_usager(usager_id)
+
+    if not usager:
+        django_messages.error(request, "Cet usager est introuvable ou inaccessible.")
+        return redirect("espace_aidant_home")
+
+    form = MandatForm()
+
+    if request.method == "GET":
+        return render(
+            request,
+            "aidants_connect_web/new_mandat/renew_mandat.html",
+            {"aidant": aidant, "form": form},
+        )
+
+    else:
+        form = MandatForm(request.POST)
+
+        if form.is_valid():
+            data = form.cleaned_data
+            access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
+            connection = Connection.objects.create(
+                aidant=request.user,
+                connection_type="FS",
+                access_token=access_token,
+                usager=usager,
+                demarches=data["demarche"],
+                duree_keyword=data["duree"],
+                mandat_is_remote=data["is_remote"],
+            )
+            duree = 1 if connection.duree_keyword == "SHORT" else 365
+            Journal.log_init_renew_mandat(
+                aidant=aidant,
+                usager=usager,
+                demarches=connection.demarches,
+                duree=duree,
+                is_remote_mandat=connection.mandat_is_remote,
+                access_token=connection.access_token,
+            )
+
+            request.session["connection"] = connection.pk
+            return redirect("new_mandat_recap")
+        else:
+            return render(
+                request,
+                "aidants_connect_web/new_mandat/renew_mandat.html",
+                {"aidant": aidant, "form": form},
+            )


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir renouveler des mandats sans repasser par une connexion France Connect. Mise en place de la possibilité de renouvellement sur la liste des usagers ayant un mandat valide ou expiré

## 🔍 Implémentation

L'objet Connection est un objet central sur la création du mandat utilisé pour passer des infos entre chaque étape. Ma première tentative visait à faire un processus de renouvellement sans objet connexion et donc totalement décorrélé des choses actuelles. Mais cela aboutissait a beaucoup beaucoup trop de rajout de ligne de code. Du coup j'ai finalement décidé de coller au plus proche de l'existant en créant un objet Connection qui simle une connection FC même si elle n'a pas lieu. 

Cela me permet du coup de me brancher sur le dispositif actuel. J'ai légèrement modifié le formulaire de l'étape 1 du mandat pour pouvoir le réutiliser en en dérivant et en changeant simplement son titre et l'input de soumission qui ne renvoie plus sur France Connect mais envoie directement à l'étape suivante. Cela permettra de ne pas à avoir à gérer 2 formulaires quasi identiques en parallèle. (Typiquement entre le début de ma PR et la fin, l'ajout du numéro de téléphone a été mis en place et du coup le renouvellement de mandat gagne cette fonctionnalité de manière automatique ). 


## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

![image](https://user-images.githubusercontent.com/354064/116390660-98255200-a81e-11eb-92b0-d1f1d6c704ba.png)
