### PR TITLE
Ajout du renouvellement de mandat sur la page d'un usager

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -39,6 +39,7 @@
             </h4>
             <div class="float-right text-right">
               <a id="view_mandat_attestation" class="button" href="{% url 'mandat_visualisation' mandat_id=mandat.id %}"><span aria-hidden="true">🖨&nbsp;</span>Voir l’attestation</a>
+                <a id="renew_mandat" class="button" href="{% url 'renew_mandat' usager_id=usager.id %}"><span aria-hidden="true">🖨&nbsp;</span>Renouveler le mandat</a>
               <a id="cancel_mandat" class="button-outline warning" href="{% url 'confirm_mandat_cancelation' mandat_id=mandat.id %}">
                 Révoquer le mandat <span aria-hidden="true">&nbsp;🗑️</span>
               </a>

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.test import tag, TestCase
 from django.test.client import Client
-from django.urls import resolve
+from django.urls import resolve, reverse
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
@@ -80,6 +80,13 @@ class UsagersDetailsPageTests(TestCase):
         self.assertIn(
             "<title>Aidants Connect - Homer Simpson</title>", response_content
         )
+
+    def test_usager_details_renew_mandat(self):
+        self.client.force_login(self.aidant)
+        response = self.client.get(f"/usagers/{self.usager.id}/")
+        response_content = response.content.decode("utf-8")
+        self.assertIn("Renouveler le mandat", response_content)
+        self.assertIn(reverse("renew_mandat", args=(self.usager.pk,)), response_content)
 
 
 @tag("responsable-structure")


### PR DESCRIPTION
## 🌮 Objectif

Ajouter le bouton renouvellement de mandat sur la liste des mandats sur la page d'un usager

## 🔍 Implémentation

Ajout du bouton dans les templates

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

![image](https://user-images.githubusercontent.com/354064/125248999-05f8fa00-e2f5-11eb-8e7c-97d2612f990c.png)
