### PR TITLE
Dépollution de l'output de test

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -433,7 +433,7 @@ OTP_TOTP_THROTTLE_FACTOR = int(os.getenv("OTP_TOTP_THROTTLE_FACTOR", 1))
 HEADLESS_FUNCTIONAL_TESTS = getenv_bool("HEADLESS_FUNCTIONAL_TESTS", True)
 
 # Disable logging in tests
-if len(sys.argv) > 1 and sys.argv[1] == "test":
+if "test" in sys.argv:
     logging.disable(logging.CRITICAL)
     LOGGING = {
         "version": 1,

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -14,6 +14,8 @@ from datetime import datetime, timedelta
 import os
 import re
 from typing import Union
+import sys
+import logging
 
 from dotenv import load_dotenv
 import sentry_sdk
@@ -429,6 +431,21 @@ OTP_TOTP_THROTTLE_FACTOR = int(os.getenv("OTP_TOTP_THROTTLE_FACTOR", 1))
 
 # Functional tests behaviour
 HEADLESS_FUNCTIONAL_TESTS = getenv_bool("HEADLESS_FUNCTIONAL_TESTS", True)
+
+# Disable logging in tests
+if len(sys.argv) > 1 and sys.argv[1] == "test":
+    logging.disable(logging.CRITICAL)
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "handlers": {
+            "file": {
+                "level": "DEBUG",
+                "class": "logging.NullHandler",
+            },
+        },
+    }
+
 
 BYPASS_FIRST_LIVESERVER_CONNECTION = getenv_bool(
     "BYPASS_FIRST_LIVESERVER_CONNECTION", False

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -480,7 +480,7 @@ class MandatModelTests(TestCase):
             usager=self.usager_1,
             demarche=",".join(procedures),
             attestation_hash=old_attestation_hash,
-            creation_date=datetime.now() - timedelta(weeks=1),
+            creation_date=timezone.now() - timedelta(weeks=1),
         )
 
         mandate = Mandat.objects.create(


### PR DESCRIPTION
## 🌮 Objectif

Quand je lance `manage.py test`, je veux avoir juste les `.` pour les tests réussis, ou `F` ou `E` pour ceux qui échouent ou sont en erreur. Mais à la place j'ai des logs django à chaque erreur 404 et des logs de gecko/selenium…

Le but de cette PR est de rendre la sortie des tests + lisible.

## 🔍 Implémentation

- Désactivation des logs Django pendant les tests
- Idéalement désactivation des logs gecko/selenium aussi

## 🖼️ Images

WIP : On voit une belle ligne de points avec un warning résiduel dont je n'ai pas encore localisé la cause, puis la première stacktrace selenium…

![Capture d’écran 2021-06-22 à 15 46 22](https://user-images.githubusercontent.com/1035145/122935911-072bac80-d371-11eb-8984-1aa4d8ffc9db.png)

