### PR TITLE
Modification de la manière d'initialiser les données dans les tests.

### DIFF
--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -34,11 +34,12 @@ ETAT_URGENCE_2020_LAST_DAY = datetime.strptime(
 
 @tag("commands")
 class DeleteExpiredConnectionsTests(TestCase):
-    def setUp(self):
-        self.conn_1 = ConnectionFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.conn_1 = ConnectionFactory(
             expires_on=datetime(2020, 1, 1, 6, 0, 0, tzinfo=timezone.utc)
         )
-        self.conn_2 = ConnectionFactory(
+        cls.conn_2 = ConnectionFactory(
             expires_on=datetime(2020, 1, 1, 8, 0, 0, tzinfo=timezone.utc)
         )
 

--- a/aidants_connect_web/tests/test_decorators.py
+++ b/aidants_connect_web/tests/test_decorators.py
@@ -12,9 +12,10 @@ fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 
 @tag("decorators")
 class ActivityRequiredTests(TestCase):
-    def setUp(self):
-        self.aidant_thierry = AidantFactory()
-        device = self.aidant_thierry.staticdevice_set.create(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidant_thierry = AidantFactory()
+        device = cls.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
 
     def test_activity_required_decorated_page_loads_if_action_just_happened(self):
@@ -35,14 +36,15 @@ class ActivityRequiredTests(TestCase):
 
 @tag("decorators")
 class AidantRequiredTests(TestCase):
-    def setUp(self):
-        self.aidant_thierry = AidantFactory()
-        self.responsable_georges = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidant_thierry = AidantFactory()
+        cls.responsable_georges = AidantFactory(
             username="georges@georges.com",
-            organisation=self.aidant_thierry.organisation,
+            organisation=cls.aidant_thierry.organisation,
             can_create_mandats=False,
         )
-        self.responsable_georges.responsable_de.add(self.aidant_thierry.organisation)
+        cls.responsable_georges.responsable_de.add(cls.aidant_thierry.organisation)
 
     def test_aidant_user_can_access_decorated_page(self):
         self.client.force_login(self.aidant_thierry)
@@ -57,15 +59,16 @@ class AidantRequiredTests(TestCase):
 
 @tag("decorators")
 class RespoStructureRequiredTests(TestCase):
-    def setUp(self):
-        self.aidant_thierry = AidantFactory()
-        self.responsable_georges = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidant_thierry = AidantFactory()
+        cls.responsable_georges = AidantFactory(
             username="georges@georges.com",
-            organisation=self.aidant_thierry.organisation,
+            organisation=cls.aidant_thierry.organisation,
             can_create_mandats=False,
         )
-        self.responsable_georges.responsable_de.add(self.aidant_thierry.organisation)
-        self.responsable_georges.responsable_de.add(OrganisationFactory())
+        cls.responsable_georges.responsable_de.add(cls.aidant_thierry.organisation)
+        cls.responsable_georges.responsable_de.add(OrganisationFactory())
 
     def test_responsable_can_access_decorated_page(self):
         self.client.force_login(self.responsable_georges)

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -14,8 +14,9 @@ from aidants_connect_web.tests.factories import AidantFactory, OrganisationFacto
 
 @tag("forms")
 class AidantCreationFormTests(TestCase):
-    def setUp(self):
-        self.data = {
+    @classmethod
+    def setUpTestData(cls):
+        cls.data = {
             "first_name": "Heliette",
             "last_name": "Bernart",
             "email": "hbernart@domain.user",
@@ -24,15 +25,15 @@ class AidantCreationFormTests(TestCase):
             "profession": "Mediatrice",
             "organisation": "3",
         }
-        self.organisation = OrganisationFactory(id=3)
-        self.existing_aidant = AidantFactory(
+        cls.organisation = OrganisationFactory(id=3)
+        cls.existing_aidant = AidantFactory(
             first_name="Armand",
             last_name="Giraud",
             email="agiraud@domain.user",
             username="agiraud@domain.user",
             password="flkqgnfdùqlgnqùflkgnùqflkngw",
             profession="Mediateur",
-            organisation=self.organisation,
+            organisation=cls.organisation,
         )
 
     def test_from_renders_item_text_input(self):
@@ -103,12 +104,13 @@ class AidantCreationFormTests(TestCase):
 
 
 class AidantChangeFormTests(TestCase):
-    def setUp(self):
-        self.organisation_nantes = OrganisationFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation_nantes = OrganisationFactory(
             name="Association Aide au Numérique"
         )
-        self.organisation_nantes = OrganisationFactory(name="Association Aide'o'Web")
-        self.nantes_id = self.organisation_nantes.id
+        cls.organisation_nantes = OrganisationFactory(name="Association Aide'o'Web")
+        cls.nantes_id = cls.organisation_nantes.id
         AidantFactory(
             first_name="Henri",
             last_name="Bernard",
@@ -116,17 +118,17 @@ class AidantChangeFormTests(TestCase):
             username="hello@domain.user",
             password="flkqgnfdùqlgnqùflkgnùqflkngw",
             profession="Mediateur",
-            organisation=self.organisation_nantes,
+            organisation=cls.organisation_nantes,
         )
-        self.aidant2 = AidantFactory(
+        cls.aidant2 = AidantFactory(
             first_name="Armand",
             last_name="Bernard",
             email="abernart@domain.user",
             username="abernart@domain.user",
             profession="Mediateur",
-            organisation=self.organisation_nantes,
+            organisation=cls.organisation_nantes,
         )
-        self.aidant2.set_password("nananana")
+        cls.aidant2.set_password("nananana")
 
     def test_change_email_propagates_to_username(self):
         self.assertEqual(self.aidant2.first_name, "Armand")
@@ -156,6 +158,7 @@ class AidantChangeFormTests(TestCase):
         self.assertCountEqual(form.errors, [])
 
     def test_change_date_propagates_to_aidant_profile(self):
+        self.aidant2.refresh_from_db()
         self.assertEqual(self.aidant2.first_name, "Armand")
         self.assertEqual(self.aidant2.email, "abernart@domain.user")
         self.assertEqual(self.aidant2.username, "abernart@domain.user")
@@ -181,6 +184,7 @@ class AidantChangeFormTests(TestCase):
         self.assertEqual(self.aidant2.last_name, "test")
 
     def test_change_to_email_fails_if_email_exists(self):
+        self.aidant2.refresh_from_db()
         changed_data = {
             "first_name": "Armand",
             "last_name": "Bernart",
@@ -255,10 +259,11 @@ class MandatFormTests(TestCase):
 
 
 class RecapMandatFormTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant_thierry = AidantFactory()
-        device = self.aidant_thierry.staticdevice_set.create(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant_thierry = AidantFactory()
+        device = cls.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
 
     def test_form_renders_item_text_input(self):

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -17,43 +17,41 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 @tag("functional")
 class CancelAutorisationTests(FunctionalTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.aidant_thierry = AidantFactory()
-        device = cls.aidant_thierry.staticdevice_set.create(id=cls.aidant_thierry.id)
+    def setUp(self):
+        self.aidant_thierry = AidantFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=self.aidant_thierry.id)
         device.token_set.create(token="123456")
-        cls.aidant_jacqueline = AidantFactory(
+        self.aidant_jacqueline = AidantFactory(
             username="jfremont@domain.user",
             email="jfremont@domain.user",
             password="motdepassedejacqueline",
             first_name="Jacqueline",
             last_name="Fremont",
         )
-        cls.usager_josephine = UsagerFactory(given_name="Joséphine")
-        cls.mandat_thierry_josephine = MandatFactory(
-            organisation=cls.aidant_thierry.organisation,
-            usager=cls.usager_josephine,
+        self.usager_josephine = UsagerFactory(given_name="Joséphine")
+        self.mandat_thierry_josephine = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager_josephine,
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        cls.money_authorization = AutorisationFactory(
-            mandat=cls.mandat_thierry_josephine,
+        self.money_authorization = AutorisationFactory(
+            mandat=self.mandat_thierry_josephine,
             demarche="argent",
         )
-        cls.family_authorization = AutorisationFactory(
-            mandat=cls.mandat_thierry_josephine,
+        self.family_authorization = AutorisationFactory(
+            mandat=self.mandat_thierry_josephine,
             demarche="famille",
         )
 
-        cls.mandat_jacqueline_josephine = MandatFactory(
-            organisation=cls.aidant_jacqueline.organisation,
-            usager=cls.usager_josephine,
+        self.mandat_jacqueline_josephine = MandatFactory(
+            organisation=self.aidant_jacqueline.organisation,
+            usager=self.usager_josephine,
             expiration_date=timezone.now() + timedelta(days=12),
         )
         AutorisationFactory(
-            mandat=cls.mandat_jacqueline_josephine,
+            mandat=self.mandat_jacqueline_josephine,
             demarche="logement",
         )
-        super().setUpClass()
 
     def test_cancel_autorisation_of_active_mandat(self):
         self.open_live_url(f"/usagers/{self.usager_josephine.id}/")

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -14,23 +14,20 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 @tag("functional", "cancel_mandat")
 class CancelAutorisationTests(FunctionalTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.aidant_thierry = AidantFactory()
-        device = cls.aidant_thierry.staticdevice_set.create(id=cls.aidant_thierry.id)
+    def setUp(self):
+        self.aidant_thierry = AidantFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=self.aidant_thierry.id)
         device.token_set.create(token="123456")
 
-        cls.mandat = MandatFactory(organisation=cls.aidant_thierry.organisation)
+        self.mandat = MandatFactory(organisation=self.aidant_thierry.organisation)
         AutorisationFactory(
-            mandat=cls.mandat,
+            mandat=self.mandat,
             demarche="argent",
         )
         AutorisationFactory(
-            mandat=cls.mandat,
+            mandat=self.mandat,
             demarche="famille",
         )
-
-        super().setUpClass()
 
     def test_cancel_autorisation_of_active_mandat(self):
         self.open_live_url(f"/usagers/{self.mandat.usager.id}/")

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -11,10 +11,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 @tag("functional")
 class CancelAutorisationTests(FunctionalTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.aidant_thierry = AidantFactory()
-        device = cls.aidant_thierry.staticdevice_set.create(id=cls.aidant_thierry.id)
+    def setUp(self):
+        self.aidant_thierry = AidantFactory()
+        device = self.aidant_thierry.staticdevice_set.create(id=self.aidant_thierry.id)
         device.token_set.create(token="123456")
         super().setUpClass()
 

--- a/aidants_connect_web/tests/test_functional/test_view_autorisations.py
+++ b/aidants_connect_web/tests/test_functional/test_view_autorisations.py
@@ -15,58 +15,55 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 @tag("functional")
 class ViewAutorisationsTests(FunctionalTestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.aidant = AidantFactory()
-        device = cls.aidant.staticdevice_set.create(id=cls.aidant.id)
+    def setUp(self):
+        self.aidant = AidantFactory()
+        device = self.aidant.staticdevice_set.create(id=self.aidant.id)
         device.token_set.create(token="123456")
 
-        cls.usager_alice = UsagerFactory(given_name="Alice", family_name="Lovelace")
-        cls.usager_josephine = UsagerFactory(
+        self.usager_alice = UsagerFactory(given_name="Alice", family_name="Lovelace")
+        self.usager_josephine = UsagerFactory(
             given_name="Joséphine", family_name="Dupont"
         )
-        cls.usager_corentin = UsagerFactory(
+        self.usager_corentin = UsagerFactory(
             given_name="Corentin", family_name="Dupont", preferred_username="Astro"
         )
 
-        cls.mandat_aidant_alice_no_autorisation = MandatFactory(
-            organisation=cls.aidant.organisation,
-            usager=cls.usager_alice,
+        self.mandat_aidant_alice_no_autorisation = MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager_alice,
             expiration_date=timezone.now() + timedelta(days=5),
         )
 
-        cls.mandat_aidant_josephine_6 = MandatFactory(
-            organisation=cls.aidant.organisation,
-            usager=cls.usager_josephine,
+        self.mandat_aidant_josephine_6 = MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager_josephine,
             expiration_date=timezone.now() + timedelta(days=6),
         )
         AutorisationFactory(
-            mandat=cls.mandat_aidant_josephine_6,
+            mandat=self.mandat_aidant_josephine_6,
             demarche="social",
         )
 
-        cls.mandat_aidant_josephine_1 = MandatFactory(
-            organisation=cls.aidant.organisation,
-            usager=cls.usager_josephine,
+        self.mandat_aidant_josephine_1 = MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager_josephine,
             expiration_date=timezone.now() + timedelta(days=1),
         )
 
         AutorisationFactory(
-            mandat=cls.mandat_aidant_josephine_1,
+            mandat=self.mandat_aidant_josephine_1,
             demarche="papiers",
         )
 
-        cls.mandat_aidant_corentin_365 = MandatFactory(
-            organisation=cls.aidant.organisation,
-            usager=cls.usager_corentin,
+        self.mandat_aidant_corentin_365 = MandatFactory(
+            organisation=self.aidant.organisation,
+            usager=self.usager_corentin,
             expiration_date=timezone.now() + timedelta(days=365),
         )
         AutorisationFactory(
-            mandat=cls.mandat_aidant_corentin_365,
+            mandat=self.mandat_aidant_corentin_365,
             demarche="famille",
         )
-
-        super().setUpClass()
 
     def test_grouped_autorisations(self):
         self.open_live_url("/espace-aidant/")

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -155,37 +155,38 @@ class UsagerModelTests(TestCase):
 
 @tag("models")
 class MandatModelTests(TestCase):
-    def setUp(self):
-        self.organisation_1 = OrganisationFactory()
-        self.aidant_1 = AidantFactory(username="aidants1@organisation1.com")
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation_1 = OrganisationFactory()
+        cls.aidant_1 = AidantFactory(username="aidants1@organisation1.com")
 
-        self.usager_1 = UsagerFactory()
-        self.mandat_1 = Mandat.objects.create(
-            organisation=self.organisation_1,
-            usager=self.usager_1,
+        cls.usager_1 = UsagerFactory()
+        cls.mandat_1 = Mandat.objects.create(
+            organisation=cls.organisation_1,
+            usager=cls.usager_1,
             creation_date=timezone.now(),
             duree_keyword="SHORT",
             expiration_date=timezone.now() + timedelta(days=1),
         )
         AutorisationFactory(
-            mandat=self.mandat_1,
+            mandat=cls.mandat_1,
             demarche="justice",
         )
 
-        self.usager_2 = UsagerFactory(sub="anothersub")
-        self.mandat_2 = Mandat.objects.create(
-            organisation=self.organisation_1,
-            usager=self.usager_2,
+        cls.usager_2 = UsagerFactory(sub="anothersub")
+        cls.mandat_2 = Mandat.objects.create(
+            organisation=cls.organisation_1,
+            usager=cls.usager_2,
             creation_date=timezone.now(),
             duree_keyword="SHORT",
             expiration_date=timezone.now() + timedelta(days=1),
         )
         AutorisationFactory(
-            mandat=self.mandat_2,
+            mandat=cls.mandat_2,
             demarche="argent",
         )
         AutorisationFactory(
-            mandat=self.mandat_2,
+            mandat=cls.mandat_2,
             demarche="transport",
         )
 

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -260,20 +260,21 @@ class FCCallback(TestCase):
 
 @tag("new_mandat", "FC_as_FS")
 class GetUserInfoTests(TestCase):
-    def setUp(self):
-        self.usager_sub_fc = "123"
-        self.usager_sub = generate_sha256_hash(
-            f"{self.usager_sub_fc}{settings.FC_AS_FI_HASH_SALT}".encode()
+    @classmethod
+    def setUpTestData(cls):
+        cls.usager_sub_fc = "123"
+        cls.usager_sub = generate_sha256_hash(
+            f"{cls.usager_sub_fc}{settings.FC_AS_FI_HASH_SALT}".encode()
         )
-        self.usager = UsagerFactory(given_name="Joséphine", sub=self.usager_sub)
-        self.aidant = AidantFactory()
-        self.connection = Connection.objects.create(
+        cls.usager = UsagerFactory(given_name="Joséphine", sub=cls.usager_sub)
+        cls.aidant = AidantFactory()
+        cls.connection = Connection.objects.create(
             access_token="mock_access_token",
-            aidant=self.aidant,
+            aidant=cls.aidant,
         )
-        self.connection_with_phone = Connection.objects.create(
+        cls.connection_with_phone = Connection.objects.create(
             access_token="mock_access_token_with_phone",
-            aidant=self.aidant,
+            aidant=cls.aidant,
             user_phone="0 800 840 800",
         )
 

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -128,40 +128,41 @@ class VisibilityAdminPageTests(TestCase):
     only_by_atac_models = [Mandat, Usager, Connection, Journal]
     amac_models = [Organisation, Aidant, StaticDevice, TOTPDevice]
 
-    def setUp(self):
-        self.amac_user = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.amac_user = AidantFactory(
             username="amac@email.com",
             email="amac@email.com",
             is_staff=True,
             is_superuser=False,
         )
-        self.amac_user.set_password("password")
-        self.amac_user.save()
-        amac_device = StaticDevice.objects.create(user=self.amac_user, name="Device")
+        cls.amac_user.set_password("password")
+        cls.amac_user.save()
+        amac_device = StaticDevice.objects.create(user=cls.amac_user, name="Device")
 
-        self.amac_client = Client()
-        self.amac_client.force_login(self.amac_user)
+        cls.amac_client = Client()
+        cls.amac_client.force_login(cls.amac_user)
         # we need do this :
         # https://docs.djangoproject.com/en/3.1/topics/testing/tools/#django.test.Client.session
-        amac_session = self.amac_client.session
+        amac_session = cls.amac_client.session
         amac_session[DEVICE_ID_SESSION_KEY] = amac_device.persistent_id
         amac_session.save()
 
-        self.atac_user = AidantFactory(
+        cls.atac_user = AidantFactory(
             username="atac@email.com",
             email="atac@email.com",
             is_staff=True,
             is_superuser=True,
         )
-        self.atac_user.set_password("password")
-        self.atac_user.save()
-        atac_device = StaticDevice.objects.create(user=self.atac_user, name="Device")
+        cls.atac_user.set_password("password")
+        cls.atac_user.save()
+        atac_device = StaticDevice.objects.create(user=cls.atac_user, name="Device")
 
-        self.atac_client = Client()
-        self.atac_client.force_login(self.atac_user)
+        cls.atac_client = Client()
+        cls.atac_client.force_login(cls.atac_user)
         # we need do this :
         # https://docs.djangoproject.com/en/3.1/topics/testing/tools/#django.test.Client.session
-        atac_session = self.atac_client.session
+        atac_session = cls.atac_client.session
         atac_session[DEVICE_ID_SESSION_KEY] = atac_device.persistent_id
         atac_session.save()
 
@@ -196,64 +197,62 @@ class VisibilityAdminPageTests(TestCase):
 
 @tag("admin")
 class JournalAdminPageTests(TestCase):
-    def setUp(self):
-        self.atac_user = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.atac_user = AidantFactory(
             username="atac@email.com",
             email="atac@email.com",
             is_staff=True,
             is_superuser=True,
         )
-        self.atac_user.set_password("password")
-        self.atac_user.save()
-        self.atac_device = StaticDevice.objects.create(
-            user=self.atac_user, name="Device"
-        )
+        cls.atac_user.set_password("password")
+        cls.atac_user.save()
+        cls.atac_device = StaticDevice.objects.create(user=cls.atac_user, name="Device")
 
-        self.atac_client = Client()
-        self.atac_client.force_login(self.atac_user)
-        atac_session = self.atac_client.session
-        atac_session[DEVICE_ID_SESSION_KEY] = self.atac_device.persistent_id
+        cls.atac_client = Client()
+        cls.atac_client.force_login(cls.atac_user)
+        atac_session = cls.atac_client.session
+        atac_session[DEVICE_ID_SESSION_KEY] = cls.atac_device.persistent_id
         atac_session.save()
         url_root = f"admin:{Journal._meta.app_label}_{Journal.__name__.lower()}"
-        self.url_root = url_root
+        cls.url_root = url_root
 
-    def test_cant_delete_journal_by_admin_views(self):
-        self.assertEqual(Journal.objects.count(), 1)
+    def test_cant_delete_journal_by_admin_views(cls):
+        cls.assertEqual(Journal.objects.count(), 1)
         journal = Journal.objects.all()[0]
-        url = reverse(self.url_root + "_delete", args=(journal.pk,))
-        response = self.atac_client.get(url)
-        self.assertEqual(response.status_code, 403)
+        url = reverse(cls.url_root + "_delete", args=(journal.pk,))
+        response = cls.atac_client.get(url)
+        cls.assertEqual(response.status_code, 403)
 
-    def test_cant_add_journal_by_admin_views(self):
-        url = reverse(self.url_root + "_add")
-        response = self.atac_client.get(url)
-        self.assertEqual(response.status_code, 403)
+    def test_cant_add_journal_by_admin_views(cls):
+        url = reverse(cls.url_root + "_add")
+        response = cls.atac_client.get(url)
+        cls.assertEqual(response.status_code, 403)
 
 
 @tag("admin")
 class UsagerAdminPageTests(TestCase):
-    def setUp(self):
-        self.atac_user = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.atac_user = AidantFactory(
             username="atac@email.com",
             email="atac@email.com",
             is_staff=True,
             is_superuser=True,
         )
-        self.atac_user.set_password("password")
-        self.atac_user.save()
-        self.atac_device = StaticDevice.objects.create(
-            user=self.atac_user, name="Device"
-        )
+        cls.atac_user.set_password("password")
+        cls.atac_user.save()
+        cls.atac_device = StaticDevice.objects.create(user=cls.atac_user, name="Device")
 
-        self.usager = UsagerFactory()
+        cls.usager = UsagerFactory()
 
-        self.atac_client = Client()
-        self.atac_client.force_login(self.atac_user)
-        atac_session = self.atac_client.session
-        atac_session[DEVICE_ID_SESSION_KEY] = self.atac_device.persistent_id
+        cls.atac_client = Client()
+        cls.atac_client.force_login(cls.atac_user)
+        atac_session = cls.atac_client.session
+        atac_session[DEVICE_ID_SESSION_KEY] = cls.atac_device.persistent_id
         atac_session.save()
         url_root = f"admin:{Journal._meta.app_label}_{Usager.__name__.lower()}"
-        self.url_root = url_root
+        cls.url_root = url_root
 
     def test_can_change_usager_by_admin_views(self):
         url = reverse(self.url_root + "_change", args=(self.usager.pk,))

--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -8,14 +8,15 @@ from django.urls import resolve
 
 @tag("datapass")
 class Datapass(TestCase):
-    def setUp(self):
-        self.good_data_from_datapass = {
+    @classmethod
+    def setUpTestData(cls):
+        cls.good_data_from_datapass = {
             "data_pass_id": 34,
             "organization_name": "La maison de l'aide",
             "organization_siret": 11111111111111,
             "organization_address": "4 rue du clos, 90210, La Colline de Bev",
         }
-        self.datapass_key = settings.DATAPASS_KEY
+        cls.datapass_key = settings.DATAPASS_KEY
 
     def datapass_request(self, data):
         return self.client.post(

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -14,9 +14,10 @@ from aidants_connect_web.views import espace_aidant, usagers
 
 @tag("usagers")
 class EspaceAidantHomePageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant = AidantFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory()
 
     def test_anonymous_user_cannot_access_espace_aidant_view(self):
         response = self.client.get("/espace-aidant/")
@@ -34,9 +35,10 @@ class EspaceAidantHomePageTests(TestCase):
 
 @tag("usagers")
 class UsagersIndexPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant = AidantFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory()
 
     def test_usagers_index_url_triggers_the_usagers_index_view(self):
         found = resolve("/usagers/")
@@ -50,14 +52,15 @@ class UsagersIndexPageTests(TestCase):
 
 @tag("usagers")
 class UsagersDetailsPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant = AidantFactory()
-        self.usager = UsagerFactory()
-        self.mandat = MandatFactory(
-            organisation=self.aidant.organisation, usager=self.usager
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory()
+        cls.usager = UsagerFactory()
+        cls.mandat = MandatFactory(
+            organisation=cls.aidant.organisation, usager=cls.usager
         )
-        AutorisationFactory(mandat=self.mandat)
+        AutorisationFactory(mandat=cls.mandat)
 
     def test_usager_details_url_triggers_the_usager_details_view(self):
         found = resolve(f"/usagers/{self.usager.id}/")

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
@@ -22,56 +22,57 @@ from aidants_connect_web.views import usagers
 
 @tag("usagers", "cancel")
 class AutorisationCancellationConfirmPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
 
-        self.our_organisation = OrganisationFactory()
-        self.our_aidant = AidantFactory(organisation=self.our_organisation)
-        self.our_usager = UsagerFactory()
+        cls.our_organisation = OrganisationFactory()
+        cls.our_aidant = AidantFactory(organisation=cls.our_organisation)
+        cls.our_usager = UsagerFactory()
 
         valid_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
         )
-        self.valid_autorisation = AutorisationFactory(
+        cls.valid_autorisation = AutorisationFactory(
             mandat=valid_mandat, demarche="Revenus"
         )
-        self.revoked_autorisation = AutorisationFactory(
+        cls.revoked_autorisation = AutorisationFactory(
             mandat=valid_mandat, demarche="Papiers", revocation_date=timezone.now()
         )
 
         expired_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
             expiration_date=timezone.now() - timedelta(days=6),
         )
-        self.expired_autorisation = AutorisationFactory(
+        cls.expired_autorisation = AutorisationFactory(
             mandat=expired_mandat, demarche="Logement"
         )
 
-        self.other_organisation = OrganisationFactory(name="Other Organisation")
-        self.unrelated_usager = UsagerFactory()
+        cls.other_organisation = OrganisationFactory(name="Other Organisation")
+        cls.unrelated_usager = UsagerFactory()
 
         unrelated_mandat = MandatFactory(
-            organisation=self.other_organisation,
-            usager=self.unrelated_usager,
+            organisation=cls.other_organisation,
+            usager=cls.unrelated_usager,
         )
-        self.unrelated_autorisation = AutorisationFactory(
+        cls.unrelated_autorisation = AutorisationFactory(
             mandat=unrelated_mandat, demarche="Revenus"
         )
 
         mandat_other_org_with_our_usager = MandatFactory(
-            organisation=self.other_organisation,
-            usager=self.our_usager,
+            organisation=cls.other_organisation,
+            usager=cls.our_usager,
         )
 
-        self.autorisation_other_org_with_our_usager = AutorisationFactory(
+        cls.autorisation_other_org_with_our_usager = AutorisationFactory(
             mandat=mandat_other_org_with_our_usager, demarche="Logement"
         )
 
-        self.good_combo = {
-            "usager": self.our_usager.id,
-            "autorisation": self.valid_autorisation.id,
+        cls.good_combo = {
+            "usager": cls.our_usager.id,
+            "autorisation": cls.valid_autorisation.id,
         }
 
     def url_for_autorisation_cancellation_confimation(self, data):
@@ -189,19 +190,20 @@ class AutorisationCancellationConfirmPageTests(TestCase):
 
 @tag("usagers", "cancel", "cancel_mandat")
 class MandatCancellationConfirmPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
 
-        self.our_organisation = OrganisationFactory()
-        self.our_aidant = AidantFactory(organisation=self.our_organisation)
-        self.our_usager = UsagerFactory()
+        cls.our_organisation = OrganisationFactory()
+        cls.our_aidant = AidantFactory(organisation=cls.our_organisation)
+        cls.our_usager = UsagerFactory()
 
-        self.valid_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+        cls.valid_mandat = MandatFactory(
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
         )
-        self.valid_autorisation = AutorisationFactory(
-            mandat=self.valid_mandat, demarche=[*settings.DEMARCHES][0]
+        cls.valid_autorisation = AutorisationFactory(
+            mandat=cls.valid_mandat, demarche=[*settings.DEMARCHES][0]
         )
 
     def test_url_triggers_the_correct_view(self):
@@ -280,53 +282,54 @@ class MandatCancellationConfirmPageTests(TestCase):
 
 @tag("usagers", "cancel", "cancel_mandat", "attestation")
 class MandatCancellationAttestationTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
 
-        self.our_organisation = OrganisationFactory()
-        self.our_aidant = AidantFactory(organisation=self.our_organisation)
-        self.our_usager = UsagerFactory()
+        cls.our_organisation = OrganisationFactory()
+        cls.our_aidant = AidantFactory(organisation=cls.our_organisation)
+        cls.our_usager = UsagerFactory()
 
-        self.valid_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+        cls.valid_mandat = MandatFactory(
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
             creation_date=datetime.datetime(
                 2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
             ),
         )
-        self.valid_autorisation = AutorisationFactory(
-            mandat=self.valid_mandat, demarche="Revenus"
+        cls.valid_autorisation = AutorisationFactory(
+            mandat=cls.valid_mandat, demarche="Revenus"
         )
 
-        self.cancelled_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+        cls.cancelled_mandat = MandatFactory(
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
             creation_date=datetime.datetime(
                 2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
             ),
         )
         AutorisationFactory(
-            mandat=self.cancelled_mandat,
+            mandat=cls.cancelled_mandat,
             demarche="Revenus",
             revocation_date=timezone.now() - timedelta(minutes=5),
         )
 
-        self.expired_mandat = MandatFactory(
-            organisation=self.our_organisation,
-            usager=self.our_usager,
+        cls.expired_mandat = MandatFactory(
+            organisation=cls.our_organisation,
+            usager=cls.our_usager,
             creation_date=datetime.datetime(
                 2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
             ),
             expiration_date=timezone.now() - timedelta(minutes=5),
         )
         AutorisationFactory(
-            mandat=self.expired_mandat,
+            mandat=cls.expired_mandat,
             demarche="Revenus",
             revocation_date=timezone.now() - timedelta(minutes=5),
         )
 
         AutorisationFactory(
-            mandat=self.expired_mandat,
+            mandat=cls.expired_mandat,
             demarche="Papiers",
         )
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
@@ -14,28 +14,29 @@ from aidants_connect_web.views import espace_responsable
 
 @tag("responsable-structure")
 class AssociateCarteTOTPTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
         # Create one responsable
-        self.responsable_tom = AidantFactory(username="tom@tom.fr")
-        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
         # Create one aidant
-        self.aidant_tim = AidantFactory(
+        cls.aidant_tim = AidantFactory(
             username="tim@tim.fr",
-            organisation=self.responsable_tom.organisation,
+            organisation=cls.responsable_tom.organisation,
             first_name="Tim",
             last_name="Onier",
         )
         # Create one carte TOTP
-        self.carte = CarteTOTPFactory(serial_number="A123", seed="zzzz")
-        self.org_id = self.responsable_tom.organisation.id
-        self.association_url = (
-            f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/lier-carte"
+        cls.carte = CarteTOTPFactory(serial_number="A123", seed="zzzz")
+        cls.org_id = cls.responsable_tom.organisation.id
+        cls.association_url = (
+            f"/espace-responsable/organisation/{cls.org_id}/"
+            f"aidant/{cls.aidant_tim.id}/lier-carte"
         )
-        self.validation_url = (
-            f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/valider-carte"
+        cls.validation_url = (
+            f"/espace-responsable/organisation/{cls.org_id}/"
+            f"aidant/{cls.aidant_tim.id}/valider-carte"
         )
 
     def test_association_page_triggers_the_right_view(self):

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -13,18 +13,19 @@ from aidants_connect_web.views import espace_responsable
 
 @tag("responsable-structure")
 class EspaceResponsableHomePageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
         # Tom is responsable of 2 structures
-        self.responsable_tom = AidantFactory(username="tom@baie.fr")
-        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
-        self.responsable_tom.responsable_de.add(OrganisationFactory())
-        self.responsable_tom.can_create_mandats = False
+        cls.responsable_tom = AidantFactory(username="tom@baie.fr")
+        cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
+        cls.responsable_tom.responsable_de.add(OrganisationFactory())
+        cls.responsable_tom.can_create_mandats = False
         # Tim is responsable of only one structure
-        self.responsable_tim = AidantFactory(username="tim@oree.fr")
-        self.responsable_tim.responsable_de.add(self.responsable_tim.organisation)
+        cls.responsable_tim = AidantFactory(username="tim@oree.fr")
+        cls.responsable_tim.responsable_de.add(cls.responsable_tim.organisation)
         # John is a simple aidant
-        self.aidant_john = AidantFactory(username="john@doe.du")
+        cls.aidant_john = AidantFactory(username="john@doe.du")
 
     def test_anonymous_user_cannot_access_espace_aidant_view(self):
         response = self.client.get("/espace-responsable/")
@@ -88,12 +89,13 @@ class EspaceResponsableHomePageTests(TestCase):
 
 @tag("responsable-structure")
 class EspaceResponsableOrganisationPage(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.responsable_tom = AidantFactory(username="georges@plop.net")
-        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
-        self.id_organisation = self.responsable_tom.organisation.id
-        self.autre_organisation = OrganisationFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.responsable_tom = AidantFactory(username="georges@plop.net")
+        cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
+        cls.id_organisation = cls.responsable_tom.organisation.id
+        cls.autre_organisation = OrganisationFactory()
 
     def test_espace_responsable_organisation_url_triggers_the_right_view(self):
         self.client.force_login(self.responsable_tom)
@@ -125,20 +127,21 @@ class EspaceResponsableOrganisationPage(TestCase):
 
 @tag("responsable-structure")
 class EspaceResponsableAidantPage(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.responsable_tom = AidantFactory(username="tom@tom.fr")
-        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
-        self.aidant_tim = AidantFactory(
-            username="tim@tim.fr", organisation=self.responsable_tom.organisation
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
+        cls.aidant_tim = AidantFactory(
+            username="tim@tim.fr", organisation=cls.responsable_tom.organisation
         )
-        self.id_organisation = self.responsable_tom.organisation.id
-        self.aidant_tim_url = (
-            f"/espace-responsable/organisation/{self.id_organisation}"
-            f"/aidant/{self.aidant_tim.id}/"
+        cls.id_organisation = cls.responsable_tom.organisation.id
+        cls.aidant_tim_url = (
+            f"/espace-responsable/organisation/{cls.id_organisation}"
+            f"/aidant/{cls.aidant_tim.id}/"
         )
-        self.autre_organisation = OrganisationFactory()
-        self.autre_aidant = AidantFactory(username="random@random.net")
+        cls.autre_organisation = OrganisationFactory()
+        cls.autre_aidant = AidantFactory(username="random@random.net")
 
     def test_espace_responsable_aidant_url_triggers_the_right_view(self):
         self.client.force_login(self.responsable_tom)
@@ -173,40 +176,41 @@ class EspaceResponsableAidantPage(TestCase):
 
 @tag("responsable-structure")
 class InsistOnTOTPDeviceActivationTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
         orga = OrganisationFactory()
         # Mario is a responsable without TOTP Device activated
         # => He should see the messages
-        self.responsable_mario = AidantFactory(
+        cls.responsable_mario = AidantFactory(
             username="mario@brosse.fr", organisation=orga
         )
-        self.responsable_mario.responsable_de.add(self.responsable_mario.organisation)
-        self.responsable_mario.responsable_de.add(OrganisationFactory())
+        cls.responsable_mario.responsable_de.add(cls.responsable_mario.organisation)
+        cls.responsable_mario.responsable_de.add(OrganisationFactory())
         # Mickey is a responsable with a TOTP Device activated
         # => He should not see the messages
-        self.responsable_mickey = AidantFactory(
+        cls.responsable_mickey = AidantFactory(
             username="mickey@mousse.fr", organisation=orga
         )
-        self.responsable_mickey.responsable_de.add(self.responsable_mickey.organisation)
-        self.responsable_mickey.responsable_de.add(OrganisationFactory())
-        device = TOTPDevice(user=self.responsable_mickey)
+        cls.responsable_mickey.responsable_de.add(cls.responsable_mickey.organisation)
+        cls.responsable_mickey.responsable_de.add(OrganisationFactory())
+        device = TOTPDevice(user=cls.responsable_mickey)
         device.save()
         # Roger is a responsable with an *inactive* TOTP Device
         # (e.g. after an unfinished card activation)
         # => He should see the messages
-        self.responsable_hubert = AidantFactory(
+        cls.responsable_hubert = AidantFactory(
             username="hubert@lingot.fr", organisation=orga
         )
-        self.responsable_hubert.responsable_de.add(self.responsable_hubert.organisation)
-        self.responsable_hubert.responsable_de.add(OrganisationFactory())
-        device = TOTPDevice(user=self.responsable_hubert, confirmed=False)
+        cls.responsable_hubert.responsable_de.add(cls.responsable_hubert.organisation)
+        cls.responsable_hubert.responsable_de.add(OrganisationFactory())
+        device = TOTPDevice(user=cls.responsable_hubert, confirmed=False)
         device.save()
         # Guy has no TOTP Device but is a simple Aidant
         # => He should not see the messages.
-        self.aidant_guy = AidantFactory(username="guy@mauve.fr")
+        cls.aidant_guy = AidantFactory(username="guy@mauve.fr")
 
-        self.urls_responsables = (
+        cls.urls_responsables = (
             "/espace-aidant/",
             "/espace-responsable/",
             f"/espace-responsable/organisation/{orga.id}/",

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
@@ -15,32 +15,33 @@ from aidants_connect_web.views import espace_responsable
 
 @tag("responsable-structure")
 class ValidateCarteTOTPTests(TestCase):
-    def setUp(self):
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
         # Create one responsable
-        self.responsable_tom = AidantFactory(username="tom@tom.fr")
-        self.responsable_tom.responsable_de.add(self.responsable_tom.organisation)
+        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
         # Create one aidant
-        self.aidant_tim = AidantFactory(
+        cls.aidant_tim = AidantFactory(
             username="tim@tim.fr",
-            organisation=self.responsable_tom.organisation,
+            organisation=cls.responsable_tom.organisation,
             first_name="Tim",
             last_name="Onier",
         )
         # Create one carte TOTP
-        self.carte = CarteTOTPFactory(
-            serial_number="A123", seed="FA169F10A9", aidant=self.aidant_tim
+        cls.carte = CarteTOTPFactory(
+            serial_number="A123", seed="FA169F10A9", aidant=cls.aidant_tim
         )
-        self.org_id = self.responsable_tom.organisation.id
+        cls.org_id = cls.responsable_tom.organisation.id
         # Create one TOTP Device
-        self.device = TOTPDevice(
-            tolerance=30, key=self.carte.seed, user=self.aidant_tim, step=60
+        cls.device = TOTPDevice(
+            tolerance=30, key=cls.carte.seed, user=cls.aidant_tim, step=60
         )
-        self.device.save()
-        self.organisation_url = f"/espace-responsable/organisation/{self.org_id}/"
-        self.validation_url = (
-            f"/espace-responsable/organisation/{self.org_id}/"
-            f"aidant/{self.aidant_tim.id}/valider-carte"
+        cls.device.save()
+        cls.organisation_url = f"/espace-responsable/organisation/{cls.org_id}/"
+        cls.validation_url = (
+            f"/espace-responsable/organisation/{cls.org_id}/"
+            f"aidant/{cls.aidant_tim.id}/valider-carte"
         )
 
     def test_validation_page_triggers_the_right_view(self):

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -29,17 +29,18 @@ from aidants_connect_web.views import id_provider
 
 @tag("id_provider")
 class AuthorizeTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant_thierry = AidantFactory()
-        self.aidant_jacques = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant_thierry = AidantFactory()
+        cls.aidant_jacques = AidantFactory(
             username="jacques@domain.user", email="jacques@domain.user"
         )
-        self.usager = UsagerFactory(given_name="Joséphine", sub="123")
+        cls.usager = UsagerFactory(given_name="Joséphine", sub="123")
 
         mandat_1 = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=timezone.now() + timedelta(days=6),
         )
 
@@ -50,8 +51,8 @@ class AuthorizeTests(TestCase):
         )
 
         mandat_2 = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=timezone.now() + timedelta(days=12),
         )
 
@@ -65,8 +66,8 @@ class AuthorizeTests(TestCase):
         )
 
         mandat_3 = MandatFactory(
-            organisation=self.aidant_jacques.organisation,
-            usager=self.usager,
+            organisation=cls.aidant_jacques.organisation,
+            usager=cls.usager,
             expiration_date=timezone.now() + timedelta(days=12),
         )
         AutorisationFactory(
@@ -76,10 +77,10 @@ class AuthorizeTests(TestCase):
         date_further_away_minus_one_hour = datetime(
             2019, 1, 9, 8, tzinfo=pytz_timezone("Europe/Paris")
         )
-        self.connection = Connection.objects.create(
+        cls.connection = Connection.objects.create(
             state="test_expiration_date_triggered",
             nonce="avalidnonce456",
-            usager=self.usager,
+            usager=cls.usager,
             expires_on=date_further_away_minus_one_hour,
         )
 
@@ -246,55 +247,56 @@ class AuthorizeTests(TestCase):
 
 @tag("id_provider")
 class FISelectDemarcheTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant_thierry = AidantFactory()
-        self.aidant_yasmina = AidantFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant_thierry = AidantFactory()
+        cls.aidant_yasmina = AidantFactory(
             username="yasmina@yasmina.com",
-            organisation=self.aidant_thierry.organisation,
+            organisation=cls.aidant_thierry.organisation,
         )
-        self.usager = UsagerFactory(given_name="Joséphine")
-        self.connection = Connection.objects.create(
+        cls.usager = UsagerFactory(given_name="Joséphine")
+        cls.connection = Connection.objects.create(
             state="avalidstate123",
             nonce="avalidnonce456",
-            usager=self.usager,
+            usager=cls.usager,
         )
         date_further_away_minus_one_hour = datetime(
             2019, 1, 9, 8, tzinfo=pytz_timezone("Europe/Paris")
         )
-        self.connection_2 = Connection.objects.create(
+        cls.connection_2 = Connection.objects.create(
             state="test_expiration_date_triggered",
             nonce="test_nonce",
-            usager=self.usager,
+            usager=cls.usager,
             expires_on=date_further_away_minus_one_hour,
         )
         mandat_creation_date = datetime(
             2019, 1, 5, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
         )
 
-        self.mandat_thierry_usager_1 = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+        cls.mandat_thierry_usager_1 = MandatFactory(
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=mandat_creation_date + timedelta(days=6),
             creation_date=mandat_creation_date,
         )
         AutorisationFactory(
-            mandat=self.mandat_thierry_usager_1,
+            mandat=cls.mandat_thierry_usager_1,
             demarche="transports",
         )
         AutorisationFactory(
-            mandat=self.mandat_thierry_usager_1,
+            mandat=cls.mandat_thierry_usager_1,
             demarche="famille",
         )
 
-        self.mandat_thierry_usager_2 = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+        cls.mandat_thierry_usager_2 = MandatFactory(
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=mandat_creation_date + timedelta(days=3),
             creation_date=mandat_creation_date,
         )
         AutorisationFactory(
-            mandat=self.mandat_thierry_usager_2,
+            mandat=cls.mandat_thierry_usager_2,
             demarche="logement",
         )
 
@@ -404,27 +406,28 @@ class FISelectDemarcheTests(TestCase):
 )
 @override_settings(FC_CONNECTION_AGE=300)
 class TokenTests(TestCase):
-    def setUp(self):
-        self.code = "test_code"
-        self.code_hash = make_password(self.code, settings.FC_AS_FI_HASH_SALT)
-        self.usager = UsagerFactory(given_name="Joséphine")
-        self.usager.sub = "avalidsub789"
-        self.usager.save()
-        self.connection = Connection()
-        self.connection.state = "avalidstate123"
-        self.connection.code = self.code_hash
-        self.connection.nonce = "avalidnonce456"
-        self.connection.usager = self.usager
-        self.connection.expires_on = datetime(
+    @classmethod
+    def setUpTestData(cls):
+        cls.code = "test_code"
+        cls.code_hash = make_password(cls.code, settings.FC_AS_FI_HASH_SALT)
+        cls.usager = UsagerFactory(given_name="Joséphine")
+        cls.usager.sub = "avalidsub789"
+        cls.usager.save()
+        cls.connection = Connection()
+        cls.connection.state = "avalidstate123"
+        cls.connection.code = cls.code_hash
+        cls.connection.nonce = "avalidnonce456"
+        cls.connection.usager = cls.usager
+        cls.connection.expires_on = datetime(
             2012, 1, 14, 3, 21, 34, tzinfo=pytz_timezone("Europe/Paris")
         )
-        self.connection.save()
-        self.fc_request = {
+        cls.connection.save()
+        cls.fc_request = {
             "grant_type": "authorization_code",
             "redirect_uri": "test_url.test_url",
             "client_id": "test_client_id",
             "client_secret": "test_client_secret",
-            "code": self.code,
+            "code": cls.code,
         }
 
     def test_token_url_triggers_token_view(self):
@@ -511,9 +514,10 @@ class TokenTests(TestCase):
     FC_AS_FI_HASH_SALT="123456"
 )
 class UserInfoTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.usager = UsagerFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.usager = UsagerFactory(
             given_name="Joséphine",
             family_name="ST-PIERRE",
             preferred_username="ST-PIERRE",
@@ -526,32 +530,32 @@ class UserInfoTests(TestCase):
             creation_date="2019-08-05T15:49:13.972Z",
             phone="0 800 840 800",
         )
-        self.aidant_thierry = AidantFactory()
-        self.mandat_thierry_usager = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+        cls.aidant_thierry = AidantFactory()
+        cls.mandat_thierry_usager = MandatFactory(
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        self.autorisation = AutorisationFactory(
-            mandat=self.mandat_thierry_usager,
+        cls.autorisation = AutorisationFactory(
+            mandat=cls.mandat_thierry_usager,
             demarche="transports",
         )
 
-        self.access_token = "test_access_token"
-        self.access_token_hash = make_password(
-            self.access_token, settings.FC_AS_FI_HASH_SALT
+        cls.access_token = "test_access_token"
+        cls.access_token_hash = make_password(
+            cls.access_token, settings.FC_AS_FI_HASH_SALT
         )
-        self.connection = Connection.objects.create(
+        cls.connection = Connection.objects.create(
             state="avalidstate123",
             code="test_code",
             nonce="avalidnonde456",
-            usager=self.usager,
-            access_token=self.access_token_hash,
+            usager=cls.usager,
+            access_token=cls.access_token_hash,
             expires_on=datetime(
                 2012, 1, 14, 3, 21, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
             ),
-            aidant=self.aidant_thierry,
-            autorisation=self.autorisation,
+            aidant=cls.aidant_thierry,
+            autorisation=cls.autorisation,
         )
 
     def test_token_url_triggers_token_view(self):
@@ -626,9 +630,10 @@ class UserInfoTests(TestCase):
 
 @tag("id_provider")
 class EndSessionEndpointTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.usager = UsagerFactory(
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.usager = UsagerFactory(
             given_name="Joséphine",
             family_name="ST-PIERRE",
             preferred_username="ST-PIERRE",
@@ -640,32 +645,32 @@ class EndSessionEndpointTests(TestCase):
             email="User@user.domain",
             creation_date="2019-08-05T15:49:13.972Z",
         )
-        self.aidant_thierry = AidantFactory()
-        self.mandat_thierry_usager = MandatFactory(
-            organisation=self.aidant_thierry.organisation,
-            usager=self.usager,
+        cls.aidant_thierry = AidantFactory()
+        cls.mandat_thierry_usager = MandatFactory(
+            organisation=cls.aidant_thierry.organisation,
+            usager=cls.usager,
             expiration_date=timezone.now() + timedelta(days=6),
         )
-        self.autorisation = AutorisationFactory(
-            mandat=self.mandat_thierry_usager,
+        cls.autorisation = AutorisationFactory(
+            mandat=cls.mandat_thierry_usager,
             demarche="transports",
         )
 
-        self.access_token = "test_access_token"
-        self.access_token_hash = make_password(
-            self.access_token, settings.FC_AS_FI_HASH_SALT
+        cls.access_token = "test_access_token"
+        cls.access_token_hash = make_password(
+            cls.access_token, settings.FC_AS_FI_HASH_SALT
         )
-        self.connection = Connection.objects.create(
+        cls.connection = Connection.objects.create(
             state="avalidstate123",
             code="test_code",
             nonce="avalidnonde456",
-            usager=self.usager,
-            access_token=self.access_token_hash,
+            usager=cls.usager,
+            access_token=cls.access_token_hash,
             expires_on=datetime(
                 2012, 1, 14, 3, 21, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
             ),
-            aidant=self.aidant_thierry,
-            autorisation=self.autorisation,
+            aidant=cls.aidant_thierry,
+            autorisation=cls.autorisation,
         )
 
     def test_end_session_endpoint_url_triggers_end_session_endpoint_view(self):

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -28,10 +28,11 @@ fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 @tag("new_mandat")
 @override_settings(PHONENUMBER_DEFAULT_REGION="FR")
 class NewMandatTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.phone_number = "0 800 840 800"
-        self.aidant_thierry = AidantFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.phone_number = "0 800 840 800"
+        cls.aidant_thierry = AidantFactory()
 
     def test_new_mandat_url_triggers_new_mandat_view(self):
         found = resolve("/creation_mandat/")
@@ -87,33 +88,34 @@ class NewMandatTests(TestCase):
 
 @tag("new_mandat")
 class NewMandatRecapTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.organisation = OrganisationFactory()
-        self.aidant_thierry = AidantFactory(organisation=self.organisation)
-        device = self.aidant_thierry.staticdevice_set.create(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.organisation = OrganisationFactory()
+        cls.aidant_thierry = AidantFactory(organisation=cls.organisation)
+        device = cls.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="223456")
-        self.aidant_monique = AidantFactory(
+        cls.aidant_monique = AidantFactory(
             first_name="Monique",
             username="monique@monique.com",
-            organisation=self.organisation,
+            organisation=cls.organisation,
         )
-        device = self.aidant_monique.staticdevice_set.create(id=2)
+        device = cls.aidant_monique.staticdevice_set.create(id=2)
         device.token_set.create(token="323456")
-        self.organisation_nantes = OrganisationFactory(name="Association Aide'o'Web")
-        self.aidant_marge = AidantFactory(
-            first_name="Marge", username="Marge", organisation=self.organisation_nantes
+        cls.organisation_nantes = OrganisationFactory(name="Association Aide'o'Web")
+        cls.aidant_marge = AidantFactory(
+            first_name="Marge", username="Marge", organisation=cls.organisation_nantes
         )
-        device = self.aidant_marge.staticdevice_set.create(id=3)
+        device = cls.aidant_marge.staticdevice_set.create(id=3)
         device.token_set.create(token="423456")
-        self.test_usager_sub = (
+        cls.test_usager_sub = (
             "46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1"
         )
-        self.test_usager = UsagerFactory(
+        cls.test_usager = UsagerFactory(
             given_name="Fabrice",
             birthplace="95277",
-            sub=self.test_usager_sub,
+            sub=cls.test_usager_sub,
         )
 
     def test_recap_url_triggers_the_recap_view(self):
@@ -511,16 +513,17 @@ class NewMandatRecapTests(TestCase):
 
 @tag("new_mandat")
 class GenerateAttestationTests(TestCase):
-    def setUp(self):
-        self.aidant_thierry = AidantFactory()
-        self.client = Client()
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidant_thierry = AidantFactory()
+        cls.client = Client()
 
-        self.test_usager = UsagerFactory(
+        cls.test_usager = UsagerFactory(
             given_name="Fabrice",
             family_name="MERCIER",
             sub="46df505a40508b9fa620767c73dc1d7ad8c30f66fa6ae5ae963bf9cccc885e8dv1",
         )
-        self.autorisation_form = MandatForm(
+        cls.autorisation_form = MandatForm(
             data={"demarche": ["papiers", "logement"], "duree": "short"}
         )
 
@@ -531,7 +534,7 @@ class GenerateAttestationTests(TestCase):
             nonce="test_another_nonce",
             demarches=["papiers", "logement"],
             duree_keyword="SHORT",
-            usager=self.test_usager,
+            usager=cls.test_usager,
         )
 
     def test_attestation_projet_url_triggers_the_correct_view(self):

--- a/aidants_connect_web/tests/test_views/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_renew_mandat.py
@@ -16,15 +16,16 @@ from aidants_connect_web.tests.factories import (
 
 @tag("renew_mandat")
 class RenewMandatTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.organisation = OrganisationFactory()
-        self.aidant_thierry = AidantFactory(organisation=self.organisation)
-        device = self.aidant_thierry.staticdevice_set.create(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.organisation = OrganisationFactory()
+        cls.aidant_thierry = AidantFactory(organisation=cls.organisation)
+        device = cls.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="223456")
 
-        self.usager = UsagerFactory(given_name="Fabrice")
+        cls.usager = UsagerFactory(given_name="Fabrice")
 
     def test_renew_mandat_ok(self):
         MandatFactory(

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -36,9 +36,10 @@ class HomePageTests(TestCase):
 
 @tag("service")
 class LoginPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant = AidantFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory()
 
     def test_journal_records_when_aidant_logs_in(self):
         self.assertEqual(len(Journal.objects.all()), 0)
@@ -61,9 +62,10 @@ class LoginPageTests(TestCase):
 
 @tag("service")
 class LogoutPageTests(TestCase):
-    def setUp(self):
-        self.client = Client()
-        self.aidant = AidantFactory()
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory()
 
     def test_logout_url_triggers_the_logout_view(self):
         found = resolve("/logout-session/")
@@ -81,9 +83,10 @@ class LogoutPageTests(TestCase):
 
 @tag("service")
 class ActivityCheckPageTests(TestCase):
-    def setUp(self):
-        self.aidant_thierry = AidantFactory()
-        device = self.aidant_thierry.staticdevice_set.create(id=1)
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidant_thierry = AidantFactory()
+        device = cls.aidant_thierry.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
 
     def test_totp_url_triggers_totp_view(self):
@@ -139,7 +142,8 @@ class EnvironmentVariablesTests(TestCase):
 
 @tag("service")
 class StatistiquesTests(TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpTestData(cls):
         mairie_de_houlbec = OrganisationFactory()
         aidant_thierry = AidantFactory()
         usager_homer = UsagerFactory()

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -18,7 +18,7 @@ from aidants_connect_web.views.usagers import _get_usagers_dict_from_mandats
 @tag("usagers")
 class ViewAutorisationsTests(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.aidant = AidantFactory()
         device = cls.aidant.staticdevice_set.create(id=cls.aidant.id)
         device.token_set.create(token="123456")
@@ -107,8 +107,6 @@ class ViewAutorisationsTests(TestCase):
             expiration_date=timezone.now() + timedelta(days=366),
         )
 
-        super().setUpClass()
-
     def test__get_mandats_for_usagers_index(self):
         mandats = _get_mandats_for_usagers_index(self.aidant)
         self.assertEqual(
@@ -157,7 +155,7 @@ class ViewAutorisationsTests(TestCase):
 @tag("usagers")
 class ViewCancelMandatTests(TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpTestData(cls):
         cls.aidant = AidantFactory(
             username="dupont@example.com", email="dupont@example.com"
         )
@@ -177,7 +175,6 @@ class ViewCancelMandatTests(TestCase):
             mandat=cls.mandat_aidant_phillomene,
             demarche="social",
         )
-        super().setUpClass()
 
     def test_cancel_inactive_mandat(self):
         self.client.force_login(self.aidant)


### PR DESCRIPTION
## 🌮 Objectif

Améliorer les manières d'initialiser les données pour les tests d'aidants connect

## 🔍 Implémentation

- Remplacement de SetupClass par setupTestData ou setUp. SetupClass n'est lancée qu'une fois au début de l'éxécution d'une suite de test. Problème, entre chaque test, django vide la base. Si on fait donc des initialisations de base de données avec SetupClass, on ne peut avoir qu'un seul test dans une suite de test. Les initialisations ont été déplacés dans setUp qui est exécutée avant chaque test ou dans setupTestData qui est une méthode de classe fournie par la classe TestCase et qui permet de faire les initialisation de données entre deux transactions pour pouvoir revenir "juste après rapidement. Malheureusement le StaticLiveServerTestCase (dont dérive FunctionalTestCase ) ne propose pas cette méthode de classe, d'où le fait d'utiliser setUp
- Remplacement de setUp par setupTestData. Dans tout les cas (très majoritaire) où on utilise la classe TestCase, on peut déplacer les initialisations de données faites dans setUp et les mettre dans setupTestData
- Pour certains tests ( dans test_forms), il a fallu rajouter des refresh_from_db. En effet, dans les tests en question, les données membres (aidants2) étaient réaffectés avant chaque test par l'appel de setup. ce n'est plus le cas et comme certains tests modifie leur valeur, il faut rafraîchir les données en début de test en allant chercher les valeurs de la base données avec un appel à refresh_from_db


L'utilisation de setupTestData permet, sur ma machine, de faire passer la durée d'execution de la totalité des tests de 185 secondes à 170 secondes.

