### PR TITLE
Migration pour réparer les chemins de gabarits des mandats

### DIFF
--- a/aidants_connect_web/migrations/0051_mandat_template_path.py
+++ b/aidants_connect_web/migrations/0051_mandat_template_path.py
@@ -1,71 +1,7 @@
-from datetime import timedelta
-from os import walk as os_walk
-from os.path import dirname, join as path_join
-
-from django.db import migrations, models, transaction
-from django.template import loader
+from django.db import migrations, models
 
 import aidants_connect_web
-from aidants_connect import settings
 from aidants_connect_web.utilities import generate_attestation_hash
-
-
-@transaction.atomic
-def populate_template_path(apps, _):
-    # noinspection PyPep8Naming
-    Journal = apps.get_model("aidants_connect_web", "Journal")
-    # noinspection PyPep8Naming
-    Mandat = apps.get_model("aidants_connect_web", "Mandat")
-
-    for mandate in Mandat.objects.filter(template_path=None).all():
-        journal = None
-
-        journal_qset = Journal.objects.filter(
-            action="create_attestation", mandat=mandate
-        )
-        if journal_qset.count() == 1:
-            journal = journal_qset.first()
-        else:
-            start = mandate.creation_date.replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            end = start + timedelta(days=1)
-
-            journal_qset = Journal.objects.filter(
-                action="create_attestation",
-                usager=mandate.usager,
-                aidant__organisation=mandate.organisation,
-                creation_date__range=(start, end),
-            )
-
-            if journal_qset.count() == 1:
-                journal = journal_qset.first()
-
-        # If we don't find a strong association between a journal
-        # and a mandate, we give up. That's a choice.
-        if journal is None:
-            continue
-
-        template_dir = dirname(
-            loader.get_template(settings.MANDAT_TEMPLATE_PATH).origin.name
-        )
-
-        for _, _, filenames in os_walk(template_dir):
-            for filename in filenames:
-                file_hash = generate_attestation_hash(
-                    journal.aidant,
-                    mandate.usager,
-                    [it.demarche for it in mandate.autorisations.all()],
-                    mandate.expiration_date,
-                    journal.creation_date.date().isoformat(),
-                    path_join(settings.MANDAT_TEMPLATE_DIR, filename),
-                )
-
-                if file_hash == journal.attestation_hash:
-                    mandate.template_path = path_join(
-                        settings.MANDAT_TEMPLATE_DIR, filename
-                    )
-                    mandate.save()
 
 
 class Migration(migrations.Migration):
@@ -87,6 +23,6 @@ class Migration(migrations.Migration):
             ),
         ),
         migrations.RunPython(
-            populate_template_path, reverse_code=migrations.RunPython.noop
+            migrations.RunPython.noop, reverse_code=migrations.RunPython.noop
         ),
     ]

--- a/aidants_connect_web/migrations/0058_fix_mandate_template_path.py
+++ b/aidants_connect_web/migrations/0058_fix_mandate_template_path.py
@@ -1,0 +1,86 @@
+from datetime import timedelta
+from os import walk as os_walk
+from os.path import dirname, join as path_join
+
+from django.db import migrations, transaction
+from django.template import loader
+from django.db.models import Q
+
+from aidants_connect import settings
+from aidants_connect_web.utilities import generate_attestation_hash
+
+
+@transaction.atomic
+def populate_template_path(apps, _):
+    # noinspection PyPep8Naming
+    Journal = apps.get_model("aidants_connect_web", "Journal")
+    # noinspection PyPep8Naming
+    Mandat = apps.get_model("aidants_connect_web", "Mandat")
+
+    for mandate in Mandat.objects.all().order_by("creation_date"):
+        journal = None
+
+        journal_qset = Journal.objects.filter(
+            action="create_attestation", mandat=mandate
+        )
+        if journal_qset.count() == 1:
+            journal = journal_qset.first()
+        else:
+            start = mandate.creation_date.replace(
+                hour=0, minute=0, second=0, microsecond=0
+            )
+            end = start + timedelta(days=1)
+
+            journal_qset = Journal.objects.filter(
+                Q(action="create_attestation"),
+                Q(usager=mandate.usager),
+                Q(aidant__organisation=mandate.organisation),
+                Q(creation_date__range=(start, end)),
+                Q(attestation_hash__isnull=False),
+                ~Q(attestation_hash__exact=""),
+            )
+
+            if journal_qset.count() == 1:
+                journal = journal_qset.first()
+
+        # If we don't find a strong association between a journal
+        # and a mandate, we give up. That's a choice.
+        if journal is None:
+            mandate.template_path = ""
+            mandate.save()
+            continue
+
+        template_dir = dirname(
+            loader.get_template(settings.MANDAT_TEMPLATE_PATH).origin.name
+        )
+
+        for _, _, filenames in os_walk(template_dir):
+            for filename in filenames:
+                file_hash = generate_attestation_hash(
+                    journal.aidant,
+                    mandate.usager,
+                    [it.demarche for it in mandate.autorisations.all()],
+                    mandate.expiration_date,
+                    journal.creation_date.date().isoformat(),
+                    path_join(settings.MANDAT_TEMPLATE_DIR, filename),
+                )
+
+                if file_hash == journal.attestation_hash:
+                    mandate.template_path = path_join(
+                        settings.MANDAT_TEMPLATE_DIR, filename
+                    )
+                    mandate.save()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("aidants_connect_web", "0057_auto_20210525_1559"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            populate_template_path, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/aidants_connect_web/migrations/0059_fix_mandate_template_path.py
+++ b/aidants_connect_web/migrations/0059_fix_mandate_template_path.py
@@ -1,10 +1,11 @@
-from datetime import timedelta
-from os import walk as os_walk
-from os.path import dirname, join as path_join
+from datetime import timedelta, datetime
+from glob import glob
+from os.path import dirname, basename, join as path_join
 
 from django.db import migrations, transaction
 from django.template import loader
 from django.db.models import Q
+from django.utils.timezone import get_default_timezone
 
 from aidants_connect import settings
 from aidants_connect_web.utilities import generate_attestation_hash
@@ -18,6 +19,10 @@ def populate_template_path(apps, _):
     Mandat = apps.get_model("aidants_connect_web", "Mandat")
 
     for mandate in Mandat.objects.all().order_by("creation_date"):
+        # Prevent erasing the field for mandate that are newer than 8th of march, 2021
+        if mandate.creation_date >= datetime(2021, 3, 8, tzinfo=get_default_timezone()):
+            continue
+
         journal = None
 
         journal_qset = Journal.objects.filter(
@@ -54,29 +59,34 @@ def populate_template_path(apps, _):
             loader.get_template(settings.MANDAT_TEMPLATE_PATH).origin.name
         )
 
-        for _, _, filenames in os_walk(template_dir):
-            for filename in filenames:
-                file_hash = generate_attestation_hash(
-                    journal.aidant,
-                    mandate.usager,
-                    [it.demarche for it in mandate.autorisations.all()],
-                    mandate.expiration_date,
-                    journal.creation_date.date().isoformat(),
-                    path_join(settings.MANDAT_TEMPLATE_DIR, filename),
-                )
+        files = glob(f"{template_dir}/**/*.html", recursive=True)
+        for file in files:
+            filename = basename(file)
+            file_hash = generate_attestation_hash(
+                journal.aidant,
+                mandate.usager,
+                [it.demarche for it in mandate.autorisations.all()],
+                mandate.expiration_date,
+                journal.creation_date.date().isoformat(),
+                path_join(settings.MANDAT_TEMPLATE_DIR, filename),
+            )
 
-                if file_hash == journal.attestation_hash:
-                    mandate.template_path = path_join(
-                        settings.MANDAT_TEMPLATE_DIR, filename
-                    )
-                    mandate.save()
+            if file_hash == journal.attestation_hash:
+                mandate.template_path = path_join(
+                    settings.MANDAT_TEMPLATE_DIR, filename
+                )
+                mandate.save()
+                break
+        else:
+            mandate.template_path = ""
+            mandate.save()
 
 
 class Migration(migrations.Migration):
     atomic = False
 
     dependencies = [
-        ("aidants_connect_web", "0057_auto_20210525_1559"),
+        ("aidants_connect_web", "0058_aidant_validated_cgu_version"),
     ]
 
     operations = [


### PR DESCRIPTION
## 🌮 Objectif

La migration pour populer le champ `template_path` du modèle `Mandat` introduit par #323 n'a pas fonctionné et a affecté la valeur `aidants_connect_web/mandat_templates/20210308_mandat.html` à tous les mandats, même pour les mandats plus anciens.