### PR TITLE
Filtrer par région dans l'admin Django

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -177,13 +177,18 @@ class OrganisationRegionFilter(SimpleListFilter):
     parameter_name = "region"
 
     def lookups(self, request, model_admin):
-        return [(r.id, r.name) for r in DatavizRegion.objects.all()]
+        return [(r.id, r.name) for r in DatavizRegion.objects.all()] + [
+            ("other", "Autre")
+        ]
 
     def queryset(self, request, queryset):
         region_id = self.value()
 
         if not region_id:
             return
+
+        if region_id == "other":
+            return queryset.filter(zipcode=0)
 
         region = DatavizRegion.objects.get(id=region_id)
         d2r = DatavizDepartmentsToRegion.objects.filter(region=region)


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux bizdev de pouvoir atteindre plus rapidement les orga et les demandes d'habilitation qui les concernent.

## 🔍 Implémentation

- Ajout d'un filtre personnalisé pour les organisations et les demandes d'habilitation

## Informations supplémentaires

En l'état actuel des choses, je n'ai pas trouvé de moyen simple de filtrer sur plusieurs régions à la fois. Je ne sais pas si Django permet de le faire simplement, je n'en ai pas l'impression.

## 🖼️ Images

Le filtre à droite de l'écran "Organisations" : 
![Capture d’écran 2021-09-07 à 12 12 09](https://user-images.githubusercontent.com/1035145/132328322-d52c6dfa-3c68-42f2-9db6-f5cca872b44e.png)

En action pour la région ARA : 
![Capture d’écran 2021-09-07 à 12 12 17](https://user-images.githubusercontent.com/1035145/132328418-7dc553a3-80af-483d-a9ce-82b14f104da6.png)

Pour les requêtes d'habilitation : 
![Capture d’écran 2021-09-07 à 12 11 28](https://user-images.githubusercontent.com/1035145/132328508-b112cc19-96ef-43a4-9391-0d446d8762eb.png)
![Capture d’écran 2021-09-07 à 12 11 21](https://user-images.githubusercontent.com/1035145/132328510-21a1882b-b87d-4753-a760-069fb11803ae.png)
