### PR TITLE
Renforcement de la vue fc_callback pour résister aux erreurs de FranceConnect

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -1,5 +1,3 @@
-from distutils.util import strtobool
-
 from django import forms
 from django.conf import settings
 from django.contrib.auth import password_validation
@@ -180,56 +178,6 @@ class MandatForm(forms.Form):
         ),
         required=False,
     )
-
-    def __init__(
-        self,
-        data=None,
-        files=None,
-        auto_id="id_%s",
-        prefix=None,
-        initial=None,
-        error_class=ErrorList,
-        label_suffix=None,
-        empty_permitted=False,
-        field_order=None,
-        use_required_attribute=None,
-        renderer=None,
-    ):
-
-        super().__init__(
-            data,
-            files,
-            auto_id,
-            prefix,
-            None,
-            error_class,
-            label_suffix,
-            empty_permitted,
-            field_order,
-            use_required_attribute,
-            renderer,
-        )
-
-        if initial is not None:
-            for field in self.fields.keys():
-                if field not in initial:
-                    continue
-                value = initial[field]
-
-                if field == "demarche" and isinstance(value, str):
-                    value = [
-                        item
-                        for item in value.split(",")
-                        if item in settings.DEMARCHES.keys()
-                    ]
-                elif field == "is_remote" and isinstance(value, str):
-                    try:
-                        value = bool(strtobool(value))
-                    except Exception:
-                        value = None
-
-                if value is not None:
-                    self.initial[field] = value
 
     def clean(self):
         cleaned = super().clean()

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -1,3 +1,5 @@
+from distutils.util import strtobool
+
 from django import forms
 from django.conf import settings
 from django.contrib.auth import password_validation
@@ -178,6 +180,56 @@ class MandatForm(forms.Form):
         ),
         required=False,
     )
+
+    def __init__(
+        self,
+        data=None,
+        files=None,
+        auto_id="id_%s",
+        prefix=None,
+        initial=None,
+        error_class=ErrorList,
+        label_suffix=None,
+        empty_permitted=False,
+        field_order=None,
+        use_required_attribute=None,
+        renderer=None,
+    ):
+
+        super().__init__(
+            data,
+            files,
+            auto_id,
+            prefix,
+            None,
+            error_class,
+            label_suffix,
+            empty_permitted,
+            field_order,
+            use_required_attribute,
+            renderer,
+        )
+
+        if initial is not None:
+            for field in self.fields.keys():
+                if field not in initial:
+                    continue
+                value = initial[field]
+
+                if field == "demarche" and isinstance(value, str):
+                    value = [
+                        item
+                        for item in value.split(",")
+                        if item in settings.DEMARCHES.keys()
+                    ]
+                elif field == "is_remote" and isinstance(value, str):
+                    try:
+                        value = bool(strtobool(value))
+                    except Exception:
+                        value = None
+
+                if value is not None:
+                    self.initial[field] = value
 
     def clean(self):
         cleaned = super().clean()

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -41,6 +41,11 @@
     </div>
   </section>
   <section id="mandat_specifications" class="section section-grey">
+    {% if messages %}
+      {% for message in messages %}
+        <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
     <div class="container">
       <form method="post">
         {% if form.errors %}
@@ -64,6 +69,7 @@
                     name="demarche"
                     class="sr-only"
                     {% if form.errors.demarche %}aria-describedby="demarche_error_notification"{% endif %}
+                    {% if value in form.demarche.initial %}checked{% endif %}
                   />
                   <label class="label-demarche" for="button-{{ value }}">
                     <img src="{{ label.icon }}" alt=""/>
@@ -101,6 +107,7 @@
                     name="duree"
                     class="sr-only"
                     {% if form.errors.duree %}aria-describedby="duree_error_notification"{% endif %}
+                    {% if value in form.duree.initial %}checked{% endif %}
                   />
                   <label class="label-duree" for="button-{{ value }}">
                     <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -9,6 +9,11 @@
 {% endblock extracss %}
 
 {% block content %}
+  {% if messages %}
+    {% for message in messages %}
+      <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+    {% endfor %}
+  {% endif %}
   <section id="engagement" class="section">
     <div class="container container-small">
       <h1 class="section__title">Créer ou renouveler un mandat</h1>
@@ -41,11 +46,6 @@
     </div>
   </section>
   <section id="mandat_specifications" class="section section-grey">
-    {% if messages %}
-      {% for message in messages %}
-        <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
-      {% endfor %}
-    {% endif %}
     <div class="container">
       <form method="post">
         {% if form.errors %}
@@ -69,7 +69,7 @@
                     name="demarche"
                     class="sr-only"
                     {% if form.errors.demarche %}aria-describedby="demarche_error_notification"{% endif %}
-                    {% if value in form.demarche.initial %}checked{% endif %}
+                    {% if value in form.demarche.value or value in form.demarche.initial %}checked{% endif %}
                   />
                   <label class="label-demarche" for="button-{{ value }}">
                     <img src="{{ label.icon }}" alt=""/>
@@ -107,7 +107,7 @@
                     name="duree"
                     class="sr-only"
                     {% if form.errors.duree %}aria-describedby="duree_error_notification"{% endif %}
-                    {% if value in form.duree.initial %}checked{% endif %}
+                    {% if value in form.duree.value or value in form.duree.initial %}checked{% endif %}
                   />
                   <label class="label-duree" for="button-{{ value }}">
                     <strong>{{ label.title }} <span class="duree-label-is-remote">à distance</span></strong>

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -1,5 +1,4 @@
 import logging
-from urllib.parse import urlencode
 from secrets import token_urlsafe
 import jwt
 from jwt.api_jwt import ExpiredSignatureError
@@ -104,16 +103,7 @@ def fc_callback(request):
             "votre requête ?",
         )
 
-        fields = urlencode(
-            {
-                "duree": connection.duree_keyword,
-                "is_remote": connection.mandat_is_remote,
-                "demarche": ",".join(connection.demarches),
-                "user_phone": connection.user_phone,
-            }
-        )
-
-        return redirect(f"{reverse('new_mandat')}?{fields}")
+        return redirect(reverse("new_mandat"))
 
     try:
         content = request_for_token.json()

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -1,14 +1,17 @@
 import logging
+from urllib.parse import urlencode
 from secrets import token_urlsafe
 import jwt
 from jwt.api_jwt import ExpiredSignatureError
 import requests as python_request
+
 
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.db import IntegrityError
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect, render
+from django.urls import reverse
 
 from aidants_connect_web.models import Connection, Usager, Journal
 from aidants_connect_web.utilities import generate_sha256_hash
@@ -91,8 +94,42 @@ def fc_callback(request):
     headers = {"Accept": "application/json"}
 
     request_for_token = python_request.post(token_url, data=payload, headers=headers)
-    content = request_for_token.json()
+
+    def fc_error(log_msg):
+        log.error(log_msg)
+        django_messages.error(
+            request,
+            "Nous avons rencontré une erreur en tentant d'interagir avec "
+            "France Connect. C'est probabablement temporaire. Pouvez-vous réessayer "
+            "votre requête ?",
+        )
+
+        fields = urlencode(
+            {
+                "duree": connection.duree_keyword,
+                "is_remote": connection.mandat_is_remote,
+                "demarche": ",".join(connection.demarches),
+                "user_phone": connection.user_phone,
+            }
+        )
+
+        return redirect(f"{reverse('new_mandat')}?{fields}")
+
+    try:
+        content = request_for_token.json()
+    except ValueError:  # not a valid JSON
+        return fc_error(
+            f"Request to {token_url} failed. Status code: "
+            f"{request_for_token.status_code}, body: {request_for_token.text}"
+        )
+
     connection.access_token = content.get("access_token")
+    if connection.access_token is None:
+        return fc_error(
+            f"No access_token return when requesting {token_url}. JSON response: "
+            f"{repr(content)}"
+        )
+
     connection.save()
     fc_id_token = content.get("id_token")
 

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -39,9 +39,10 @@ log = logging.getLogger()
 @activity_required
 def new_mandat(request):
     aidant = request.user
-    form = MandatForm()
 
     if request.method == "GET":
+        form = MandatForm(initial=request.GET)
+
         return render(
             request,
             "aidants_connect_web/new_mandat/new_mandat.html",

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -39,9 +39,24 @@ log = logging.getLogger()
 @activity_required
 def new_mandat(request):
     aidant = request.user
+    try:
+        connection = Connection.objects.get(pk=request.session.get("connection"))
+    except Connection.DoesNotExist:
+        connection = None
 
     if request.method == "GET":
-        form = MandatForm(initial=request.GET)
+        inital = (
+            {
+                "duree": connection.duree_keyword,
+                "is_remote": connection.mandat_is_remote,
+                "demarche": connection.demarches,
+                "user_phone": connection.user_phone,
+            }
+            if connection is not None
+            else None
+        )
+
+        form = MandatForm(initial=inital)
 
         return render(
             request,


### PR DESCRIPTION
## 🌮 Objectif

La vue `fc_callback` [fait une requête vers France Connect pour récupérer un token](https://github.com/betagouv/Aidants_Connect/blob/main/aidants_connect_web/views/FC_as_FS.py#L93-L96). Il peut arriver, de temps en temps que cette requête n'aboutisse pas. Ne code n'est pas protégé contre ça pour le moment.

Il. Est. Temps. De. Réparer. Cette. Erreur :smiling_imp: 

## :camping: Amélioration continue

Cette PR rajoute aussi la sauvegarde de l'état d'un formulaire de création de nouveau mandat en cas d'erreur.