### PR TITLE
Import de la "responsabilité structure" et création du static token lors de l'import des aidants

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -119,6 +119,7 @@ class AidantResource(resources.ModelResource):
             "profession",
             "organisation_id",
             "is_active",
+            "responsable_de",
         )
 
     def before_save_instance(self, instance: Aidant, using_transactions, dry_run):

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
@@ -11,6 +11,9 @@
       <dd>Identifiant interne Django de l'organisation. Vous pouvez le retrouver dans la colonne ID de la page
         Organisations de l'admin Django.
       </dd>
+      <dt>responsable_de</dt>
+      <dd>Identifiants internes Django des organisations dont l'aidant est responsable.<br>
+        Séparez les identifiants par des virgules, par exemple&nbsp;: <code>4,5,6</code></dd>
       <dt>first_name, last_name</dt>
       <dd>Prénom et nom de famille de l'aidant, respectivement.</dd>
       <dt>is_active</dt>

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_aidant.html
@@ -14,6 +14,8 @@
       <dt>responsable_de</dt>
       <dd>Identifiants internes Django des organisations dont l'aidant est responsable.<br>
         Séparez les identifiants par des virgules, par exemple&nbsp;: <code>4,5,6</code></dd>
+      <dt>token</dt>
+      <dd>Code à 6 chiffres permettant à un responsable de se connecter avant l'activation de sa carte TOTP.</dd>
       <dt>first_name, last_name</dt>
       <dd>Prénom et nom de famille de l'aidant, respectivement.</dd>
       <dt>is_active</dt>


### PR DESCRIPTION
## 🌮 Objectif

Faciliter la création des aidants et des responsables structure par import excel/CSV.

## 🔍 Implémentation

Donner deux nouvelles possibilités à l'import des aidants dans l'administration Django : 

- remplissage du champ "responsable de" pour marquer les respo structure ;
- remplissage du champ "token" pour créer le code de première connexion.


## 🖼️ Images

Les champs "token" et "responsable_de" sont disponibles dans l'import des aidants : 

![Capture d’écran 2021-05-31 à 17 54 15](https://user-images.githubusercontent.com/1035145/120217875-3ef37880-c239-11eb-98d0-28369aaf8178.png)

