### PR TITLE
Sauvegarde du nom d'usage

### DIFF
--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -302,6 +302,7 @@ class GetUserInfoTests(TestCase):
 
         self.assertEqual(usager.given_name, "Fabrice")
         self.assertEqual(usager.email, "test@test.com")
+        self.assertEqual(usager.preferred_username, "TROIS")
         self.assertIsNone(error)
 
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -363,7 +363,7 @@ class GetUserInfoTests(TestCase):
                 "given_name": self.usager.given_name,
                 "family_name": self.usager.family_name,
                 "sub": self.usager_sub_fc,
-                "preferred_username": self.usager.preferred_username,
+                "preferred_username": "TROIS",
                 "birthdate": self.usager.birthdate,
                 "gender": self.usager.gender,
                 "birthplace": self.usager.birthplace,
@@ -377,6 +377,7 @@ class GetUserInfoTests(TestCase):
 
         self.assertEqual(usager.id, self.usager.id)
         self.assertEqual(usager.given_name, "Joséphine")
+        self.assertEqual(usager.preferred_username, "TROIS")
         self.assertEqual(usager.email, "new@email.com")
         self.assertIsNone(error)
 

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -36,6 +36,7 @@ def fc_authorize(request):
         "birthplace",
         "given_name",
         "family_name",
+        "preferred_username",
         "birthcountry",
     ]
 
@@ -177,6 +178,7 @@ def get_user_info(connection: Connection) -> tuple:
             "gender": user_info.get("gender"),
             "birthplace": user_info.get("birthplace"),
             "birthcountry": user_info.get("birthcountry"),
+            "preferred_username": user_info.get("preferred_username"),
             "sub": usager_sub,
             "email": user_info.get("email"),
         }

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -158,14 +158,15 @@ def get_user_info(connection: Connection) -> tuple:
         if usager.email != user_info.get("email"):
             usager.email = user_info.get("email")
             usager.save()
-
             Journal.log_update_email_usager(aidant=connection.aidant, usager=usager)
 
         if user_phone is not None and usager.phone != user_phone:
             usager.phone = user_phone
-
             Journal.log_update_phone_usager(aidant=connection.aidant, usager=usager)
+            usager.save()
 
+        if not usager.preferred_username and user_info.get("preferred_username"):
+            usager.preferred_username = user_info.get("preferred_username")
             usager.save()
 
         return usager, None


### PR DESCRIPTION
## 🌮 Objectif

Sauvegarder le nom d'usage (par opposition au nom de naissance) souvent usité par les usagers-usagères

## 🔍 Implémentation

- Ajout du nom d'usage dans le scope des infos demandées à France Connect 
- Sauvegarde du nom lors de l'ajout d'un usager

## 🖼️ Images

France Connect nous fait bien passer l'info, reste à l'afficher à divers endroits comme ici dans la liste des mandats : 

![Usagère Jennifer Fauteuil, née Canapé](https://user-images.githubusercontent.com/1035145/124152732-122ebd00-da94-11eb-8d70-9d8b536e0626.png)

