### PR TITLE
Réparation de la sérialisation sur '/userinfo/'

### DIFF
--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -524,6 +524,7 @@ class UserInfoTests(TestCase):
             sub="test_sub",
             email="User@user.domain",
             creation_date="2019-08-05T15:49:13.972Z",
+            phone="0 800 840 800",
         )
         self.aidant_thierry = AidantFactory()
         self.mandat_thierry_usager = MandatFactory(
@@ -569,7 +570,6 @@ class UserInfoTests(TestCase):
         FC_formatted_info = {
             "given_name": "Joséphine",
             "family_name": "ST-PIERRE",
-            "phone": "",
             "preferred_username": "ST-PIERRE",
             "birthdate": "1969-12-25",
             "gender": Usager.GENDER_FEMALE,

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -344,8 +344,22 @@ def user_info(request):
         log.info(auth_token)
         return HttpResponseForbidden()
 
-    usager = model_to_dict(connection.usager)
-    del usager["id"]
+    usager = model_to_dict(
+        connection.usager,
+        fields=[
+            "birthcountry",
+            "birthdate",
+            "birthplace",
+            "creation_date",
+            "email",
+            "family_name",
+            "gender",
+            "given_name",
+            "preferred_username",
+            "sub",
+        ],
+    )
+
     birthdate = usager["birthdate"]
     birthplace = usager["birthplace"]
     birthcountry = usager["birthcountry"]


### PR DESCRIPTION
## 🌮 Objectif

#343 a introduit une régression dans la sérialization sur le endpoint `/userinfo/`. Le type utilisé pour le champ numéro de téléphone n'est pas nativement sérialisation en JSON. Celui-ci a été exclut (pour des raisons de confidentialité) par cette PR des infos sérialisées.

**Attention** : Cette PR fait un choix radicale concernant la sérialisation. Auparavant, tous les champs du modèle `Usager` étaient sérialisés par défaut. Maintenant, les champs à sérialiser sont explicitement définis. Aucun nouveau champ ne sera rajouté à la sérialisation à moins de le définir explicitement.