### PR TITLE
Supprime une erreur de l'import excel si le fichier ne contient pas de colonne "carte_ac"

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -142,7 +142,7 @@ class AidantResource(resources.ModelResource):
             add_static_token(row["username"], token)
 
     def after_save_instance(self, instance: Aidant, using_transactions, dry_run):
-        if instance.carte_ac:
+        if hasattr(instance, "carte_ac"):
             card_sn = instance.carte_ac
             # instance.carte_ac is the sn the import added to the aidant instance,
             # it will not be persisted as-is in database.


### PR DESCRIPTION
## 🌮 Objectif

Permettre de pouvoir importer un fichier excel qui ne contient pas la colonne `carte_ac` car elle n'est pas obligatoire.

## 🔍 Implémentation

- Utilisation de `hasattr` pour voir si l'attribut a été ajouté à l'instance par l'import, au lieu de directement chercher la valeur de l'attribut.
