### PR TITLE
Création de comptes aidants par import de fichier excel

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -95,8 +95,15 @@ class TOTPDeviceStaffAdmin(VisibleToAdminMetier, TOTPDeviceAdmin):
 
 
 class OrganisationAdmin(VisibleToAdminMetier, ModelAdmin):
-    list_display = ("name", "address", "admin_num_active_aidants", "admin_num_mandats")
-    search_fields = ("name",)
+    list_display = (
+        "name",
+        "address",
+        "siret",
+        "admin_num_active_aidants",
+        "admin_num_mandats",
+        "id",
+    )
+    search_fields = ("name", "siret")
 
 
 class AidantResource(resources.ModelResource):

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -146,6 +146,7 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
 
     # For bulk import
     resource_class = AidantResource
+    import_template_name = "aidants_connect_web/admin/import_export/import_aidant.html"
 
     # The fields to be used in displaying the `Aidant` model.
     # These override the definitions on the base `UserAdmin`

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import.html
@@ -29,10 +29,11 @@
       {% csrf_token %}
 
       <p>
-        Le fichier à importer doit contenir les en-têtes suivants&nbsp;:
+        {% block fields_intro %}Le fichier à importer doit contenir les en-têtes suivants&nbsp;:{% endblock %}
         <code>{{ fields|join:", " }}</code>
       </p>
-
+      {% block more_help %}
+      {% endblock %}
       <fieldset class="module aligned">
         {% for field in form %}
           <div class="form-row">
@@ -149,7 +150,7 @@
             {% endfor %}
           </tr>
           </thead>
-          {% for row in status.list|slice:":10" %}
+          {% for row in status.list|slice:":100" %}
             <tr class="{{ row.import_type }}">
               {% for field in row.diff %}
                 <td>{{ field }}</td>

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
@@ -1,0 +1,25 @@
+{% extends "aidants_connect_web/admin/import_export/import.html" %}
+{% block fields_intro %}Seuls les en-têtes suivants dans le fichier seront importés&nbsp;:{% endblock %}
+
+{% block more_help %}
+  <details>
+    <summary>🆘 Aide sur les champs</summary>
+    <dl>
+      <dt>username</dt>
+      <dd>Obligatoire. Doit contenir l'e-mail de l'aidant.</dd>
+      <dt>organisation_id</dt>
+      <dd>Identifiant interne Django de l'organisation. Vous pouvez le retrouver dans la colonne ID de la page
+        Organisations de l'admin Django.
+      </dd>
+      <dt>first_name, last_name</dt>
+      <dd>Prénom et nom de famille de l'aidant, respectivement.</dd>
+      <dt>is_active</dt>
+      <dd>
+        Permet d'activer ou de désactiver le compte de l'aidant.<br>
+        Entrer 0 (zéro) ou <code>False</code> pour désactiver le compte.<br>
+        Entrer 1 ou <code>True</code> pour activer le compte.<br>
+        Même avec un compte activé, l'aidant ne peut pas se connecter sans carte TOTP.
+      </dd>
+    </dl>
+  </details>
+{% endblock %}


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir créer facilement de nombreux comptes aidants à partir des infos présentes dans les fichiers excel des bizdev.

## 🔍 Implémentation

- Je réutilise le module import-export déjà installé pour les cartes TOTP.
- Les comptes aidants sont créés sans mot de passe, ils ne sont pas utilisables tant qu'on ne leur a pas associé de carte TOTP.
- On peut créer des comptes activés ou désactivés, et on peut les changer d'état avec un import excel dont le fichier ne contiendrait que la colonne "username" et "is_active".

## ⚠️ Informations supplémentaires

Je trouve qu'il y a quelques limites à l'UX du truc (j'aurais bien aimé pouvoir utiliser des en-têtes plus sympa comme "prénom" ou "nom" mais ça n'a pas marché du tout).

Plus embêtant côté UX : pour rattacher un aidant à son organisation, il faut aller chercher l'ID Django de son organisation et la mettre dans le fichier : 
<img width="1083" alt="Capture d’écran 2021-05-04 à 17 44 47" src="https://user-images.githubusercontent.com/1035145/117033353-90741a80-ad02-11eb-87c6-4a404fd930f2.png">

Bref je ne suis pas satisfaite de cette solution, je pense qu'on cherchera vite un autre moyen de procéder pour créer ces comptes ! Mais pour commencer et essayer d'avancer, c'est déjà un début.

## 🖼️ Images

Le petit bouton "importer" en haut de la liste des aidants dans l'admin : 

![Capture d’écran 2021-05-04 à 17 41 13-fullpage](https://user-images.githubusercontent.com/1035145/117032426-c49b0b80-ad01-11eb-8cf1-949f36b7e15e.png)

Une page qui permet d'importer, avec plus de détails sur comment remplir son fichier excel si on clique sur "SOS" : 

![Capture d’écran 2021-05-04 à 17 41 18-fullpage](https://user-images.githubusercontent.com/1035145/117032566-ded4e980-ad01-11eb-8ef4-ea19b94c25f3.png)

![Capture d’écran 2021-05-04 à 17 41 21-fullpage](https://user-images.githubusercontent.com/1035145/117032598-e5fbf780-ad01-11eb-9809-2c7d2a6740b9.png)

Ensuite il y a un aperçu des lignes qui vont être créées (en vert) ou modifiées (en jaune) : 
![Capture d’écran 2021-05-04 à 17 43 25-fullpage](https://user-images.githubusercontent.com/1035145/117032749-06c44d00-ad02-11eb-9b50-aec5ce558d2e.png)

![Capture d’écran 2021-05-04 à 17 41 42-fullpage](https://user-images.githubusercontent.com/1035145/117032641-f01df600-ad01-11eb-9ffa-fd0ed8a9eeb3.png)


Et notez enfin que j'ai modifié les pages de listes d'organisations, j'ai ajouté une colonne qui donne l'ID interne Django : 
![Capture d’écran 2021-05-04 à 17 40 43-fullpage](https://user-images.githubusercontent.com/1035145/117033023-4ab75200-ad02-11eb-8e8c-69e17cc14b17.png)

Et j'autorise la recherche par SIRET : 
![Capture d’écran 2021-05-04 à 17 41 00-fullpage](https://user-images.githubusercontent.com/1035145/117033132-628ed600-ad02-11eb-975d-08dc6b9dd2d3.png)


