### PR TITLE
Suppression du tracking Mailjet sur les mails de connexion

### DIFF
--- a/aidants_connect_web/templates/login/email_template.html
+++ b/aidants_connect_web/templates/login/email_template.html
@@ -24,7 +24,7 @@
                               <table border="0" cellpadding="0" cellspacing="0">
                                 <tbody>
                                   <tr>
-                                    <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}">Connexion</a> </td>
+                                    <td align="center"> <a href="https://{{ site.domain }}{% url 'magicauth-wait' token.key %}?next={{ next_url|urlencode }}" rel="notrack">Connexion</a> </td>
                                   </tr>
                                 </tbody>
                               </table>


### PR DESCRIPTION
## 🌮 Objectif

Permettre à toutes les aidantes de recevoir nos mails de connexion, y compris celles qui ont une adresse en laposte.net.
Le problème semblait venir des URL de suivi de Mailjet : il réécrit notre URL en aidantsconnect pour suivre les clics dans les mails.

## 🔍 Implémentation

A priori on n'a pas besoin du suivi des clics dans les e-mails : on a déjà la journalisation qui mentionne les connexions des aidants.

Pour empêcher mailjet de suivre les mails, [leur documentation](https://documentation.mailjet.com/hc/fr/articles/360042751854-Comment-exclure-un-lien-du-suivi-lorsque-le-suivi-des-clics-est-activ%C3%A9-) indique qu'il suffit d'ajouter un attribut `rel="notrack"` dans le HTML…
