### PR TITLE
Améliorations de l'admin

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -157,7 +157,7 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
     # The forms to add and change `Aidant` instances
     form = AidantChangeForm
     add_form = AidantCreationForm
-    raw_id_fields = ("responsable_de",)
+    raw_id_fields = ("responsable_de", "organisation")
 
     # For bulk import
     resource_class = AidantResource

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -298,7 +298,7 @@ class CarteTOTPResource(resources.ModelResource):
 
 
 class CarteTOTPAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
-    list_display = ("serial_number",)
+    list_display = ("serial_number", "aidant")
     search_fields = ("serial_number",)
     raw_id_fields = ("aidant",)
     ordering = ("-created_at",)


### PR DESCRIPTION
## 🌮 Objectif

Faciliter la vie des utilisatrices et utilisateurs de l'admin Django

## 🔍 Implémentation

- Affichage de l'aidant associé aux cartes TOTP
- Utilisation d'un champ de recherche plutôt qu'une liste déroulante pour associer un Aidant à une Organisation


## 🖼️ Images

Champ de recherche d'une Organisation sur la page d'un Aidant à la place de la liste déroulante : 

![](https://user-images.githubusercontent.com/1035145/121870837-b9c19680-cd03-11eb-99c3-54ae9690d4e2.png)

Affichage de l'aidant associé à la carte TOTP dans la liste d'icelles de l'admin Django : 

![](https://user-images.githubusercontent.com/1035145/121871036-f1c8d980-cd03-11eb-920a-e0b27d2f98ed.png)
