### PR TITLE
Mise à jour des CGU

### DIFF
--- a/aidants_connect_web/templates/public_website/cgu.html
+++ b/aidants_connect_web/templates/public_website/cgu.html
@@ -324,7 +324,7 @@
       contacté par courriel à l’adresse : dpo@anct.gouv.f et par courrier à l’adresse :
       <br>
       <i>
-        Service du Premier ministre
+        Agence Nationale de la Cohésion des Territoires
         <br>
         A l'attention du délégué à la protection des données (DPD)
         <br>
@@ -337,6 +337,14 @@
       Conformément au règlement général sur la protection des données, vous disposez du droit d’introduire une
       réclamation auprès de la CNIL (3 place de Fontenoy – TSA 80715 – 75334 PARIS CEDEX 07). Les modalités de
       réclamation sont précisées sur le site de la CNIL : www.cnil.fr.
+    </p>
+    
+    <h3>Destinataires des données</h3>
+    
+    <p>
+    Seuls sont destinataires des informations et des données à caractère personnel : les usagers, les membres habilités des structures 
+    d’accompagnement partenaires (pour les seules données qu’ils ont à connaitre), les agents affectés à la startup d'État dénommé « Aidants Connect » 
+    et leurs sous-traitants. Seules les données strictement nécessaires aux missions respectives de chacun des intervenants sont transmises.
     </p>
 
     <h3>Procédure en cas de violations de données à caractère personnel</h3>

--- a/aidants_connect_web/templates/public_website/cgu.html
+++ b/aidants_connect_web/templates/public_website/cgu.html
@@ -343,7 +343,7 @@
     
     <p>
     Seuls sont destinataires des informations et des données à caractère personnel : les usagers, les membres habilités des structures 
-    d’accompagnement partenaires (pour les seules données qu’ils ont à connaitre), les agents affectés à la startup d'État dénommé « Aidants Connect » 
+    d’accompagnement partenaires (pour les seules données qu’ils ont à connaitre), les agents affectés à la startup d'État dénommée « Aidants Connect » 
     et leurs sous-traitants. Seules les données strictement nécessaires aux missions respectives de chacun des intervenants sont transmises.
     </p>
 


### PR DESCRIPTION
## 🌮 Objectif

_Ajout des destinataires des données de traitement
_Suppression de la coquille "Service du Premier Ministre", car Aidants Connect dépend de l'ANCT

## ⚠️ Informations supplémentaires

_Reste à ajouter les durées de conservation des aidants (sur tableau pour plus de visibilité ?)
