### PR TITLE
Suppresion des aidants du hash généré dans les journeaux de création d'attestation

### DIFF
--- a/aidants_connect_web/migrations/0059_fix_mandate_template_path.py
+++ b/aidants_connect_web/migrations/0059_fix_mandate_template_path.py
@@ -63,12 +63,12 @@ def populate_template_path(apps, _):
         for file in files:
             filename = basename(file)
             file_hash = generate_attestation_hash(
-                journal.aidant,
-                mandate.usager,
-                [it.demarche for it in mandate.autorisations.all()],
-                mandate.expiration_date,
-                journal.creation_date.date().isoformat(),
-                path_join(settings.MANDAT_TEMPLATE_DIR, filename),
+                organisation=journal.aidant.organisation,
+                usager=mandate.usager,
+                demarches=[it.demarche for it in mandate.autorisations.all()],
+                expiration_date=mandate.expiration_date,
+                creation_date=journal.creation_date,
+                mandat_template_path=path_join(settings.MANDAT_TEMPLATE_DIR, filename),
             )
 
             if file_hash == journal.attestation_hash:

--- a/aidants_connect_web/migrations/0068_recompute_attestation_hashes.py
+++ b/aidants_connect_web/migrations/0068_recompute_attestation_hashes.py
@@ -1,0 +1,31 @@
+from django.db import migrations, transaction
+
+from aidants_connect_web.constants import JournalActionKeywords
+from aidants_connect_web.utilities import generate_attestation_hash
+
+
+@transaction.atomic
+def populate_template_path(apps, _):
+    Journal = apps.get_model("aidants_connect_web", "Journal")
+
+    for journal in Journal.objects.filter(
+        action=JournalActionKeywords.CREATE_ATTESTATION
+    ):
+        journal.attestation_hash = generate_attestation_hash(
+            organisation=journal.organisation,
+            usager=journal.usager,
+            demarches=journal.demarche,
+            expiration_date=journal,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("aidants_connect_web", "0067_auto_20210817_1534"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            populate_template_path, reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -579,11 +579,11 @@ class Mandat(models.Model):
             for _, _, filenames in os_walk(template_dir):
                 for filename in filenames:
                     file_hash = generate_attestation_hash(
-                        journal_entry.aidant,
+                        journal_entry.aidant.organisation,
                         self.usager,
                         demarches,
                         self.expiration_date,
-                        journal_entry.creation_date.date().isoformat(),
+                        journal_entry.creation_date,
                         path_join(settings.MANDAT_TEMPLATE_DIR, filename),
                     )
 
@@ -647,13 +647,12 @@ class Mandat(models.Model):
                     )
                     if journal is not None:
                         journal.attestation_hash = generate_attestation_hash(
-                            aidant=journal.aidant,
+                            organisation=organisation,
                             usager=mandate.usager,
                             demarches=journal.demarche,
                             expiration_date=mandate.expiration_date,
-                            creation_date=mandate.expiration_date.date().isoformat(),
+                            creation_date=mandate.expiration_date,
                             mandat_template_path=mandate.get_mandate_template_path(),
-                            organisation_id=organisation.id,
                         )
                         journal.save()
             except Exception:

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -364,10 +364,10 @@ class MandatModelTests(TestCase):
         procedures = ["transports", "logement"]
         expiration_date = timezone.now() + timedelta(days=6)
         attestation_hash = generate_attestation_hash(
-            self.aidant_1,
-            self.usager_1,
-            procedures,
-            expiration_date,
+            organisation=self.aidant_1.organisation,
+            usager=self.usager_1,
+            demarches=procedures,
+            expiration_date=expiration_date,
             mandat_template_path=path_join(settings.MANDAT_TEMPLATE_DIR, tpl_name),
         )
 
@@ -398,7 +398,7 @@ class MandatModelTests(TestCase):
 
         result = mandate._get_mandate_template_path_from_journal_hash()
 
-        self.assertEqual(result, f"aidants_connect_web/mandat_templates/{tpl_name}")
+        self.assertEqual(f"aidants_connect_web/mandat_templates/{tpl_name}", result)
 
     def test__get_template_path_from_journal_hash_with_old_mandate(self):
         tpl_name = "20200511_mandat.html"
@@ -406,11 +406,11 @@ class MandatModelTests(TestCase):
         expiration_date = timezone.now() - timedelta(days=6)
         creation_date = timezone.now() - timedelta(days=12)
         attestation_hash = generate_attestation_hash(
-            self.aidant_1,
-            self.usager_1,
-            procedures,
-            expiration_date,
-            creation_date=creation_date.date().isoformat(),
+            organisation=self.aidant_1.organisation,
+            usager=self.usager_1,
+            demarches=procedures,
+            expiration_date=expiration_date,
+            creation_date=creation_date,
             mandat_template_path=path_join(settings.MANDAT_TEMPLATE_DIR, tpl_name),
         )
 
@@ -446,25 +446,25 @@ class MandatModelTests(TestCase):
 
         result = mandate._get_mandate_template_path_from_journal_hash()
 
-        self.assertEqual(result, f"aidants_connect_web/mandat_templates/{tpl_name}")
+        self.assertEqual(f"aidants_connect_web/mandat_templates/{tpl_name}", result)
 
     def test__get_template_path_from_journal_hash_with_old_delegation(self):
         tpl_name = "20200511_mandat.html"
         procedures = ["transports", "logement"]
         expiration_date = timezone.now() + timedelta(days=6)
         attestation_hash = generate_attestation_hash(
-            self.aidant_1,
-            self.usager_1,
-            procedures,
-            expiration_date,
+            organisation=self.aidant_1.organisation,
+            usager=self.usager_1,
+            demarches=procedures,
+            expiration_date=expiration_date,
             mandat_template_path=path_join(settings.MANDAT_TEMPLATE_DIR, tpl_name),
         )
 
         old_attestation_hash = generate_attestation_hash(
-            self.aidant_1,
-            self.usager_1,
-            procedures,
-            expiration_date,
+            organisation=self.aidant_1.organisation,
+            usager=self.usager_1,
+            demarches=procedures,
+            expiration_date=expiration_date,
             mandat_template_path=path_join(
                 settings.MANDAT_TEMPLATE_DIR, "20200201_mandat.html"
             ),
@@ -1197,7 +1197,10 @@ class JournalModelTests(TestCase):
             is_remote_mandat=False,
             access_token="fjfgjfdkldlzlsmqqxxcn",
             attestation_hash=generate_attestation_hash(
-                self.aidant_thierry, self.usager_ned, demarches, expiration_date
+                organisation=self.aidant_thierry.organisation,
+                usager=self.usager_ned,
+                demarches=demarches,
+                expiration_date=expiration_date,
             ),
             mandat=mandat,
         )
@@ -1207,7 +1210,6 @@ class JournalModelTests(TestCase):
 
         attestation_string = ";".join(
             [
-                str(self.aidant_thierry.id),
                 date.today().isoformat(),
                 "logement,transports",
                 expiration_date.date().isoformat(),

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -80,8 +80,8 @@ def new_mandat(request):
 @activity_required
 def new_mandat_recap(request):
     connection = Connection.objects.get(pk=request.session["connection"])
-    aidant = request.user
-    usager = connection.usager
+    aidant: Aidant = request.user
+    usager: Usager = connection.usager
     demarches_description = [
         humanize_demarche_names(demarche) for demarche in connection.demarches
     ]
@@ -133,7 +133,10 @@ def new_mandat_recap(request):
                     is_remote_mandat=connection.mandat_is_remote,
                     access_token=connection.access_token,
                     attestation_hash=generate_attestation_hash(
-                        aidant, usager, connection.demarches, mandat_expiration_date
+                        organisation=aidant.organisation,
+                        usager=usager,
+                        demarches=connection.demarches,
+                        expiration_date=mandat_expiration_date,
                     ),
                     mandat=mandat,
                 )


### PR DESCRIPTION
## 🌮 Objectif

Tout est dans le titre

## Interrogation complémentaire

Il ne semble pas possible de recalculer le hash des anciens journeaux. Certaines données sont irrémédiablement perdues pour les plus anciens (date de création, date d'expiration, chemin du gabarit utilisé). Pour les plus récents, #319 a rajouté une référence sur le mandat en qauestion, dont il est possible de le faire.