### PR TITLE
Ajouter la possibilité de mettre à jour les codes postaux à partir du fichier datapass

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -168,6 +168,12 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         "aidants_connect_web/admin/import_export/import_organisation.html"
     )
 
+    actions = ("find_zipcode_in_address",)
+
+    def find_zipcode_in_address(self, request, queryset):
+        for organisation in queryset:
+            organisation.set_empty_zipcode_from_address()
+
 
 class AidantResource(resources.ModelResource):
     organisation_id = Field(attribute="organisation_id", column_name="organisation_id")

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -69,6 +69,20 @@ class Organisation(models.Model):
 
     admin_num_mandats.short_description = "Nombre de mandats"
 
+    def set_empty_zipcode_from_address(self):
+        if self.zipcode != "0":
+            return
+        adr = self.address
+        if adr:
+            try:
+                without_city = adr.rpartition(" ")[0]
+                zipcode = without_city.rsplit(" ")[-1]
+                if zipcode.isdigit():
+                    self.zipcode = zipcode
+                    self.save()
+            except Exception:
+                pass
+
 
 class AidantManager(UserManager):
     def active(self):

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/change_list_organisation_import.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/change_list_organisation_import.html
@@ -1,0 +1,10 @@
+{% extends "admin/import_export/change_list.html" %}
+{% load i18n %}
+{% load admin_urls %}
+
+{% block object-tools-items %}
+    {% if has_import_permission %}
+        <li><a href='{% url opts|admin_urlname:"import" %}' class="import_link">{% trans "Mettre à jour avec le fichier datapass" %}</a></li>
+    {% endif %}
+  {{ block.super }}
+{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import.html
@@ -28,10 +28,12 @@
     <form action="" method="post" enctype="multipart/form-data">
       {% csrf_token %}
 
+    {% block fields_listing %}
       <p>
         {% block fields_intro %}Le fichier à importer doit contenir les en-têtes suivants&nbsp;:{% endblock %}
         <code>{{ fields|join:", " }}</code>
       </p>
+    {% endblock %}
       {% block more_help %}
       {% endblock %}
       <fieldset class="module aligned">

--- a/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/import_export/import_organisation.html
@@ -1,0 +1,12 @@
+{% extends "aidants_connect_web/admin/import_export/import.html" %}
+{% load i18n %}
+
+{% block breadcrumbs_last %}
+  {% trans "Mettre à jour le siret" %}
+{% endblock %}
+
+{% block content_title %}{% if title %}<h1>{% trans "Mettre à jour à partir du fichier datapass [Code postal uniquement]" %}</h1>{% endif %}{% endblock %}
+
+
+{% block fields_listing %}
+{% endblock %}

--- a/aidants_connect_web/tests/test_admin_resources.py
+++ b/aidants_connect_web/tests/test_admin_resources.py
@@ -1,0 +1,56 @@
+import tablib
+from django.test import tag, TestCase
+
+from aidants_connect_web.admin import OrganisationResource
+from aidants_connect_web.models import Organisation
+from aidants_connect_web.tests.factories import OrganisationFactory
+
+
+@tag("admin")
+class OrganisationResourceTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation = OrganisationFactory(siret="121212122")
+        cls.orga_data = tablib.Dataset(
+            headers=[
+                "Statut de la demande (send = à valider; pending = brouillon)",
+                "Code postal de la structure",
+                "SIRET de l’organisation",
+            ]
+        )
+
+    def test_dont_create_new_organisation(self):
+        self.assertEqual(1, Organisation.objects.all().count())
+        orga_ressource = OrganisationResource()
+        self.orga_data.append(["validated", "13013", "121212123"])
+        orga_ressource.import_data(self.orga_data, dry_run=False)
+        self.assertEqual(1, Organisation.objects.all().count())
+
+    def test_dont_raise_exception_without_status(self):
+        self.assertEqual(1, Organisation.objects.all().count())
+        orga_ressource = OrganisationResource()
+        invalid_orga_data = tablib.Dataset(
+            headers=["Code postal de la structure", "SIRET de l’organisation"]
+        )
+        invalid_orga_data.append(["13013", "121212122"])
+        orga_ressource.import_data(invalid_orga_data, dry_run=False)
+        self.assertEqual(1, Organisation.objects.all().count())
+
+    def test_update_organisation_without_zipcode(self):
+        self.assertEqual(1, Organisation.objects.all().count())
+        orga_ressource = OrganisationResource()
+        self.orga_data.append(["validated", "13013", "121212122"])
+        orga_ressource.import_data(self.orga_data, dry_run=False)
+        self.assertEqual(1, Organisation.objects.all().count())
+        self.assertEqual("13013", Organisation.objects.first().zipcode)
+
+    def test_dont_update_organisation_with_zipcode(self):
+        self.organisation.zipcode = "34034"
+        self.organisation.save()
+        self.assertEqual(1, Organisation.objects.all().count())
+
+        orga_ressource = OrganisationResource()
+        self.orga_data.append(["validated", "13013", "121212122"])
+        orga_ressource.import_data(self.orga_data, dry_run=False)
+        self.assertEqual(1, Organisation.objects.all().count())
+        self.assertEqual("34034", Organisation.objects.first().zipcode)

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -671,6 +671,32 @@ class OrganisationModelTests(TestCase):
             organisation_address.display_address, organisation_address.address
         )
 
+    def test_set_empty_zipcode_from_address(self):
+        organisation_no_address = Organisation(name="L'Internationale")
+        organisation_no_address.save()
+        self.assertEqual("0", organisation_no_address.zipcode)
+        organisation_no_address.set_empty_zipcode_from_address()
+        organisation_no_address.refresh_from_db()
+        self.assertEqual("0", organisation_no_address.zipcode)
+
+        organisation_with_address = Organisation(
+            name="L'Internationale", address=" blaa 13013 Paris"
+        )
+        organisation_with_address.save()
+        self.assertEqual("0", organisation_with_address.zipcode)
+        organisation_with_address.set_empty_zipcode_from_address()
+        organisation_with_address.refresh_from_db()
+        self.assertEqual("13013", organisation_with_address.zipcode)
+
+        organisation_with_zipcode = Organisation(
+            name="L'Internationale", zipcode="75015", address=" blaa 13013 Paris"
+        )
+        organisation_with_zipcode.save()
+        self.assertEqual("75015", organisation_with_zipcode.zipcode)
+        organisation_with_zipcode.set_empty_zipcode_from_address()
+        organisation_with_zipcode.refresh_from_db()
+        self.assertEqual("75015", organisation_with_zipcode.zipcode)
+
 
 @tag("models", "aidant")
 class AidantModelTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir mettre à jour les code postaux (mais aussi plus tard plus de choses) à partir du fichier de datapass.
EDIT : j'ai rajouté une action dans l'admin des organisations pour trouver les zipcode à partir de l'adresse, si le zipcode est vide.

## 🔍 Implémentation

Cette fonctionnalité va être utile épisodiquement. A chaque fois qu'on veut rajouter des informations à partir de Datapass et à postériori. Ici on ne s'occupe de mettre à jour que les codes postaux, mais une prochaine PR suivra pour les types d'organsations (si celle-ci est validée). 

J'ai du coup choisi d'utiliser un tordant un peu le bras les fonctionnalités d'import déjà mise en place pour les aidants. 

Une Resource d'import a donc été créé, coté admin pour les organisations, mais en surchargeant `import_row`, `after_import_instance` et `skip_row` pour réceptivement : 
- ne pas tenir compte des organisations non validées du fichier 
- vérifier si l'organisation existe ou pas déjà dans aidants connect (en utilisant le siret) 
- ne pas prendre en compte les orga n'existant pas ou existant mais ayant déjà un code postal.

En dévoyant ainsi le mécanisme d'import pour le transformer en mécanisme d'import uniquement update, cela permet de ne pas avoir à écrire tout le code d'upload de fichier, de vérification des entêtes et de lecture du fichier excel ... 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

![image](https://user-images.githubusercontent.com/354064/128268208-67d9a0e7-82bd-408c-8855-0f91e5c21a19.png)

