### PR TITLE
Consentement à distance, partie 2

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -473,6 +473,7 @@ SUPPORT_EMAIL = "support@aidantsconnect.beta.gouv.fr"
 
 PHONENUMBER_DEFAULT_REGION = os.getenv("PHONENUMBER_DEFAULT_REGION", "FR")
 
+JS_REVERSE_EXCLUDE_NAMESPACES = ["admin_honeypot", "djdt", "otpadmin", ADMIN_URL]
 JS_REVERSE_JS_GLOBAL_OBJECT_NAME = "window"
 
 # OVH API will be disengaged during testing

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -9,7 +9,7 @@ https://docs.djangoproject.com/en/2.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.2/ref/settings/
 """
-
+import sys
 from datetime import datetime, timedelta
 import os
 import re
@@ -138,6 +138,7 @@ INSTALLED_APPS = [
     "django_extensions",
     "import_export",
     "phonenumber_field",
+    "django_js_reverse",
 ]
 
 MIDDLEWARE = [
@@ -471,3 +472,16 @@ MANDAT_EXPIRED_SOON_EMAIL_FROM = "support@aidantsconnect.beta.gouv.fr"
 SUPPORT_EMAIL = "support@aidantsconnect.beta.gouv.fr"
 
 PHONENUMBER_DEFAULT_REGION = os.getenv("PHONENUMBER_DEFAULT_REGION", "FR")
+
+JS_REVERSE_JS_GLOBAL_OBJECT_NAME = "window"
+
+# OVH API will be disengaged during testing
+OVH_SMS_ENABLED = False if "test" in sys.argv else getenv_bool("OVH_SMS_ENABLED", False)
+OVH_SMS_SERVICE_NAME = os.getenv("OVH_SMS_SERVICE_NAME")
+OVH_SMS_ENDPOINT = os.getenv("OVH_SMS_ENDPOINT")
+OVH_SMS_APPLICATION_KEY = os.getenv("OVH_SMS_APPLICATION_KEY")
+OVH_SMS_APPLICATION_SECRET = os.getenv("OVH_SMS_APPLICATION_SECRET")
+OVH_SMS_CONSUMER_KEY = os.getenv("OVH_SMS_CONSUMER_KEY")
+OVH_SMS_SENDER_ID = os.getenv("OVH_SMS_SENDER_ID")
+OVH_SMS_CALLBACK_DOMAIN = os.getenv("OVH_SMS_CALLBACK_DOMAIN", "http://localhost")
+OVH_SMS_RESPONSE_CONSENT = os.getenv("OVH_SMS_RESPONSE_CONSENT", "Oui")

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,14 +1,18 @@
 from django.conf import settings
 from django.urls import path, include
+from django.views.decorators.cache import cache_page
+from django_js_reverse.views import urls_js
 
 from aidants_connect import views
 from aidants_connect_web.admin import admin_site
+
 
 urlpatterns = [
     path("favicon.ico", views.favicon),
     path(settings.ADMIN_URL, admin_site.urls),
     path("admin/", include("admin_honeypot.urls", namespace="admin_honeypot")),
     path("", include("aidants_connect_web.urls")),
+    path("jsreverse/", cache_page(3600)(urls_js), name="js_reverse"),
 ]
 
 if settings.DEBUG:

--- a/aidants_connect_web/constants.py
+++ b/aidants_connect_web/constants.py
@@ -1,0 +1,55 @@
+class JournalActionKeywords:
+    CONNECT_AIDANT = "connect_aidant"
+    ACTIVITY_CHECK_AIDANT = "activity_check_aidant"
+    FRANCECONNECT_USAGER = "franceconnect_usager"
+    UPDATE_EMAIL_USAGER = "update_email_usager"
+    UPDATE_PHONE_USAGER = "update_phone_usager"
+    CREATE_ATTESTATION = "create_attestation"
+    CREATE_AUTORISATION = "create_autorisation"
+    USE_AUTORISATION = "use_autorisation"
+    CANCEL_AUTORISATION = "cancel_autorisation"
+    IMPORT_TOTP_CARDS = "import_totp_cards"
+    INIT_RENEW_MANDAT = "init_renew_mandat"
+    CONSENT_REQUEST_SENT = "consent_request_sent"
+    AGREEMENT_OF_CONSENT_RECEIVED = "agreement_of_consent_received"
+    DENIAL_OF_CONSENT_RECEIVED = "denial_of_consent_received"
+
+
+JOURNAL_ACTIONS = (
+    (JournalActionKeywords.CONNECT_AIDANT, "Connexion d'un aidant"),
+    (JournalActionKeywords.ACTIVITY_CHECK_AIDANT, "Reprise de connexion d'un aidant"),
+    (JournalActionKeywords.FRANCECONNECT_USAGER, "FranceConnexion d'un usager"),
+    (JournalActionKeywords.UPDATE_EMAIL_USAGER, "L'email de l'usager a été modifié"),
+    (
+        JournalActionKeywords.UPDATE_PHONE_USAGER,
+        "Le téléphone de l'usager a été modifié",
+    ),
+    (JournalActionKeywords.CREATE_ATTESTATION, "Création d'une attestation"),
+    (JournalActionKeywords.CREATE_AUTORISATION, "Création d'une autorisation"),
+    (JournalActionKeywords.USE_AUTORISATION, "Utilisation d'une autorisation"),
+    (JournalActionKeywords.CANCEL_AUTORISATION, "Révocation d'une autorisation"),
+    (JournalActionKeywords.IMPORT_TOTP_CARDS, "Importation de cartes TOTP"),
+    (
+        JournalActionKeywords.INIT_RENEW_MANDAT,
+        "Lancement d'une procédure de renouvellement",
+    ),
+    (
+        JournalActionKeywords.CONSENT_REQUEST_SENT,
+        "Un SMS de demande de consentement a été envoyé",
+    ),
+    (
+        JournalActionKeywords.AGREEMENT_OF_CONSENT_RECEIVED,
+        "Un SMS d'accord de consentement a été reçu",
+    ),
+    (
+        JournalActionKeywords.DENIAL_OF_CONSENT_RECEIVED,
+        "Un SMS de refus de consentement a été reçu",
+    ),
+)
+
+
+class RemotePendingResponses:
+    INVALID_CONNECTION = "INVALID_CONNECTION"
+    NOT_DRAFT_CONNECTION = "NOT_DRAFT_CONNECTION"
+    NO_CONSENT = "NO_CONSENT"
+    OK = "OK"

--- a/aidants_connect_web/management/commands/validate_consent_requests.py
+++ b/aidants_connect_web/management/commands/validate_consent_requests.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from aidants_connect_web.constants import JournalActionKeywords
+from aidants_connect_web.models import Journal
+
+
+class Command(BaseCommand):
+    help = (
+        "Validates all sent consent requests without response. "
+        "This function exists for test purposes. DO NOT CALL IN PRODUCTION!"
+    )
+
+    def handle(self, *args, **options):
+        if not settings.DEBUG:
+            raise CommandError(
+                "This command should not be called on a production "
+                "environement; Set DEBUG to a truthy value to enable this "
+                "command"
+            )
+
+        for request in Journal.objects.filter(
+            action=JournalActionKeywords.CONSENT_REQUEST_SENT
+        ):
+            if not Journal.find_consent_denial_or_agreement(
+                request.user_phone, request.consent_request_tag
+            ):
+                Journal.log_agreement_of_consent_received(
+                    aidant=request.aidant,
+                    user_phone=request.user_phone,
+                    consent_request_tag=request.consent_request_tag,
+                    demarche=request.demarche,
+                    duree=request.duree,
+                )

--- a/aidants_connect_web/migrations/0058_remote_mandate.py
+++ b/aidants_connect_web/migrations/0058_remote_mandate.py
@@ -1,0 +1,127 @@
+from django.db import migrations, models
+import phonenumber_field.modelfields
+
+
+def migrate_phone_field_blank_to_null(apps, _):
+    Connection = apps.get_model("aidants_connect_web", "Connection")
+    Connection.objects.filter(user_phone="").update(user_phone=None)
+
+
+def migrate_phone_field_null_to_blank(apps, _):
+    Connection = apps.get_model("aidants_connect_web", "Connection")
+    Connection.objects.filter(user_phone=None).update(user_phone="")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("aidants_connect_web", "0057_auto_20210525_1559"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="connection",
+            name="consent_request_tag",
+            field=models.CharField(default=None, max_length=36, null=True),
+        ),
+        migrations.AddField(
+            model_name="connection",
+            name="draft",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="journal",
+            name="consent_request_tag",
+            field=models.CharField(default=None, max_length=36, null=True),
+        ),
+        migrations.AddField(
+            model_name="journal",
+            name="user_phone",
+            field=phonenumber_field.modelfields.PhoneNumberField(
+                default=None, max_length=128, null=True, region=None
+            ),
+        ),
+        migrations.AlterField(
+            model_name="connection",
+            name="user_phone",
+            field=phonenumber_field.modelfields.PhoneNumberField(
+                default=None, max_length=128, null=True, region=None
+            ),
+        ),
+        migrations.AlterField(
+            model_name="journal",
+            name="action",
+            field=models.CharField(
+                choices=[
+                    ("connect_aidant", "Connexion d'un aidant"),
+                    ("activity_check_aidant", "Reprise de connexion d'un aidant"),
+                    ("franceconnect_usager", "FranceConnexion d'un usager"),
+                    ("update_email_usager", "L'email de l'usager a été modifié"),
+                    ("update_phone_usager", "Le téléphone de l'usager a été modifié"),
+                    ("create_attestation", "Création d'une attestation"),
+                    ("create_autorisation", "Création d'une autorisation"),
+                    ("use_autorisation", "Utilisation d'une autorisation"),
+                    ("cancel_autorisation", "Révocation d'une autorisation"),
+                    ("import_totp_cards", "Importation de cartes TOTP"),
+                    (
+                        "init_renew_mandat",
+                        "Lancement d'une procédure de renouvellement",
+                    ),
+                    (
+                        "consent_request_sent",
+                        "Un SMS de demande de consentement a été envoyé",
+                    ),
+                    (
+                        "agreement_of_consent_received",
+                        "Un SMS d'accord de consentement a été reçu",
+                    ),
+                    (
+                        "denial_of_consent_received",
+                        "Un SMS de refus de consentement a été reçu",
+                    ),
+                ],
+                max_length=30,
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="journal",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    ("user_phone__isnull", False),
+                    ("consent_request_tag__isnull", False),
+                ),
+                fields=("action", "user_phone", "consent_request_tag"),
+                name="journal_unique_consent_request_conversation",
+            ),
+        ),
+        migrations.RunPython(
+            migrate_phone_field_blank_to_null,
+            reverse_code=migrate_phone_field_null_to_blank,
+        ),
+        migrations.AddConstraint(
+            model_name="connection",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    ("user_phone__isnull", False),
+                    ("consent_request_tag__isnull", False),
+                ),
+                fields=("user_phone", "consent_request_tag"),
+                name="connection_unique_consent_request_conversation",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="connection",
+            constraint=models.CheckConstraint(
+                check=models.Q(
+                    ("draft", False),
+                    models.Q(
+                        ("draft", True),
+                        ("user_phone__isnull", False),
+                        ("consent_request_tag__isnull", False),
+                    ),
+                    _connector="OR",
+                ),
+                name="connection_remote_mandate_constraint",
+            ),
+        ),
+    ]

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -23,7 +23,11 @@ from phonenumbers import (
     parse as numbers_parse,
 )
 
-from aidants_connect_web.constants import JOURNAL_ACTIONS, JournalActionKeywords
+from aidants_connect_web.constants import (
+    JOURNAL_ACTIONS,
+    JournalActionKeywords,
+    AuthorizationDurationChoices,
+)
 from aidants_connect_web.utilities import (
     generate_attestation_hash,
     mandate_template_path,
@@ -334,21 +338,6 @@ class Usager(models.Model):
         return self.birthplace
 
 
-class AutorisationDureeKeywords(models.TextChoices):
-    SHORT = (
-        "SHORT",
-        "pour une durée de 1 jour",
-    )
-    LONG = (
-        "LONG",
-        "pour une durée de 1 an",
-    )
-    EUS_03_20 = (
-        "EUS_03_20",
-        "jusqu’à la fin de l’état d’urgence sanitaire ",
-    )
-
-
 def get_staff_organisation_name_id() -> int:
     try:
         return Organisation.objects.get(name=settings.STAFF_ORGANISATION_NAME).pk
@@ -382,7 +371,7 @@ class Mandat(models.Model):
     creation_date = models.DateTimeField("Date de création", default=timezone.now)
     expiration_date = models.DateTimeField("Date d'expiration", default=timezone.now)
     duree_keyword = models.CharField(
-        "Durée", max_length=16, choices=AutorisationDureeKeywords.choices, null=True
+        "Durée", max_length=16, choices=AuthorizationDurationChoices.choices, null=True
     )
     is_remote = models.BooleanField("Signé à distance ?", default=False)
 
@@ -502,7 +491,7 @@ class Mandat(models.Model):
         end = start + timedelta(days=nb_days_before)
 
         return cls.objects.filter(
-            duree_keyword=AutorisationDureeKeywords.LONG,
+            duree_keyword=AuthorizationDurationChoices.LONG,
             expiration_date__range=(start, end),
         ).order_by("organisation", "expiration_date")
 
@@ -641,7 +630,7 @@ class Connection(models.Model):
     )
     demarches = ArrayField(models.TextField(default="No démarche"), null=True)  # FS
     duree_keyword = models.CharField(
-        max_length=16, choices=AutorisationDureeKeywords.choices, null=True
+        max_length=16, choices=AuthorizationDurationChoices.choices, null=True
     )
     mandat_is_remote = models.BooleanField(default=False)
     user_phone = PhoneNumberField(blank=False, null=True, default=None)

--- a/aidants_connect_web/sms_api.py
+++ b/aidants_connect_web/sms_api.py
@@ -1,0 +1,102 @@
+from django.urls import reverse
+from django.conf import settings
+
+from ovh import Client
+from phonenumbers import PhoneNumber, PhoneNumberFormat, format_number
+
+__all__ = ["api", "SafeClient"]
+
+
+class SafeClient:
+    class SmsApiNotEnabledError(Exception):
+        def __init__(self):
+            super().__init__("Setting OVH_SMS_ENDPOINT is set to false in settings.py")
+
+    def get(self, *args, **kwargs):
+        raise SafeClient.SmsApiNotEnabledError()
+
+    def put(self, *args, **kwargs):
+        raise SafeClient.SmsApiNotEnabledError()
+
+    def post(self, *args, **kwargs):
+        raise SafeClient.SmsApiNotEnabledError()
+
+    def delete(self, *args, **kwargs):
+        raise SafeClient.SmsApiNotEnabledError()
+
+
+class SmsApi:
+    """
+    For reference:
+    OVH SMS documentation: https://eu.api.ovh.com/console/#/sms
+    OVH SMS cookbook: https://docs.ovh.com/fr/sms/api_sms_cookbook/
+    OVH python module documentation: https://pypi.org/project/ovh/
+    """
+
+    def __init__(self):
+        self.__client_impl: Client = None
+
+    @property
+    def __client(self) -> Client:
+        if self.__client_impl is None:
+            self.__client_impl = (
+                Client(
+                    endpoint=settings.OVH_SMS_ENDPOINT,
+                    application_key=settings.OVH_SMS_APPLICATION_KEY,
+                    application_secret=settings.OVH_SMS_APPLICATION_SECRET,
+                    consumer_key=settings.OVH_SMS_CONSUMER_KEY,
+                )
+                if settings.OVH_SMS_ENABLED
+                else SafeClient()
+            )
+        return self.__client_impl
+
+    def send_sms_for_response(self, tel_num: PhoneNumber, sms_tag: str, message: str):
+        """
+        Takes a a phone number to which send a consent request and returns the tag of
+        the SMS. This tag can be used on the OVH API to uniquely identify a conversation
+        with the user. The tag is a generated UUID.
+        """
+
+        self.__client.put(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}",
+            callBack="",
+            stopCallBack="",
+            smsResponse={
+                "cgiUrl": settings.OVH_SMS_CALLBACK_DOMAIN + reverse("sms_callback"),
+                "responseType": "cgi",
+            },
+        )
+
+        self.__send_sms(tel_num, sms_tag, message, for_response=True)
+
+    def send_simple_sms(self, tel_num: PhoneNumber, sms_tag: str, message: str):
+        self.__send_sms(tel_num, sms_tag, message, for_response=False)
+
+    def delete_response(self, sms_id: str):
+        return self.__client.delete(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/incoming/{sms_id}"
+        )
+
+    def __send_sms(
+        self, tel_num: PhoneNumber, sms_tag: str, message: str, for_response: bool
+    ):
+        tel_num: str = format_number(tel_num, PhoneNumberFormat.E164)
+
+        result = self.__client.post(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/jobs",
+            receivers=[tel_num],
+            message=message,
+            sender=settings.OVH_SMS_SENDER_ID,
+            senderForResponse=for_response,
+            noStopClause=True,
+            tag=sms_tag,
+        )
+
+        valid_receivers = result.get("validReceivers", [])
+
+        if not valid_receivers or valid_receivers[0] != tel_num:
+            raise Exception("SMS was not sent")
+
+
+api = SmsApi()

--- a/aidants_connect_web/static/js/remote_pending.js
+++ b/aidants_connect_web/static/js/remote_pending.js
@@ -1,0 +1,28 @@
+"use strict";
+
+(function () {
+    window.addEventListener("load", function () {
+        function poll() {
+            function onLoad(event) {
+                var xhr = event.target;
+                if (xhr.status === 200 && xhr.response.connectionStatus === "OK") {
+                    var url = window.location.origin + Urls.fcAuthorize();
+                    location.replace(url);
+                }
+            }
+
+            var xhr = new XMLHttpRequest();
+            xhr.responseType = "json";
+            xhr.timeout = 15000;
+            xhr.addEventListener("load", onLoad);
+
+            var url = window.location.origin + Urls.newMandatRemotePendingJson();
+            xhr.open("GET", url, true);
+            xhr.setRequestHeader("Accept", "application/json");
+
+            xhr.send()
+        }
+
+        setInterval(poll, 30000);
+    })
+})();

--- a/aidants_connect_web/static/js/remote_pending.js
+++ b/aidants_connect_web/static/js/remote_pending.js
@@ -6,14 +6,20 @@
             function onLoad(event) {
                 var xhr = event.target;
                 if (xhr.status === 200 && xhr.response.connectionStatus === "OK") {
-                    var url = window.location.origin + Urls.fcAuthorize();
+                    var path = "";
+                    if (window.location.pathname === Urls.renewMandatRemotePending()) {
+                        path = Urls.newMandatRecap();
+                    } else {
+                        path = Urls.fcAuthorize();
+                    }
+                    var url = window.location.origin + path;
                     location.replace(url);
                 }
             }
 
             var xhr = new XMLHttpRequest();
             xhr.responseType = "json";
-            xhr.timeout = 15000;
+            xhr.timeout = 5000;
             xhr.addEventListener("load", onLoad);
 
             var url = window.location.origin + Urls.newMandatRemotePendingJson();
@@ -23,6 +29,7 @@
             xhr.send()
         }
 
-        setInterval(poll, 30000);
+        window.addEventListener("trigger_manual", poll);
+        setInterval(poll, 10000);
     })
 })();

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat_recap.html
@@ -17,8 +17,8 @@
   <section class="section section-grey">
     <div class="container container-small">
       <form method="post">
-        {% if form.errors %}
-          <div class="notification error" role="alert">{{ form.errors }}</div>
+        {% if form.non_field_errors %}
+          <div class="notification error" role="alert">{{ form.non_field_errors }}</div>
         {% endif %}
         {% csrf_token %}
         <a class="button-outline primary small float-right" href="{% url 'new_attestation_projet' %}" target="_blank" rel="noopener noreferrer">Voir le projet de mandat</a>
@@ -41,8 +41,8 @@
           </div>
         </div>
         <h2>Validation de l'usager</h2>
-        {% if form.non_field_errors %}
-          <div class="notification error" role="alert">{{ form.non_field_errors }}</div>
+        {% if form.errors.personal_data %}
+          <div class="notification error" role="alert">{{ form.errors.personal_data }}</div>
         {% endif %}
         <div class="panel form__group">
           <div class="margin-bottom-1em">En cochant les cases, <strong>{{ aidant }}</strong> confirme :</div>
@@ -65,6 +65,9 @@
         <p>🗣 L'usager a des droits d'accès, de rectification et de suppression sur ses données.</p>
         </div>
         <h2>Validation de l'aidant</h2>
+        {% if form.errors.otp_token %}
+          <div class="notification error" role="alert">{{ form.errors.otp_token }}</div>
+        {% endif %}
         <div class="panel form__group">
           <fieldset>
             <div class="not_checkbox_group">

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/remote_pending.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/remote_pending.html
@@ -1,0 +1,22 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+
+{% block title %}Aidants Connect - En attente de consentement{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/new_mandat.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1>Le mandat a distance est en attente du consentement de l’utilisateur ou l’utilisatrice.</h1>
+  </div>
+</section>
+{% endblock content %}
+
+{% block extrajs %}
+  <script src="{% url 'js_reverse' %}" type="text/javascript"></script>
+  <script src="{% static 'js/remote_pending.js' %}"></script>
+{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/sms_agreement_receipt.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms_agreement_receipt.txt
@@ -1,0 +1,3 @@
+Aidant Connect, bonjour.
+
+Nous avons bien enregistré votre accord concernant la création de mandat à distance.

--- a/aidants_connect_web/templates/aidants_connect_web/sms_consent_request.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms_consent_request.txt
@@ -1,0 +1,6 @@
+Aidant Connect, bonjour.
+
+Un aidant a créé un mandat en votre nom. Confirmez-vous la création de ce mandat ?
+Répondez « oui » sans ponctuation à ce message pour confirmer votre consentement.
+
+Notez que toute autre réponse que « oui » sera interprétée comme un refus explicite.

--- a/aidants_connect_web/templates/aidants_connect_web/sms_denial_receipt.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms_denial_receipt.txt
@@ -1,0 +1,3 @@
+Aidant Connect, bonjour.
+
+Nous avons bien enregistré votre refus concernant la création de mandat à distance.

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -19,9 +19,7 @@ from aidants_connect_web.tests.test_utilities import SmsTestUtils
 
 
 @tag("functional", "new_mandat")
-@override_settings(
-    OVH_SMS_ENABLED=False,
-)
+@override_settings(OVH_SMS_ENABLED=False)
 class CreateNewMandatTests(FunctionalTestCase):
     @classmethod
     def setUpClass(cls):
@@ -203,7 +201,15 @@ class CreateNewMandatTests(FunctionalTestCase):
                 user_phone=consent_request.user_phone,
             ),
         )
-        self.selenium.refresh()
+
+        # Trigger the JS script
+        self.selenium.execute_script(
+            """
+            let event = new Event("trigger_manual");
+            window.dispatchEvent(event);
+            """
+        )
+        time.sleep(1)
 
         fc_title = self.selenium.title
         self.assertEqual("Connexion - choix du compte", fc_title)

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -1,10 +1,17 @@
+import time
 from datetime import timedelta
+from unittest.mock import patch
 
-from django.test import tag
-
+from django.conf import settings
+from django.test import tag, override_settings
+from django.urls import reverse
 from django.utils import timezone
-from aidants_connect_web.models import Mandat
 
+from phonenumbers import parse as phone_parse
+
+from aidants_connect_web.constants import JournalActionKeywords
+from aidants_connect_web.models import Mandat, Journal
+from aidants_connect_web.sms_api import SafeClient
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     MandatFactory,
@@ -12,9 +19,11 @@ from aidants_connect_web.tests.factories import (
 )
 from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
+from aidants_connect_web.tests.test_utilities import SmsTestUtils
 
 
 @tag("functional", "renew_mandat")
+@override_settings(OVH_SMS_ENABLED=False)
 class RenewMandatTests(FunctionalTestCase):
     def test_renew_mandat(self):
         self.aidant = AidantFactory()
@@ -57,6 +66,106 @@ class RenewMandatTests(FunctionalTestCase):
         # Renew Mandat
         fc_button = self.selenium.find_element_by_id("submit_renew_button")
         fc_button.click()
+
+        # Recap all the information for the Mandat
+        recap_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(recap_title, "Récapitulatif du mandat")
+        recap_text = self.selenium.find_element_by_id("recap_text").text
+        self.assertIn("Fabrice Simpson ", recap_text)
+        checkboxes = self.selenium.find_elements_by_tag_name("input")
+        id_personal_data = checkboxes[1]
+        self.assertEqual(id_personal_data.get_attribute("id"), "id_personal_data")
+        id_personal_data.click()
+        id_otp_token = checkboxes[2]
+        self.assertEqual(id_otp_token.get_attribute("id"), "id_otp_token")
+        id_otp_token.send_keys("123455")
+        submit_button = checkboxes[-1]
+        self.assertEqual(submit_button.get_attribute("type"), "submit")
+        submit_button.click()
+
+        # Success page
+        success_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(success_title, "Le mandat a été créé avec succès !")
+        go_to_usager_button = self.selenium.find_element_by_class_name(
+            "tiles"
+        ).find_elements_by_tag_name("a")[1]
+        go_to_usager_button.click()
+
+        self.assertEqual(Mandat.objects.filter(usager=self.usager).count(), 2)
+
+    @patch.object(SafeClient, "put")
+    @patch.object(SafeClient, "post", side_effect=SmsTestUtils.patched_safe_client_post)
+    def test_renew_remote_mandat(self, mock_post, mock_put):
+        self.aidant = AidantFactory()
+        device = self.aidant.staticdevice_set.create(id=1)
+        device.token_set.create(token="123456")
+        device.token_set.create(token="123455")
+
+        self.usager = UsagerFactory(given_name="Fabrice")
+        MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+            is_remote=True,
+        )
+        self.assertEqual(Mandat.objects.filter(usager=self.usager).count(), 1)
+
+        self.open_live_url(f"/renew_mandat/{self.usager.pk}")
+
+        login_aidant(self)
+
+        demarches_section = self.selenium.find_element_by_id("demarches")
+        demarche_title = demarches_section.find_element_by_tag_name("h2").text
+        self.assertEqual(demarche_title, "Étape 1 : Sélectionnez la ou les démarche(s)")
+
+        demarches_grid = self.selenium.find_element_by_id("demarches_list")
+        demarches = demarches_grid.find_elements_by_tag_name("input")
+        self.assertEqual(len(demarches), 10)
+
+        demarches_section.find_element_by_id("argent").find_element_by_tag_name(
+            "label"
+        ).click()
+        demarches_section.find_element_by_id("famille").find_element_by_tag_name(
+            "label"
+        ).click()
+
+        duree_section = self.selenium.find_element_by_id("duree")
+        duree_section.find_element_by_id("SHORT").find_element_by_tag_name(
+            "label"
+        ).click()
+
+        self.selenium.find_element_by_id("id_is_remote").click()
+        self.selenium.find_element_by_id("id_user_phone").send_keys("0 800 840 800")
+
+        # Renew Mandat
+        fc_button = self.selenium.find_element_by_id("submit_renew_button")
+        fc_button.click()
+
+        # Simulate user consent
+        consent_request = Journal.objects.get(
+            aidant=self.aidant,
+            user_phone=phone_parse(
+                "0 800 840 800", settings.PHONENUMBER_DEFAULT_REGION
+            ),
+            action=JournalActionKeywords.CONSENT_REQUEST_SENT,
+        )
+
+        self.client.post(
+            reverse("sms_callback"),
+            data=SmsTestUtils.get_request_data(
+                sms_tag=consent_request.consent_request_tag,
+                user_phone=consent_request.user_phone,
+            ),
+        )
+
+        # Trigger the JS script
+        self.selenium.execute_script(
+            """
+            let event = new Event("trigger_manual");
+            window.dispatchEvent(event);
+            """
+        )
+        time.sleep(1)
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element_by_tag_name("h1").text

--- a/aidants_connect_web/tests/test_views/test_sms.py
+++ b/aidants_connect_web/tests/test_views/test_sms.py
@@ -1,0 +1,201 @@
+from random import randint
+from unittest.mock import patch, Mock
+from uuid import uuid4
+from typing import List
+
+import factory
+from django.template.loader import render_to_string
+from django.test import tag, TestCase, override_settings
+from django.urls import reverse
+from django.conf import settings
+
+from phonenumbers import PhoneNumberFormat, format_number
+
+from aidants_connect_web.constants import JournalActionKeywords
+from aidants_connect_web.models import Journal
+from aidants_connect_web.sms_api import SafeClient
+from aidants_connect_web.tests.factories import AidantFactory
+from aidants_connect_web.tests.test_utilities import SmsTestUtils
+
+
+@tag("sms")
+@override_settings(
+    OVH_SMS_ENABLED=False,
+    OVH_SMS_SERVICE_NAME="d59194b4-f920-460a-bc23-1b62b82b76cc",
+    OVH_SMS_SENDER_ID="Aidant Connect",
+)
+class SmsCallbackTests(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.aidant = AidantFactory(
+            username=factory.Faker("name"), email=factory.Faker("email")
+        )
+        cls.request_no_response = Journal.log_consent_request_sent(
+            aidant=cls.aidant,
+            demarche=cls.__select_random_procedures(),
+            duree=365,
+            user_phone="0 800 840 801",
+            consent_request_tag=str(uuid4()),
+        )
+
+        kwargs = {
+            "aidant": cls.aidant,
+            "demarche": cls.__select_random_procedures(),
+            "duree": 365,
+            "user_phone": "+33 800 840 802",
+            "consent_request_tag": str(uuid4()),
+        }
+        cls.request_with_response = Journal.log_consent_request_sent(**kwargs)
+        Journal.log_denial_of_consent_received(**kwargs)
+
+        super().setUpClass()
+
+    def test_no_corresponding_consent_request(self):
+        data = SmsTestUtils.get_request_data()
+        self.client.post(reverse("sms_callback"), data=data)
+        self.client.post(reverse("sms_callback"), data=data)
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        query_set = Journal.find_consent_denial_or_agreement(
+            data["senderid"],
+            data["tag"],
+        )
+        self.assertEqual(query_set.count(), 0)
+        self.assertEqual(response.status_code, 200)
+
+    def test_with_corresponding_consent_denial(self):
+        data = SmsTestUtils.get_request_data(
+            sms_tag=self.request_with_response.consent_request_tag,
+            user_phone=self.request_with_response.user_phone,
+        )
+
+        query_set = Journal.find_consent_denial_or_agreement(
+            data["senderid"],
+            data["tag"],
+        )
+        self.assertEqual(query_set.count(), 1)
+
+        self.client.post(reverse("sms_callback"), data=data)
+        self.client.post(reverse("sms_callback"), data=data)
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        query_set = Journal.find_consent_denial_or_agreement(
+            data["senderid"],
+            data["tag"],
+        )
+        self.assertEqual(query_set.count(), 1)
+        self.assertEqual(response.status_code, 200)
+
+    @patch.object(SafeClient, "delete")
+    @patch.object(SafeClient, "post", side_effect=SmsTestUtils.patched_safe_client_post)
+    def test_nominal_case(self, mock_post: Mock, mock_delete: Mock):
+        data = SmsTestUtils.get_request_data(
+            sms_tag=self.request_no_response.consent_request_tag,
+            user_phone=self.request_no_response.user_phone,
+        )
+
+        query_set = Journal.find_consent_denial_or_agreement(
+            data["senderid"],
+            data["tag"],
+        )
+        self.assertEqual(query_set.count(), 0)
+
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        self.assertEqual(query_set.count(), 1)
+        self.assertEqual(
+            query_set.first().action,
+            JournalActionKeywords.AGREEMENT_OF_CONSENT_RECEIVED,
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_delete.assert_called_once_with(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/incoming/{data['id']}"
+        )
+        mock_post.assert_called_once_with(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/jobs",
+            receivers=[
+                format_number(
+                    self.request_no_response.user_phone, PhoneNumberFormat.E164
+                )
+            ],
+            message=render_to_string("aidants_connect_web/sms_agreement_receipt.txt"),
+            sender=settings.OVH_SMS_SENDER_ID,
+            senderForResponse=False,
+            noStopClause=True,
+            tag=self.request_no_response.consent_request_tag,
+        )
+
+        mock_delete.reset_mock()
+        mock_post.reset_mock()
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        self.assertEqual(query_set.count(), 1)
+        self.assertEqual(
+            query_set.first().action,
+            JournalActionKeywords.AGREEMENT_OF_CONSENT_RECEIVED,
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_delete.assert_not_called()
+        mock_post.assert_not_called()
+
+    @patch.object(SafeClient, "delete")
+    @patch.object(SafeClient, "post", side_effect=SmsTestUtils.patched_safe_client_post)
+    def test_deny_case(self, mock_post: Mock, mock_delete: Mock):
+        data = SmsTestUtils.get_request_data(
+            sms_tag=self.request_no_response.consent_request_tag,
+            user_phone=self.request_no_response.user_phone,
+            message="Nope",
+        )
+
+        query_set = Journal.find_consent_denial_or_agreement(
+            data["senderid"],
+            data["tag"],
+        )
+        self.assertEqual(query_set.count(), 0)
+
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        self.assertEqual(query_set.count(), 1)
+        self.assertEqual(
+            query_set.first().action, JournalActionKeywords.DENIAL_OF_CONSENT_RECEIVED
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_delete.assert_called_once_with(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/incoming/{data['id']}"
+        )
+        mock_post.assert_called_once_with(
+            f"/sms/{settings.OVH_SMS_SERVICE_NAME}/jobs",
+            receivers=[
+                format_number(
+                    self.request_no_response.user_phone, PhoneNumberFormat.E164
+                )
+            ],
+            message=render_to_string("aidants_connect_web/sms_denial_receipt.txt"),
+            sender=settings.OVH_SMS_SENDER_ID,
+            senderForResponse=False,
+            noStopClause=True,
+            tag=self.request_no_response.consent_request_tag,
+        )
+
+        mock_delete.reset_mock()
+        mock_post.reset_mock()
+        response = self.client.post(reverse("sms_callback"), data=data)
+
+        self.assertEqual(query_set.count(), 1)
+        self.assertEqual(
+            query_set.first().action, JournalActionKeywords.DENIAL_OF_CONSENT_RECEIVED
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_delete.assert_not_called()
+        mock_post.assert_not_called()
+
+    @classmethod
+    def __select_random_procedures(cls) -> List[str]:
+        procedures = [*settings.DEMARCHES.keys()]
+        nb = randint(1, len(procedures))
+        result = []
+        for _ in range(nb):
+            value = procedures[randint(0, len(procedures) - 1)]
+            result.append(value)
+            procedures.remove(value)
+        return result

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -71,6 +71,11 @@ urlpatterns = [
     path(
         "renew_mandat/<int:usager_id>", renew_mandat.renew_mandat, name="renew_mandat"
     ),
+    path(
+        "renew_mandat/remote/pending",
+        renew_mandat.remote_pending,
+        name="renew_mandat_remote_pending",
+    ),
     # new mandat
     path("creation_mandat/", mandat.new_mandat, name="new_mandat"),
     path(
@@ -88,7 +93,6 @@ urlpatterns = [
         mandat.remote_pending_json,
         name="new_mandat_remote_pending_json",
     ),
-    path("logout-callback/", mandat.new_mandat_recap, name="new_mandat_recap"),
     path(
         "creation_mandat/visualisation/projet/",
         mandat.attestation_projet,
@@ -118,6 +122,11 @@ urlpatterns = [
         "logout/",
         id_provider.end_session_endpoint,
         name="end_session_endpoint",
+    ),
+    path(
+        "logout-callback/",
+        mandat.new_mandat_recap,
+        name="end_session_endpoint_callback",
     ),
     # Espace responsable structure
     path(

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -13,6 +13,7 @@ from aidants_connect_web.views import (
     espace_responsable,
     usagers,
     datapass,
+    sms,
 )
 
 urlpatterns = [
@@ -76,6 +77,16 @@ urlpatterns = [
         "creation_mandat/recapitulatif/",
         mandat.new_mandat_recap,
         name="new_mandat_recap",
+    ),
+    path(
+        "creation_mandat/remote/pending",
+        mandat.remote_pending,
+        name="new_mandat_remote_pending",
+    ),
+    path(
+        "creation_mandat/remote/pending.json",
+        mandat.remote_pending_json,
+        name="new_mandat_remote_pending_json",
     ),
     path("logout-callback/", mandat.new_mandat_recap, name="new_mandat_recap"),
     path(
@@ -165,6 +176,8 @@ urlpatterns = [
     ),
     # # Datapass
     path("datapass_receiver/", datapass.receiver, name="datapass_receiver"),
+    # # SMS
+    path("sms/callback/", sms.callback, name="sms_callback"),
 ]
 
 urlpatterns.extend(magicauth_urls)

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -21,6 +21,16 @@ log = logging.getLogger()
 def fc_authorize(request):
     connection = Connection.objects.get(pk=request.session["connection"])
 
+    if connection.draft:
+        # TODO: Test
+        django_messages.error(
+            request,
+            "Vous êtes en train de créer un mandat à distance pour "
+            "lequel l’utilisateur ou l'utilisatrice n'a pas encore donné son accord",
+        )
+
+        return redirect("home_page")
+
     connection.state = token_urlsafe(16)
     connection.nonce = token_urlsafe(16)
     connection.connection_type = "FS"
@@ -142,7 +152,7 @@ def get_user_info(connection: Connection) -> tuple:
     )
     user_info = fc_user_info.json()
 
-    user_phone = connection.user_phone if len(connection.user_phone) > 0 else None
+    user_phone = connection.user_phone
 
     if user_info.get("birthplace") == "":
         user_info["birthplace"] = None

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -1,68 +1,134 @@
+from uuid import uuid4
 from secrets import token_urlsafe
-
 
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
 from django.shortcuts import render, redirect
+from django.template.loader import render_to_string
+from django.views.decorators.http import require_http_methods, require_GET
 
+from phonenumbers import (
+    PhoneNumber,
+    PhoneNumberFormat,
+    format_number,
+)
 
 from aidants_connect_web.decorators import activity_required, user_is_aidant
 from aidants_connect_web.forms import MandatForm
-from aidants_connect_web.models import Connection, Journal
+from aidants_connect_web.models import Connection, Journal, Aidant, Usager
+from aidants_connect_web.sms_api import api
+from aidants_connect_web.views.mandat import __remote_pending
+from aidants_connect_web.constants import (
+    RemotePendingResponses,
+    AuthorizationDurations,
+)
 
 
 @login_required
 @user_is_aidant
 @activity_required
+@require_http_methods(["GET", "POST"])
 def renew_mandat(request, usager_id):
-    aidant = request.user
-    usager = aidant.get_usager(usager_id)
+    aidant: Aidant = request.user
+    usager: Usager = aidant.get_usager(usager_id)
 
     if not usager:
         django_messages.error(request, "Cet usager est introuvable ou inaccessible.")
         return redirect("espace_aidant_home")
 
-    form = MandatForm()
-
     if request.method == "GET":
+        return render(
+            request,
+            "aidants_connect_web/new_mandat/renew_mandat.html",
+            {"aidant": aidant, "form": MandatForm()},
+        )
+
+    form = MandatForm(request.POST)
+
+    if not form.is_valid():
         return render(
             request,
             "aidants_connect_web/new_mandat/renew_mandat.html",
             {"aidant": aidant, "form": form},
         )
 
-    else:
-        form = MandatForm(request.POST)
+    data = form.cleaned_data
+    is_remote = data["is_remote"]
+    access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
+    duree = AuthorizationDurations.duration(data["duree"])
+    kwargs = {
+        "aidant": request.user,
+        "connection_type": "FS",
+        "access_token": access_token,
+        "usager": usager,
+        "demarches": data["demarche"],
+        "duree_keyword": data["duree"],
+        "mandat_is_remote": is_remote,
+    }
 
-        if form.is_valid():
-            data = form.cleaned_data
-            access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
-            connection = Connection.objects.create(
-                aidant=request.user,
-                connection_type="FS",
-                access_token=access_token,
-                usager=usager,
-                demarches=data["demarche"],
-                duree_keyword=data["duree"],
-                mandat_is_remote=data["is_remote"],
-            )
-            duree = 1 if connection.duree_keyword == "SHORT" else 365
-            Journal.log_init_renew_mandat(
-                aidant=aidant,
-                usager=usager,
-                demarches=connection.demarches,
-                duree=duree,
-                is_remote_mandat=connection.mandat_is_remote,
-                access_token=connection.access_token,
-            )
+    if is_remote:
+        user_phone: PhoneNumber = data["user_phone"]
 
-            request.session["connection"] = connection.pk
-            return redirect("new_mandat_recap")
-        else:
-            return render(
-                request,
-                "aidants_connect_web/new_mandat/renew_mandat.html",
-                {"aidant": aidant, "form": form},
-            )
+        sms_tag = str(uuid4())
+
+        # Try to choose another UUID if there's already one
+        # associated with this number in DB.
+        while Journal.find_consent_requests(user_phone, sms_tag).count() != 0:
+            sms_tag = str(uuid4())
+
+        kwargs["user_phone"] = format_number(user_phone, PhoneNumberFormat.E164)
+        kwargs["consent_request_tag"] = sms_tag
+
+        api.send_sms_for_response(
+            user_phone,
+            sms_tag,
+            render_to_string("aidants_connect_web/sms_consent_request.txt"),
+        )
+
+        Journal.log_consent_request_sent(
+            aidant=aidant,
+            user_phone=user_phone,
+            consent_request_tag=sms_tag,
+            demarche=data["demarche"],
+            duree=duree,
+        )
+
+    connection = Connection.objects.create(**kwargs)
+    Journal.log_init_renew_mandat(
+        aidant=aidant,
+        usager=usager,
+        demarches=connection.demarches,
+        duree=duree,
+        is_remote_mandat=connection.mandat_is_remote,
+        access_token=connection.access_token,
+    )
+
+    request.session["connection"] = connection.pk
+    return (
+        redirect("renew_mandat_remote_pending")
+        if is_remote
+        else redirect("new_mandat_recap")
+    )
+
+
+@login_required
+@user_is_aidant
+@activity_required
+@require_GET
+def remote_pending(request):
+    result = __remote_pending(request)
+
+    if result == RemotePendingResponses.INVALID_CONNECTION:
+        django_messages.error(
+            request,
+            "Il n'y a aucun mandat à distance actuellement en cours de création",
+        )
+        return redirect("home_page")
+    elif result == RemotePendingResponses.NOT_DRAFT_CONNECTION:
+        return redirect("new_mandat_recap")
+    elif result == RemotePendingResponses.NO_CONSENT:
+        return render(request, "aidants_connect_web/new_mandat/remote_pending.html")
+
+    return redirect("new_mandat_recap")

--- a/aidants_connect_web/views/sms.py
+++ b/aidants_connect_web/views/sms.py
@@ -1,0 +1,68 @@
+from django.conf import settings
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from django.template.loader import render_to_string
+
+from phonenumbers import parse as numbers_parse, PhoneNumber
+
+from aidants_connect_web.sms_api import api
+from aidants_connect_web.models import Journal
+
+
+@csrf_exempt
+@require_POST
+def callback(request):
+    # Short tel num that received response
+    shortcode: str = request.POST["shortcode"]  # noqa: F841 (ignore unused var)
+    sms_tag: str = request.POST["tag"]
+    sms_id: str = request.POST["id"]
+    user_phone: PhoneNumber = numbers_parse(
+        request.POST["senderid"], settings.PHONENUMBER_DEFAULT_REGION
+    )
+    message: str = request.POST["message"].strip()
+
+    # Security: search for consent request fisrt.
+    # That ensures nobody outside from the OVH service tries to force the consent making
+    # an HTTP request. The SMS tag is a UUID theorically known only to us and the OVH
+    # service so it's practically unguessable. It can serve as an authentication token.
+    try:
+        consent_request = Journal.find_consent_request(user_phone, sms_tag)
+    except Journal.DoesNotExist:
+        return HttpResponse()
+
+    # Return directy if agreement or denial already exists.
+    if Journal.find_consent_denial_or_agreement(user_phone, sms_tag).count() != 0:
+        return HttpResponse()
+
+    try:
+        api.delete_response(sms_id)
+    except Exception:
+        pass
+
+    consent_response = settings.OVH_SMS_RESPONSE_CONSENT.lower().strip()
+
+    kwargs = {
+        "aidant": consent_request.aidant,
+        "demarche": consent_request.demarche,
+        "duree": consent_request.duree,
+        "user_phone": consent_request.user_phone,
+        "consent_request_tag": consent_request.consent_request_tag,
+    }
+
+    if message.lower() != consent_response:  # No consent case
+        Journal.log_denial_of_consent_received(**kwargs)
+        api.send_simple_sms(
+            user_phone,
+            sms_tag,
+            render_to_string("aidants_connect_web/sms_denial_receipt.txt"),
+        )
+    else:
+        Journal.log_agreement_of_consent_received(**kwargs)
+        api.send_simple_sms(
+            user_phone,
+            sms_tag,
+            render_to_string("aidants_connect_web/sms_agreement_receipt.txt"),
+        )
+
+    return HttpResponse()

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,9 +10,11 @@ django-referrer-policy==1.0
 django-tabbed-admin==1.0.4
 django-import-export==2.5.0
 django-debug-toolbar==3.2.1
+django-js-reverse==0.9.1
 
 phonenumberslite==8.12.21
 django-phonenumber-field==5.0.0
+ovh==0.5.0
 
 black==20.8b1
 celery[redis]==4.4.6


### PR DESCRIPTION
## 🌮 Objectif

Cette PR est la suite de #343. Elle prend en charge le consentement lors de la création d'un mandat à distance avec l'envoi de SMS en utilisant l'API SMS d'OVH. 

## 🔍 Implémentation

- Ajout de toute la plomberie pour consommer l'API SMS d'OVH
- Le modèle `Journal` possède 2 événements supplémentaires dénotant l'envoie d'une requête de consentement et la réception d'un accord de consentement.

## ⚠️ Informations supplémentaires

- Cette PR change légèrement la gestion des numéros de téléphones absent dans le modèle `Connection`. Lorsqu'un numéro sera absent pour un enregistrement, le champ sera `null` et plus vide, ceci afin de rester cohérent avec le modèle `Journal` qui contient maintenant aussi un champ de numéro de téléphone et pour lequel les champs non-renseigné sont tous `null`. Afin de ne pas apporter trop de modifications au code existant, cette modification n'a pas été appliquée au modèle `Usager`.
- La fonction `new_mandat` de `aidants_connect_web/views/mandat.py` a été pas mal modifiée afin d'éliminer la plupart des `if` imbriqués. Les cas particuliers sont maintenant gérés et sortent de la fonction au plus tôt.
- Les choix du champ `action` du model `Journal` ont été déplacés dans un nouveau module `constants.py` et les clefs variabilisés pour tirer partie de l'autocomplétion des IDE.

## 🖼️ Images

