### PR TITLE
Faciliter le contrôle des cartes TOTP par les bizdev dans l'admin

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -264,11 +264,21 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
 
         return form
 
+    def display_totp_device_status(self, obj):
+        return obj.has_a_totp_device
+
+    display_totp_device_status.short_description = "Carte TOTP Activée"
+    display_totp_device_status.boolean = True
+
     # The forms to add and change `Aidant` instances
     form = AidantChangeForm
     add_form = AidantCreationForm
     raw_id_fields = ("responsable_de", "organisation")
-    readonly_fields = ("validated_cgu_version",)
+    readonly_fields = (
+        "validated_cgu_version",
+        "display_totp_device_status",
+        "carte_totp",
+    )
 
     # For bulk import
     resource_class = AidantResource
@@ -295,7 +305,17 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
     fieldsets = (
         (
             "Informations personnelles",
-            {"fields": ("username", "first_name", "last_name", "email", "password")},
+            {
+                "fields": (
+                    "username",
+                    "first_name",
+                    "last_name",
+                    "email",
+                    "password",
+                    "carte_totp",
+                    "display_totp_device_status",
+                )
+            },
         ),
         ("Informations professionnelles", {"fields": ("profession", "organisation")}),
         (

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -281,7 +281,9 @@ class AidantAdmin(ImportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         "__str__",
         "email",
         "organisation",
+        "carte_totp",
         "is_active",
+        "can_create_mandats",
         "is_staff",
         "is_superuser",
     )

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -1025,6 +1025,9 @@ class CarteTOTP(models.Model):
         verbose_name = "carte TOTP"
         verbose_name_plural = "cartes TOTP"
 
+    def __str__(self):
+        return self.serial_number
+
     def createTOTPDevice(self, confirmed=False, tolerance=30):
         return TOTPDevice(
             key=self.seed,


### PR DESCRIPTION
## 🌮 Objectif

Les bizdev m'ont demandé de pouvoir voir dans Django, en partant des aidants, qui a une carte AC et si elle est activée.

## 🔍 Implémentation

- J'affiche le numéro de la carte AC dans les colonnes de la liste de l'admin
- Je n'affiche le détail (activée ou non) que dans le détail de l'aidant, pour des questions de performances.

## 🏕 Amélioration continue

- J'ai aussi ajouté la colonne "aidant" (peut créer des mandats).

## 🖼️ Images

Deux nouvelles colonnes dans l'écran "liste d'aidants" : 

<img width="1047" alt="Capture d’écran 2021-08-05 à 16 21 49" src="https://user-images.githubusercontent.com/1035145/128367755-eff7da83-f0b8-4d59-a695-a97b172a020c.png">

Et sur la page "un aidant" si la carte existe et est activée : 

<img width="585" alt="Capture d’écran 2021-08-05 à 16 21 35" src="https://user-images.githubusercontent.com/1035145/128367862-25f06f68-92cb-49f4-a77f-9389ec3595aa.png">

Et à l'inverse, si la carte n'a pas été associée et n'est pas activée : 

<img width="913" alt="Capture d’écran 2021-08-05 à 16 21 18" src="https://user-images.githubusercontent.com/1035145/128367956-e4e7b9e9-44ce-4a1f-aa50-5c9e91f4ac7b.png">
