### PR TITLE
Réparation du script de release pour les numéros de version au-delà de 10

### DIFF
--- a/aidants_connect_web/management/commands/release.py
+++ b/aidants_connect_web/management/commands/release.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
 
     def ask_for_new_version(self):
         self.stdout.write("Here are the latest versions:")
-        os.system("git tag -l | tail -5")
+        os.system("git tag -l --sort=creatordate | tail -5")
         version = input("How will you name this new version? ")
         return version
 
@@ -52,7 +52,9 @@ class Command(BaseCommand):
         return are_they_sure.lower().strip() == "y"
 
     def display_and_get_changelog(self):
-        previous_version = os.popen("git tag | tail -1").read().strip()
+        previous_version = (
+            os.popen("git tag --sort=creatordate | tail -1").read().strip()
+        )
         command = (
             f"git log --pretty='format:%s' --first-parent main {previous_version}..main"
         )


### PR DESCRIPTION
## 🌮 Objectif

Après avoir tagué ma version `v1.4.10`, le script de release considérait toujours que la version la plus récente était la version `v1.4.9`. Ceci car le script lance un simple `git tag`, trié par défaut par ordre alphabétique, et regarde la ou les dernières lignes.

## 🔍 Implémentation

- Je demande à git de me donner les derniers tags par ordre chronologique, avec l'option `--sort=creatordate`
