### PR TITLE
Update habilitation sans élus

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -57,7 +57,7 @@
           <h3>Les élus peuvent-ils être habilités Aidants Connect&nbsp;?</h3>
           <p>Pour les communes disposant d’un <abbr title="Centre Communal d’action sociale">CCAS</abbr>, les élus ne peuvent pas être habilités.
             Nous recommandons aux élus de faire habiliter le CCAS qui est la structure missionnée pour l’accompagnement social d’usagers.</p>
-          <p>Pour les communes ne disposant pas de CCAS (moins de 1500 habitants), les élus sont éligibles.</p>
+          <p>Pour les communes ne disposant pas de CCAS (moins de 1500 habitants), nous recommandons l'habilitation des services de la commune.</p>
           <h3>Qui doit remplir le formulaire d’habilitation au sein de la structure&nbsp;?</h3>
           <p>Nous recommandons que ce soit le responsable de structure, en charge de la mise en place d’Aidants Connect, qui se charge de remplir le formulaire d’habilitation.
             Néanmoins, il est possible qu’un aidant puisse remplir le formulaire d’habilitation si le responsable de structure lui en a donné l’autorisation.</p>


### PR DESCRIPTION
## 🌮 Objectif

- Suite aux échanges avec notre DPO, il est recommandé de retirer tout mention de l'éligibilité des élus dans notre FAQ. 

## 🔍 Implémentation

- Suppression "les élus sont éligibles" -> "nous recommandons l'habilitation des services de la commune"

