### PR TITLE
Modifierl l'import modificateur des code postaux des organisations

### DIFF
--- a/aidants_connect_web/tests/test_admin_resources.py
+++ b/aidants_connect_web/tests/test_admin_resources.py
@@ -10,9 +10,10 @@ from aidants_connect_web.tests.factories import OrganisationFactory
 class OrganisationResourceTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.organisation = OrganisationFactory(siret="121212122")
+        cls.organisation = OrganisationFactory(name="MAIRIE", siret="121212122")
         cls.orga_data = tablib.Dataset(
             headers=[
+                "Nom de la structure",
                 "Statut de la demande (send = à valider; pending = brouillon)",
                 "Code postal de la structure",
                 "SIRET de l’organisation",
@@ -22,7 +23,8 @@ class OrganisationResourceTestCase(TestCase):
     def test_dont_create_new_organisation(self):
         self.assertEqual(1, Organisation.objects.all().count())
         orga_ressource = OrganisationResource()
-        self.orga_data.append(["validated", "13013", "121212123"])
+        self.orga_data._data = list()
+        self.orga_data.append(["L'internationale", "validated", "13013", "121212123"])
         orga_ressource.import_data(self.orga_data, dry_run=False)
         self.assertEqual(1, Organisation.objects.all().count())
 
@@ -30,16 +32,21 @@ class OrganisationResourceTestCase(TestCase):
         self.assertEqual(1, Organisation.objects.all().count())
         orga_ressource = OrganisationResource()
         invalid_orga_data = tablib.Dataset(
-            headers=["Code postal de la structure", "SIRET de l’organisation"]
+            headers=[
+                "Nom de la structure",
+                "Code postal de la structure",
+                "SIRET de l’organisation",
+            ]
         )
-        invalid_orga_data.append(["13013", "121212122"])
+        invalid_orga_data.append(["L'internationale", "13013", "121212122"])
         orga_ressource.import_data(invalid_orga_data, dry_run=False)
         self.assertEqual(1, Organisation.objects.all().count())
 
     def test_update_organisation_without_zipcode(self):
         self.assertEqual(1, Organisation.objects.all().count())
         orga_ressource = OrganisationResource()
-        self.orga_data.append(["validated", "13013", "121212122"])
+        self.orga_data._data = list()
+        self.orga_data.append(["MAIRIE", "validated", "13013", "121212122"])
         orga_ressource.import_data(self.orga_data, dry_run=False)
         self.assertEqual(1, Organisation.objects.all().count())
         self.assertEqual("13013", Organisation.objects.first().zipcode)
@@ -50,7 +57,30 @@ class OrganisationResourceTestCase(TestCase):
         self.assertEqual(1, Organisation.objects.all().count())
 
         orga_ressource = OrganisationResource()
-        self.orga_data.append(["validated", "13013", "121212122"])
+        self.orga_data._data = list()
+        self.orga_data.append(["MAIRIE", "validated", "13013", "121212122"])
         orga_ressource.import_data(self.orga_data, dry_run=False)
         self.assertEqual(1, Organisation.objects.all().count())
         self.assertEqual("34034", Organisation.objects.first().zipcode)
+
+    def test_dont_raise_exception_(self):
+        self.organisation.zipcode = "34034"
+        self.organisation.save()
+        self.assertEqual(1, Organisation.objects.all().count())
+
+        orga_ressource = OrganisationResource()
+        self.orga_data._data = list()
+        self.orga_data.append(["MAIRIE", "validated", "13013", "121212122"])
+        orga_ressource.import_data(self.orga_data, dry_run=False)
+        self.assertEqual(1, Organisation.objects.all().count())
+        self.assertEqual("34034", Organisation.objects.first().zipcode)
+
+    def test_dont_raise_exception_multiple_same_siret(self):
+        OrganisationFactory(name="MAIRIE12", siret="121212122")
+
+        self.assertEqual(2, Organisation.objects.all().count())
+        orga_ressource = OrganisationResource()
+        self.orga_data._data = list()
+        self.orga_data.append(["MAIRIE", "validated", "13013", "121212122"])
+        orga_ressource.import_data(self.orga_data, dry_run=False)
+        self.assertEqual(2, Organisation.objects.all().count())


### PR DESCRIPTION
## 🌮 Objectif

Prendre en compte que plusieurs organisations peuvent avoir le même SIRET

## 🔍 Implémentation

Modification de la ressource d'import des organisations dans l'admin django

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
