### PR TITLE
Feature flag pour le nom d'usage France Connect

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -90,6 +90,7 @@ if os.environ.get("FC_AS_FS_TEST_PORT"):
 else:
     FC_AS_FS_TEST_PORT = 0
 
+GET_PREFERRED_USERNAME_FROM_FC = getenv_bool("GET_PREFERRED_USERNAME_FROM_FC", True)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -36,9 +36,10 @@ def fc_authorize(request):
         "birthplace",
         "given_name",
         "family_name",
-        "preferred_username",
         "birthcountry",
     ]
+    if settings.GET_PREFERRED_USERNAME_FROM_FC:
+        fc_scopes.append("preferred_username")
 
     parameters = (
         f"response_type=code"


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir gérer facilement les exigences différentes de FC selon les environnements : ils sont OK avec le nom d'usage en integ et en préprod, mais la prod non.

## 🔍 Implémentation

- Une variable d'environnement booléenne qui indique si on demande le nom d'usage.


## ⚠️ Informations supplémentaires

Je vais passer `GET_PREFERRED_USERNAME_FROM_FC` à `False` en production dès maintenant en prévision du déploiement de cette feature.
