### PR TITLE
Accentuer la non-habilitation des élus

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -70,7 +70,7 @@
             Exemples : les travailleurs sociaux.
           </li>
         </ul>
-        <p><strong>Les aidants familiaux, les bénévoles et services civiques ne sont donc pas éligibles. Pour plus
+        <p><strong>Les aidants familiaux, les bénévoles, les services civiques et les élus ne sont donc pas éligibles. Pour plus
           d'informations,
           nous vous invitons à consulter <a href="https://aidantsconnect.beta.gouv.fr/faq/mandat/">notre
             FAQ.</a></strong></p><br>


### PR DESCRIPTION
## 🌮 Objectif

Suite à la confirmation de la DPO, mettre l'accent sur la non-habilitation des élus sur notre page habilitation.
