### PR TITLE
Ajoute un lien « j'ai perdu ma carte »

### DIFF
--- a/aidants_connect_web/static/css/home.css
+++ b/aidants_connect_web/static/css/home.css
@@ -9,3 +9,9 @@
 #faq-content {
   border-top: 1px solid #c9d3df;
 }
+
+.lost-card {
+  font-size: .9em;
+  font-style: italic;
+  line-height: 1.3em;
+}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -58,6 +58,12 @@
         <div class="form__group">
           <button type="submit" class="button">Valider</button>
         </div>
+        <div class="form__group lost-card">
+          Un problème avec votre carte OTP ou votre téléphone&nbsp;?<br>
+          <a href="mailto:contact@aidantsconnect.beta.gouv.fr?subject=Problème OTP&body=Bonjour, je suis (nom,prénom), de la structure (nom de structure). J’ai un problème pour me connecter : (description du problème). Voici mon numéro (numéro de téléphone).">
+            Contactez-nous par courriel
+          </a>.
+        </div>
       {% endif %}
     </form>
   </div>


### PR DESCRIPTION
## 🌮 Objectif

Encourager les aidants à nous signaler la perte de leur carte ou de leur téléphone

## 🔍 Implémentation

- Ajout d'un lien permettant de créer un e-mail pré-rempli

## 🖼️ Images

![Capture d’écran 2021-05-24 à 14 37 30](https://user-images.githubusercontent.com/1035145/119358401-dd676300-bca8-11eb-8d9e-41a195ca9214.png)

