### PR TITLE
Stabilisation d'un test clignotant

### DIFF
--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
@@ -1,9 +1,10 @@
+import mock
+
 from django.test import tag, TestCase
 from django.test.client import Client
 from django.urls import resolve
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
-from django_otp.oath import TOTP
 
 from aidants_connect_web.tests.factories import (
     AidantFactory,
@@ -56,24 +57,15 @@ class ValidateCarteTOTPTests(TestCase):
     def test_validation_totp_with_valid_token(self):
         self.client.force_login(self.responsable_tom)
 
-        # Generate a valid TOTP token
-        totp = TOTP(
-            self.device.bin_key,
-            self.device.step,
-            self.device.t0,
-            self.device.digits,
-            self.device.drift,
-        )
-        valid_token = totp.token()
-
-        # Submit post and check redirection is correct
-        response = self.client.post(
-            self.validation_url,
-            data={"otp_token": str(valid_token)},
-        )
-        self.assertRedirects(
-            response, self.organisation_url, fetch_redirect_response=False
-        )
+        with mock.patch("django_otp.oath.TOTP.verify", return_value=True):
+            # Submit post and check redirection is correct
+            response = self.client.post(
+                self.validation_url,
+                data={"otp_token": str(888888)},
+            )
+            self.assertRedirects(
+                response, self.organisation_url, fetch_redirect_response=False
+            )
 
         # Check TOTP device is correct
         totp_device = TOTPDevice.objects.first()
@@ -98,17 +90,15 @@ class ValidateCarteTOTPTests(TestCase):
     def test_validation_totp_with_invalid_token(self):
         self.client.force_login(self.responsable_tom)
 
-        # Generate an invalid TOTP token
-        invalid_token = 999999
-
-        # Submit post and check there is no redirection
-        response = self.client.post(
-            self.validation_url,
-            data={"otp_token": str(invalid_token)},
-        )
-        response_content = response.content.decode("utf-8")
-        self.assertIn(
-            "Ce code n’est pas valide.",
-            response_content,
-            "Form should warn if the code is not valid.",
-        )
+        with mock.patch("django_otp.oath.TOTP.verify", return_value=False):
+            # Submit post and check there is no redirection
+            response = self.client.post(
+                self.validation_url,
+                data={"otp_token": str(999999)},
+            )
+            response_content = response.content.decode("utf-8")
+            self.assertIn(
+                "Ce code n’est pas valide.",
+                response_content,
+                "Form should warn if the code is not valid.",
+            )


### PR DESCRIPTION
## 🌮 Objectif

Stabiliser le test de validation de token OTP, qui tendait à échouer sans raison.

## 🔍 Implémentation

- Au lieu de générer un token valide (qui apparemment n'est pas valide tout le temps), on mock la fonction centrale de vérification d'un token pour qu'elle retourne forcément `True` pendant le test.
- Dans le même ordre d'idée on mock la fonction pour le cas de test "token invalide" même si ce test avait seulement 0,001% de chance d'échouer pour cause de token accidentellement valide.


## 🖼️ Images

ChezMoiÇaMarche™, j'attends de voir ce qu'en dit la CI : 

![Capture d’écran 2021-06-21 à 16 37 05](https://user-images.githubusercontent.com/1035145/122780447-23ffab80-d2af-11eb-9759-a46c02cad47d.png)

