### PR TITLE
Répare l'import excel des aidants

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -135,8 +135,9 @@ class AidantResource(resources.ModelResource):
             RowResult.IMPORT_TYPE_UPDATE,
         ):
             return
-        if len(row["token"]) == 6 and row["token"].isnumeric():
-            add_static_token(row["username"], row["token"])
+        token = str(row.get("token"))
+        if token and len(token) == 6 and token.isnumeric():
+            add_static_token(row["username"], int(token))
 
 
 class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -137,7 +137,7 @@ class AidantResource(resources.ModelResource):
             return
         token = str(row.get("token"))
         if token and len(token) == 6 and token.isnumeric():
-            add_static_token(row["username"], int(token))
+            add_static_token(row["username"], token)
 
 
 class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux bizdev d'importer des comptes aidants en masse à l'aide de leur fichier excel.

## 🔍 Implémentation

On se retrouve avec une succession de problèmes d'origines diverses : 
- J'avais fait mes tests à l'aide de fichiers CSV que je générais à la main, séparés par des virgules.
- Quand on importe un fichier excel xlsx, la colonne "token" est transformée en un integer dans le code Python, mais quand j'importais un CSV pour tester le code, la colonne token est une chaîne de caractères. => Ça plante quand on importe un excel .xlsx
- Quand on exporte un fichier excel en CSV depuis Excel, les colonnes sont toujours séparées par des points-virgules (même si on sélectionne bien "virgules") => ça plante quand on importe un fichier csv venant d'Excel.
- Et en plus quand la colonne token est manquante ou vide, on a une keyError : my bad entirely

Donc : 
- on récupère la valeur avec row.get("token") au lieu de row["token"] pour éviter la keyError ;
- on parse la valeur en string pour analyser sa longueur et sa numérosité ;
- <del>on re-parse la valeur en entier pour la passer dans la fonction de création de token.</del> ➡️ En fait non, c'était crétin : ça casse tout si le token commence par un zéro. (En fait Excel pré-casse déjà les tokens commençant par zéro, mais autant ne pas en remettre une couche.)
