### PR TITLE
Suivi des erreurs 404 dans Sentry

### DIFF
--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path("admin/", include("admin_honeypot.urls", namespace="admin_honeypot")),
     path("", include("aidants_connect_web.urls")),
 ]
+handler404 = "aidants_connect_web.views.custom_errors.custom_404"
 
 if settings.DEBUG:
     import debug_toolbar

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -15,6 +15,9 @@ from aidants_connect_web.views import (
     datapass,
 )
 
+# custom error handlers
+handler404 = "aidants_connect_web.views.custom_errors.custom_404"
+
 urlpatterns = [
     # service
     path("accounts/login/", magicauth_views.LoginView.as_view(), name="login"),

--- a/aidants_connect_web/views/custom_errors.py
+++ b/aidants_connect_web/views/custom_errors.py
@@ -1,0 +1,9 @@
+from django.shortcuts import render
+
+from sentry_sdk import capture_message
+
+
+def custom_404(request, exception):
+    """Observe 404 errors to log them in Sentry"""
+    capture_message(f"Page not found: {request.get_full_path()}", level="error")
+    return render(request, "404.html", status=404)


### PR DESCRIPTION
## 🌮 Objectif

On sait depuis longtemps que l'on a relativement peu d'erreurs 500 sur AC. Par contre on n'a aucune mesure facile des erreurs 404, qui peuvent pourtant poser aux utilisateurs des problèmes aussi conséquents que les erreurs 500.

## 🔍 Implémentation

- Envoi d'une alerte Sentry à chaque fois qu'un internaute rencontrera une 404 sur Aidants Connect. Ça va ressembler à ceci : https://sentry.io/organizations/betagouv-f7/issues/2321803736/?project=5707861&query=&statsPeriod=90d
