### PR TITLE
Recherche d'un TOTP Device "confirmé" pour déterminer si on demande au responsable d'activer une carte

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -219,7 +219,7 @@ class Aidant(AbstractUser):
     @cached_property
     def has_a_totp_device(self):
         try:
-            TOTPDevice.objects.get(user=self)
+            TOTPDevice.objects.get(user=self, confirmed=True)
             return True
         except TOTPDevice.MultipleObjectsReturned:
             return True


### PR DESCRIPTION
## 🌮 Objectif

Éviter des soucis à un responsable de structure qui n'aurait qu'à moitié activé sa carte.

Pour encourager les responsables à activer leur carte AC, on affiche un message d'avertissement "activez votre carte". Mais ce message est masqué dès qu'il existe un TOTP Device associé en base, même s'il est "désactivé". Or ce cas risque de se produire, car si le responsable s'arrête entre l'étape 2 et 3 (où il entre le code à 6 chiffres généré par la carte), il se retrouve avec un TOTP Device désactivé.

Pour éviter de perdre trop d'utilisateurs à cette étape-là, je continue d'afficher le message tant que je ne trouve pas un TOTP Device "confirmé" (et donc utilisable) dans la base.

## 🔍 Implémentation

- Ajout d'une condition "confirmed=True" dans la recherche des TOTP Device associés à l'utilisateur

## À faire

- [x] Ajouter un test (à part ou dans le scénario "saisie du numéro de série")
