### PR TITLE
Fix de la migration 'Aidant.organisations' quand 'Aidant.organisation' vaut 'None'

### DIFF
--- a/aidants_connect_web/migrations/0070_auto_20210908_1644.py
+++ b/aidants_connect_web/migrations/0070_auto_20210908_1644.py
@@ -4,7 +4,10 @@ import django.db.models.deletion
 
 @transaction.atomic
 def populate_carers(apps, _):
-    objects = apps.get_model("aidants_connect_web", "Aidant").objects.all()
+    objects = apps.get_model("aidants_connect_web", "Aidant").objects.filter(
+        organisation__isnull=False
+    )
+
     for obj in objects:
         obj.organisations.add(obj.organisation)
 


### PR DESCRIPTION
## 🌮 Objectif

La migration `0070_auto_20210908_1644` est un tout petit peu cassée pour les enregistrements pour lesquels le champ `organisation` est nul.