### PR TITLE
Cesser de suivre les 404 dans Sentry

### DIFF
--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -8,7 +8,6 @@ urlpatterns = [
     path("admin/", include("admin_honeypot.urls", namespace="admin_honeypot")),
     path("", include("aidants_connect_web.urls")),
 ]
-handler404 = "aidants_connect_web.views.custom_errors.custom_404"
 
 if settings.DEBUG:
     import debug_toolbar

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -15,9 +15,6 @@ from aidants_connect_web.views import (
     datapass,
 )
 
-# custom error handlers
-handler404 = "aidants_connect_web.views.custom_errors.custom_404"
-
 urlpatterns = [
     # service
     path("accounts/login/", magicauth_views.LoginView.as_view(), name="login"),

--- a/aidants_connect_web/views/custom_errors.py
+++ b/aidants_connect_web/views/custom_errors.py
@@ -1,9 +1,0 @@
-from django.shortcuts import render
-
-from sentry_sdk import capture_message
-
-
-def custom_404(request, exception):
-    """Observe 404 errors to log them in Sentry"""
-    capture_message(f"Page not found: {request.get_full_path()}", level="error")
-    return render(request, "404.html", status=404)


### PR DESCRIPTION
## 🌮 Objectif

Arrêter de spammer Sentry dès qu'un robot passe sur notre site. (Environ 1500 alertes en moins de 24h)

## 🔍 Implémentation

- Cesser de suivre les 404 dans Sentry : revert de la PR #361 

J'ai envisagé de ne lever une alerte que s'il n'y a pas "nuclei" dans le user-agent, mais je crains que la charge de filtrage des alertes sentry reste quand même trop élevée pour un résultat décevant.
