### PR TITLE
Première connexion d'un ou une responsable structure

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -143,6 +143,7 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
     # The forms to add and change `Aidant` instances
     form = AidantChangeForm
     add_form = AidantCreationForm
+    raw_id_fields = ("responsable_de",)
 
     # For bulk import
     resource_class = AidantResource
@@ -172,7 +173,15 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         ("Informations professionnelles", {"fields": ("profession", "organisation")}),
         (
             "Permissions",
-            {"fields": ("is_active", "is_staff", "is_superuser", "responsable_de")},
+            {
+                "fields": (
+                    "is_active",
+                    "can_create_mandats",
+                    "is_staff",
+                    "is_superuser",
+                    "responsable_de",
+                )
+            },
         ),
     )
 
@@ -277,6 +286,7 @@ class CarteTOTPResource(resources.ModelResource):
 class CarteTOTPAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
     list_display = ("serial_number",)
     search_fields = ("serial_number",)
+    raw_id_fields = ("aidant",)
     ordering = ("-created_at",)
     resource_class = CarteTOTPResource
     import_template_name = "aidants_connect_web/admin/import_export/import.html"

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -9,6 +9,7 @@ from django.template import loader
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django_otp.plugins.otp_totp.models import TOTPDevice
 from typing import Union, Optional
 from os import walk as os_walk
 from os.path import join as path_join, dirname
@@ -214,6 +215,16 @@ class Aidant(AbstractUser):
         :return: True if the Aidant is responsable of at least one organisation
         """
         return self.responsable_de.count() >= 1
+
+    @cached_property
+    def has_a_totp_device(self):
+        try:
+            TOTPDevice.objects.get(user=self)
+            return True
+        except TOTPDevice.MultipleObjectsReturned:
+            return True
+        except TOTPDevice.DoesNotExist:
+            return False
 
 
 class UsagerQuerySet(models.QuerySet):

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -76,7 +76,14 @@ class Aidant(AbstractUser):
     responsable_de = models.ManyToManyField(
         Organisation, related_name="responsables", blank=True
     )
-    can_create_mandats = models.BooleanField(default=True)
+    can_create_mandats = models.BooleanField(
+        default=True,
+        verbose_name="Aidant - Peut créer des mandats",
+        help_text=(
+            "Précise si l’utilisateur peut accéder à l’espace aidant "
+            "pour créer des mandats."
+        ),
+    )
     objects = AidantManager()
 
     class Meta:

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -20,6 +20,14 @@
       Bienvenue sur
       {% if aidant.can_create_mandats %}votre Espace Aidant{% else %}Aidants Connect{% endif %},
       {{ aidant.first_name }} !</h1>
+      {% if aidant.is_responsable_structure and not aidant.has_a_totp_device %}
+        <div class="notification warning" role="alert">
+          Bienvenue&nbsp;! Avant toute chose, nous vous invitons à
+          <strong><a
+              href="{% url "espace_responsable_associate_totp" organisation_id=aidant.organisation.id aidant_id=aidant.id %}">
+            activer votre carte TOTP</a></strong> afin de pouvoir vous connecter à nouveau à l’avenir.
+        </div>
+      {% endif %}
     <div class="tiles aidant-home-services">
       <h2>Vos services</h2>
       <div class="grid">
@@ -27,7 +35,7 @@
           <a id="view_organisation" class="tile text-center background-color-grey" href="{% url 'espace_responsable_home' %}">
             <span aria-hidden="true">🏢<br /></span>Mon espace responsable
           </a>
-          {% if not user.has_a_totp_device %}
+          {% if not aidant.has_a_totp_device %}
             <a id="view_organisation" class="tile text-center background-color-grey" href="{% url "espace_responsable_associate_totp" organisation_id=aidant.organisation.id aidant_id=aidant.id %}">
               <span aria-hidden="true">💳<br /></span>Activer ma carte TOTP
             </a>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -16,13 +16,27 @@
         <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
       {% endfor %}
     {% endif %}
-    <h1 class="section__title">Bienvenue sur votre Espace Aidant, {{ aidant.first_name }} !</h1>
+    <h1 class="section__title">
+      Bienvenue sur
+      {% if aidant.can_create_mandats %}votre Espace Aidant{% else %}Aidants Connect{% endif %},
+      {{ aidant.first_name }} !</h1>
     <div class="tiles aidant-home-services">
       <h2>Vos services</h2>
       <div class="grid">
-        <a id="view_organisation" class="tile text-center background-color-grey" href="{% url 'espace_aidant_organisation' %}">
-          <span aria-hidden="true">🏢<br /></span>Mon organisation
-        </a>
+        {% if aidant.is_responsable_structure %}
+          <a id="view_organisation" class="tile text-center background-color-grey" href="{% url 'espace_responsable_home' %}">
+            <span aria-hidden="true">🏢<br /></span>Mon espace responsable
+          </a>
+          {% if not user.has_a_totp_device %}
+            <a id="view_organisation" class="tile text-center background-color-grey" href="{% url "espace_responsable_associate_totp" organisation_id=aidant.organisation.id aidant_id=aidant.id %}">
+              <span aria-hidden="true">💳<br /></span>Activer ma carte TOTP
+            </a>
+          {% endif %}
+        {% else %}
+          <a id="view_organisation" class="tile text-center background-color-grey" href="{% url 'espace_aidant_organisation' %}">
+            <span aria-hidden="true">🏢<br /></span>Mon organisation
+          </a>
+        {% endif %}
         {% if aidant.can_create_mandats %}
           <a id="view_mandats" class="tile text-center background-color-grey" href="{% url 'usagers' %}" >
             <span aria-hidden="true">📂<br /></span>Mes mandats

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -17,6 +17,15 @@
         {% endfor %}
       {% endif %}
       <h1 class="section__title">Bienvenue sur votre Espace Responsable, {{ responsable.first_name }}&nbsp!</h1>
+      {% if not responsable.has_a_totp_device %}
+        <div class="notification warning" role="alert">
+          Avant toute chose, nous vous invitons à
+          <strong><a
+              href="{% url "espace_responsable_associate_totp" organisation_id=responsable.organisation.id aidant_id=responsable.id %}">
+            activer votre carte TOTP.
+          </a></strong>
+        </div>
+      {% endif %}
       <h2>Les structures dont vous êtes responsable</h2>
       <ul class="grid cards structures">
         {% for org in organisations %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -18,6 +18,15 @@
         {% endfor %}
       {% endif %}
       <h1>Mon organisation : {{ organisation.name }}</h1>
+      {% if not responsable.has_a_totp_device %}
+        <div class="notification warning" role="alert">
+          Avant toute chose, nous vous invitons à
+          <strong><a
+              href="{% url "espace_responsable_associate_totp" organisation_id=responsable.organisation.id aidant_id=responsable.id %}">
+            activer votre carte TOTP.
+          </a></strong>
+        </div>
+      {% endif %}
       <div class="tiles">
         <div class="grid">
           <div class="tile background-color-grey">
@@ -46,7 +55,7 @@
           <tr>
             <th scope="col">Nom</th>
             <th scope="col">Email</th>
-            <th scope="col" >Carte TOTP</th>
+            <th scope="col">Carte TOTP</th>
           </tr>
           </thead>
           <tbody>
@@ -56,7 +65,7 @@
                 <a href="{% url "espace_responsable_aidant" organisation_id=organisation.id aidant_id=aidant.id %}">
                   {{ aidant.get_full_name }}
                   {% if not aidant.is_active %}
-                  <br>(Compte désactivé)
+                    <br>(Compte désactivé)
                   {% endif %}
                 </a>
               </th>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
@@ -40,7 +40,7 @@
         <div class="form__group">
           <label for="{{ form.serial_number.id_for_label }}">
             Entrez le numéro de série de la carte TOTP que vous allez associer
-            à {{ aidant.get_full_name }}&nbsp;:
+            à {% if aidant.id == responsable.id %}votre compte{% else %}{{ aidant.get_full_name }}{% endif %}&nbsp;:
           </label>
           {{ form.serial_number }}
           {% if form.errors.serial_number %}

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -5,6 +5,7 @@ from django.db.utils import IntegrityError
 from django.test import tag, TestCase
 from django.utils import timezone
 from django.conf import settings
+from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from freezegun import freeze_time
 from pytz import timezone as pytz_timezone
@@ -729,6 +730,10 @@ class AidantModelMethodsTests(TestCase):
         )
         cls.respo_juliette.responsable_de.add(cls.aidant_marge.organisation)
 
+        # TOTP Device
+        device = TOTPDevice(user=cls.aidant_marge)
+        device.save()
+
         # Active Usagers
         cls.usager_homer = UsagerFactory(given_name="Homer")
         cls.usager_ned = UsagerFactory(given_name="Ned")
@@ -1016,6 +1021,10 @@ class AidantModelMethodsTests(TestCase):
         self.assertFalse(self.aidant_lisa.is_responsable_structure())
         # however Juliette is responsable structure
         self.assertTrue(self.respo_juliette.is_responsable_structure())
+
+    def test_has_a_totp_device(self):
+        self.assertFalse(self.aidant_lisa.has_a_totp_device)
+        self.assertTrue(self.aidant_marge.has_a_totp_device)
 
 
 @tag("models", "journal")

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -25,13 +25,8 @@ def check_responsable_has_a_totp_device(sender, user: Aidant, request, **kwargs)
     if not user.is_responsable_structure():
         return
 
-    try:  # try to get at least one totp device attached to this user, and return if so
-        TOTPDevice.objects.get(user=user)
+    if user.has_a_totp_device:
         return
-    except TOTPDevice.MultipleObjectsReturned:
-        return  # it's OK, I need at least one
-    except TOTPDevice.DoesNotExist:
-        pass
 
     association_url = reverse(
         "espace_responsable_associate_totp",

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -186,7 +186,12 @@ def associate_aidant_carte_totp(request, organisation_id, aidant_id):
     return render(
         request,
         "aidants_connect_web/espace_responsable/write-carte-totp-sn.html",
-        {"aidant": aidant, "organisation": organisation, "form": form},
+        {
+            "aidant": aidant,
+            "organisation": organisation,
+            "responsable": responsable,
+            "form": form,
+        },
     )
 
 

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,11 +1,8 @@
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.signals import user_logged_in
 from django.db import transaction
 from django.http import Http404
 from django.shortcuts import render, redirect, get_object_or_404
-from django.utils.safestring import mark_safe
-from django.urls import reverse
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from aidants_connect_web.models import Aidant, CarteTOTP, Organisation
@@ -19,31 +16,6 @@ from aidants_connect_web.forms import CarteOTPSerialNumberForm, CarteTOTPValidat
 def check_organisation_and_responsable(responsable: Aidant, organisation: Organisation):
     if responsable not in organisation.responsables.all():
         raise Http404
-
-
-def check_responsable_has_a_totp_device(sender, user: Aidant, request, **kwargs):
-    if not user.is_responsable_structure():
-        return
-
-    if user.has_a_totp_device:
-        return
-
-    association_url = reverse(
-        "espace_responsable_associate_totp",
-        kwargs={"organisation_id": user.organisation.id, "aidant_id": user.id},
-    )
-    django_messages.warning(
-        request,
-        mark_safe(
-            "Bienvenue ! Avant toute chose, vous devez associer une carte TOTP à votre "
-            "compte afin de pouvoir vous connecter à nouveau à l'avenir. "
-            f'<strong><a href="{association_url}">Cliquez ici pour associer une carte '
-            "TOTP à votre compte.</a></strong>"
-        ),
-    )
-
-
-user_logged_in.connect(check_responsable_has_a_totp_device)
 
 
 @login_required


### PR DESCRIPTION
## 🌮 Objectif

Encourager les responsables structure à associer une carte TOTP à leur propre compte, lors de leur première connexion.

## 🔍 Implémentation

Des messages insistants : 
- au login,
- sur la page "espace aidant" le cas échéant,
- sur la page "espace responsable" et sur les sous-pages…

## 🏕 Amélioration continue

J'ai modifié légèrement la page "aidant" pour faciliter la création de responsables structure par nos bizdev.


## 🖼️ Images

À la connexion : 
<img width="1372" alt="Capture d’écran 2021-05-19 à 11 09 48" src="https://user-images.githubusercontent.com/1035145/118787150-d4cef100-b892-11eb-9057-fec2077cb39a.png">


Sur l'accueil espace responsable : 
<img width="1389" alt="Capture d’écran 2021-05-18 à 19 10 34" src="https://user-images.githubusercontent.com/1035145/118695766-d5717400-b80d-11eb-961e-48fa091d24eb.png">


Sur la page de détail d'une structure : 
<img width="1389" alt="Capture d’écran 2021-05-18 à 19 10 44" src="https://user-images.githubusercontent.com/1035145/118695739-d0142980-b80d-11eb-8a28-dcd5ecb3a76c.png">

