### PR TITLE
Reformulation de termes mal compris par les utilisateurs

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -184,7 +184,7 @@ class OTPForm(forms.Form):
         validators=[RegexValidator(r"^\d{6}$")],
         label=(
             "Entrez le code à 6 chiffres généré par votre téléphone "
-            "ou votre carte OTP"
+            "ou votre carte Aidants Connect"
         ),
         widget=forms.TextInput(attrs={"autocomplete": "off"}),
     )

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -25,7 +25,7 @@
           Bienvenue&nbsp;! Avant toute chose, nous vous invitons à
           <strong><a
               href="{% url "espace_responsable_associate_totp" organisation_id=aidant.organisation.id aidant_id=aidant.id %}">
-            activer votre carte TOTP</a></strong> afin de pouvoir vous connecter à nouveau à l’avenir.
+            activer votre carte Aidants Connect</a></strong> afin de pouvoir vous connecter à nouveau à l’avenir.
         </div>
       {% endif %}
     <div class="tiles aidant-home-services">
@@ -37,7 +37,7 @@
           </a>
           {% if not aidant.has_a_totp_device %}
             <a id="view_organisation" class="tile text-center background-color-grey" href="{% url "espace_responsable_associate_totp" organisation_id=aidant.organisation.id aidant_id=aidant.id %}">
-              <span aria-hidden="true">💳<br /></span>Activer ma carte TOTP
+              <span aria-hidden="true">💳<br /></span>Activer ma carte
             </a>
           {% endif %}
         {% else %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -22,7 +22,7 @@
           Avant toute chose, nous vous invitons à
           <strong><a
               href="{% url "espace_responsable_associate_totp" organisation_id=responsable.organisation.id aidant_id=responsable.id %}">
-            activer votre carte TOTP.
+            activer votre carte Aidants Connect.
           </a></strong>
         </div>
       {% endif %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -23,7 +23,7 @@
           Avant toute chose, nous vous invitons à
           <strong><a
               href="{% url "espace_responsable_associate_totp" organisation_id=responsable.organisation.id aidant_id=responsable.id %}">
-            activer votre carte TOTP.
+            activer votre carte Aidants Connect.
           </a></strong>
         </div>
       {% endif %}
@@ -55,7 +55,7 @@
           <tr>
             <th scope="col">Nom</th>
             <th scope="col">Email</th>
-            <th scope="col">Carte TOTP</th>
+            <th scope="col">Carte Aidants Connect</th>
           </tr>
           </thead>
           <tbody>
@@ -87,7 +87,7 @@
                     {% endif %}
                   {% else %}
                     <a href="{% url "espace_responsable_associate_totp" organisation_id=organisation.id aidant_id=aidant.id %}"
-                       class="button">Associer</a>
+                       class="button">Lier une carte</a>
                   {% endif %}
                 {% endwith %}
               </td>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/validate-carte-totp.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/validate-carte-totp.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - Valider la carte TOTP de {{ aidant.get_full_name }}{% endblock %}
+{% block title %}Aidants Connect - Valider la carte de {{ aidant.get_full_name }}{% endblock %}
 
 {% block extracss %}
   <link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
@@ -25,7 +25,7 @@
         </li>
         <li class="done">
           <div>
-            Saisie du numéro de série<br>de la carte TOTP
+            Saisie du numéro de série<br>de la carte
           </div>
         </li>
         <li class="active">

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
@@ -25,7 +25,7 @@
         </li>
         <li class="active">
           <div>
-            Saisie du numéro de série<br>de la carte TOTP
+            Saisie du numéro de série<br>de la carte
           </div>
         </li>
         <li>
@@ -39,7 +39,7 @@
         {% csrf_token %}
         <div class="form__group">
           <label for="{{ form.serial_number.id_for_label }}">
-            Entrez le numéro de série de la carte TOTP que vous allez associer
+            Entrez le numéro de série de la carte Aidants Connect que vous allez lier
             à {% if aidant.id == responsable.id %}votre compte{% else %}{{ aidant.get_full_name }}{% endif %}&nbsp;:
           </label>
           {{ form.serial_number }}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -59,7 +59,7 @@
           <button type="submit" class="button">Valider</button>
         </div>
         <div class="form__group lost-card">
-          Un problème avec votre carte OTP ou votre téléphone&nbsp;?<br>
+          Un problème avec votre carte ou votre téléphone&nbsp;?<br>
           <a href="mailto:contact@aidantsconnect.beta.gouv.fr?subject=Problème OTP&body=Bonjour, je suis (nom,prénom), de la structure (nom de structure). J’ai un problème pour me connecter : (description du problème). Voici mon numéro (numéro de téléphone).">
             Contactez-nous par courriel
           </a>.

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
@@ -31,11 +31,11 @@ class AssociateCarteTOTPTests(TestCase):
         self.org_id = self.responsable_tom.organisation.id
         self.association_url = (
             f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/associer-carte-totp"
+            f"aidant/{self.aidant_tim.id}/lier-carte"
         )
         self.validation_url = (
             f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/valider-carte-totp"
+            f"aidant/{self.aidant_tim.id}/valider-carte"
         )
 
     def test_association_page_triggers_the_right_view(self):

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -208,7 +208,7 @@ class InsistOnTOTPDeviceActivationTests(TestCase):
             response = self.client.get(page)
             response_content = response.content.decode("utf-8")
             self.assertIn(
-                "activer votre carte TOTP",
+                "activer votre carte Aidants Connect",
                 response_content,
                 f"TOTP message is hidden on '{page}', it should be visible",
             )
@@ -219,7 +219,7 @@ class InsistOnTOTPDeviceActivationTests(TestCase):
             response = self.client.get(page)
             response_content = response.content.decode("utf-8")
             self.assertNotIn(
-                "activer votre carte TOTP",
+                "activer votre carte Aidants Connect",
                 response_content,
                 f"TOTP message is shown on '{page}', it should be hidden",
             )
@@ -229,7 +229,7 @@ class InsistOnTOTPDeviceActivationTests(TestCase):
         response = self.client.get("/espace-aidant/")
         response_content = response.content.decode("utf-8")
         self.assertNotIn(
-            "activer votre carte TOTP",
+            "activer votre carte Aidants Connect",
             response_content,
             "TOTP message is shown on espace-aidant, it should be hidden",
         )

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
@@ -39,7 +39,7 @@ class ValidateCarteTOTPTests(TestCase):
         self.organisation_url = f"/espace-responsable/organisation/{self.org_id}/"
         self.validation_url = (
             f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/valider-carte-totp"
+            f"aidant/{self.aidant_tim.id}/valider-carte"
         )
 
     def test_validation_page_triggers_the_right_view(self):

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -128,7 +128,7 @@ urlpatterns = [
     path(
         (
             "espace-responsable/organisation/<int:organisation_id>"
-            "/aidant/<int:aidant_id>/associer-carte-totp"
+            "/aidant/<int:aidant_id>/lier-carte"
         ),
         espace_responsable.associate_aidant_carte_totp,
         name="espace_responsable_associate_totp",
@@ -136,7 +136,7 @@ urlpatterns = [
     path(
         (
             "espace-responsable/organisation/<int:organisation_id>"
-            "/aidant/<int:aidant_id>/valider-carte-totp"
+            "/aidant/<int:aidant_id>/valider-carte"
         ),
         espace_responsable.validate_aidant_carte_totp,
         name="espace_responsable_validate_totp",

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -104,9 +104,9 @@ def associate_aidant_carte_totp(request, organisation_id, aidant_id):
         django_messages.error(
             request,
             (
-                f"Le compte de {aidant.get_full_name()} est déjà associé à une carte "
-                "TOTP. Vous devez d’abord retirer la carte de son compte avant de "
-                "pouvoir en associer une nouvelle."
+                f"Le compte de {aidant.get_full_name()} est déjà lié à une carte "
+                "Aidants Connect. Vous devez d’abord retirer la carte de son compte "
+                "avant de pouvoir en lier une nouvelle."
             ),
         )
         return redirect(
@@ -178,9 +178,9 @@ def validate_aidant_carte_totp(request, organisation_id, aidant_id):
         django_messages.error(
             request,
             (
-                "Impossible de trouver une carte TOTP associée au compte de "
+                "Impossible de trouver une carte Aidants Connect associée au compte de "
                 f"{aidant.get_full_name()}."
-                "Vous devez d’abord associer une carte à son compte."
+                "Vous devez d’abord lier une carte à son compte."
             ),
         )
         return redirect(


### PR DESCRIPTION
## 🌮 Objectif

Faciliter la prise en main des nouvelles fonctionnalités par les principaux concernés (responsables et aidants).

## 🔍 Implémentation

- Suppression des occurences de "carte OTP" ou "carte TOTP" et reformulation en "cartes Aidants Connect" ou simplement "cartes".
- Reformulation de "associer une carte" en "lier une carte".

## 🖼️ Images

![Capture d’écran 2021-06-01 à 15 34 09](https://user-images.githubusercontent.com/1035145/120332295-e7174900-c2ee-11eb-9d9a-f6c5e6a32000.png)

![Capture d’écran 2021-06-01 à 15 33 58](https://user-images.githubusercontent.com/1035145/120332335-f0a0b100-c2ee-11eb-858c-5bfca6bd53ec.png)

![Capture d’écran 2021-06-01 à 15 31 09](https://user-images.githubusercontent.com/1035145/120332376-f9918280-c2ee-11eb-9410-4eed523d426b.png)

