### PR TITLE
Developer Experience : Réparer quatre tests en environnement local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ FC_AS_FS_CALLBACK_URL=http://localhost:3000
 FC_AS_FS_TEST_PORT=3000
 
 FC_AS_FI_ID=<insert_your_data>
-FC_AS_FI_CALLBACK_URL=https://...
-FC_AS_FI_LOGOUT_REDIRECT_URI=https://...
+FC_AS_FI_CALLBACK_URL=https://fcp.integ01.dev-franceconnect.fr/oidc_callback
+FC_AS_FI_LOGOUT_REDIRECT_URI=http://localhost:3000
 FC_AS_FI_HASH_SALT=""
 HASH_FC_AS_FI_SECRET=<insert_your_data>
 
@@ -66,7 +66,7 @@ HEADLESS_FUNCTIONAL_TESTS = True
 BYPASS_FIRST_LIVESERVER_CONNECTION = False
 
 # COVID-19 Changes
-ETAT_URGENCE_2020_LAST_DAY=23/05/2020 23:59:59 +01:00
+ETAT_URGENCE_2020_LAST_DAY="23/05/2020 23:59:59 +01:00"
 
 # Datapass information
 DATAPASS_KEY = <insert_your_data>

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -400,6 +400,7 @@ class FISelectDemarcheTests(TestCase):
     "31b5d581e70",
     FC_AS_FI_CALLBACK_URL="test_url.test_url",
     HOST="localhost",
+    FC_AS_FI_HASH_SALT="123456",
 )
 @override_settings(FC_CONNECTION_AGE=300)
 class TokenTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

4 tests ont toujours cassé sur mon environnement local mais passaient sur la CI. J'ai fini par me pencher sur la raison. À chaque fois, il s'agissait d'un problème de variables d'environnement mouvantes. C'est maintenant réglé.
