### PR TITLE
Afficher davantage de statistiques sur les pages "organisation"

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -76,6 +76,10 @@ class Organisation(models.Model):
             expiration_date__gte=timezone.now(), organisation=self
         ).count()
 
+    @cached_property
+    def num_usagers(self):
+        return Mandat.objects.filter(organisation=self).distinct("usager").count()
+
     @property
     def display_address(self):
         return self.address if self.address != "No address provided" else ""

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -70,6 +70,10 @@ class Organisation(models.Model):
     def admin_num_mandats(self):
         return self.num_mandats
 
+    @cached_property
+    def num_active_mandats(self):
+        return sum(1 if m.is_active else 1 for m in self.mandats.all())
+
     @property
     def display_address(self):
         return self.address if self.address != "No address provided" else ""
@@ -523,6 +527,8 @@ class Mandat(models.Model):
 
     @property
     def is_active(self):
+        if self.is_expired:
+            return False
         # A `mandat` is considered `active` if it contains
         # at least one active `autorisation`.
         return self.autorisations.active().exists()

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -72,7 +72,9 @@ class Organisation(models.Model):
 
     @cached_property
     def num_active_mandats(self):
-        return sum(1 if m.is_active else 1 for m in self.mandats.all())
+        return Mandat.objects.filter(
+            expiration_date__gte=timezone.now(), organisation=self
+        ).count()
 
     @property
     def display_address(self):

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/organisation.html
@@ -17,22 +17,8 @@
       {% endfor %}
     {% endif %}
     <h1>Mon organisation : {{ organisation.name }}</h1>
-    <div class="tiles">
-      <div class="grid">
-        <div class="tile background-color-grey">
-          <h3>Adresse</h3>
-          <p>{{ organisation.address }}</p>
-        </div>
-        <div class="tile background-color-grey">
-          <h3>Aidants actifs</h3>
-          <h5>{{ organisation.num_active_aidants }}</h5>
-        </div>
-        <div class="tile background-color-grey">
-          <h3>Mandats créés</h3>
-          <h5>{{ organisation.num_mandats }}</h5>
-        </div>
-      </div>
-    </div>
+    {% include "aidants_connect_web/espace_aidant/notifications.html" with user=aidant %}
+    {% include "aidants_connect_web/espace_aidant/statistics.html" with organisation=organisation %}
   </div>
 </section>
 

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -1,0 +1,18 @@
+<div class="tiles">
+  <div class="grid">
+    <div class="tile background-color-grey">
+      <h3>Adresse</h3>
+      <p>
+        {{ organisation.address }}
+      </p>
+    </div>
+    <div class="tile background-color-grey">
+      <h3>Aidants actifs</h3>
+      <h5>{{ organisation.num_active_aidants }}</h5>
+    </div>
+    <div class="tile background-color-grey">
+      <h3>Mandats créés</h3>
+      <h5>{{ organisation.num_mandats }}</h5>
+    </div>
+  </div>
+</div>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -12,11 +12,11 @@
     </div>
     <div class="tile background-color-grey">
       <h3>Mandats créés</h3>
-      <p class="font-weight-bold">{{ organisation.num_mandats }}</p>
+      <p class="font-weight-bold"> {{ organisation.num_mandats }} </p>
     </div>
     <div class="tile background-color-grey">
       <h3>Mandats actifs</h3>
-      <p class="font-weight-bold">{{ organisation.num_active_mandats }}</p>
+      <p class="font-weight-bold"> {{ organisation.num_active_mandats }}</p>
     </div>
     <div class="tile background-color-grey">
       <h3>Usagers accompagnés</h3>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -20,7 +20,7 @@
     </div>
     <div class="tile background-color-grey">
       <h3>Usagers accompagnés</h3>
-      <p class="font-weight-bold">xxx</p>
+      <p class="font-weight-bold">{{ organisation.num_usagers }}</p>
     </div>
   </div>
 </div>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -14,5 +14,13 @@
       <h3>Mandats créés</h3>
       <p class="font-weight-bold">{{ organisation.num_mandats }}</p>
     </div>
+    <div class="tile background-color-grey">
+      <h3>Mandats actifs</h3>
+      <p class="font-weight-bold">{{ organisation.num_active_mandats }}</p>
+    </div>
+    <div class="tile background-color-grey">
+      <h3>Usagers accompagnés</h3>
+      <p class="font-weight-bold">xxx</p>
+    </div>
   </div>
 </div>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -8,11 +8,11 @@
     </div>
     <div class="tile background-color-grey">
       <h3>Aidants actifs</h3>
-      <h5>{{ organisation.num_active_aidants }}</h5>
+      <p class="font-weight-bold">{{ organisation.num_active_aidants }}</p>
     </div>
     <div class="tile background-color-grey">
       <h3>Mandats créés</h3>
-      <h5>{{ organisation.num_mandats }}</h5>
+      <p class="font-weight-bold">{{ organisation.num_mandats }}</p>
     </div>
   </div>
 </div>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -19,24 +19,7 @@
       {% endif %}
       <h1>Mon organisation : {{ organisation.name }}</h1>
       {% include "aidants_connect_web/espace_aidant/notifications.html" with user=responsable %}
-      <div class="tiles">
-        <div class="grid">
-          <div class="tile background-color-grey">
-            <h3>Adresse</h3>
-            <p>
-              {{ organisation.address }}
-            </p>
-          </div>
-          <div class="tile background-color-grey">
-            <h3>Aidants actifs</h3>
-            <h5>{{ organisation.num_active_aidants }}</h5>
-          </div>
-          <div class="tile background-color-grey">
-            <h3>Mandats créés</h3>
-            <h5>{{ organisation.num_mandats }}</h5>
-          </div>
-        </div>
-      </div>
+      {% include "aidants_connect_web/espace_aidant/statistics.html" with organisation=organisation %}
     </div>
   </section>
 

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -758,6 +758,17 @@ class OrganisationModelTests(TestCase):
         self.assertEqual(7, org_with_active_and_inactive_mandats.num_mandats)
         self.assertEqual(3, org_with_active_and_inactive_mandats.num_active_mandats)
 
+    def test_count_usagers(self):
+        def create_6_mandats_for_2_usagers(organisation):
+            thomas = UsagerFactory(given_name="Thomas")
+            for _ in range(5):
+                MandatFactory(organisation=organisation, usager=thomas)
+            MandatFactory(organisation=organisation)
+
+        organisation = OrganisationFactory()
+        create_6_mandats_for_2_usagers(organisation=organisation)
+        self.assertEqual(2, organisation.num_usagers)
+
 
 @tag("models", "aidant")
 class AidantModelTests(TestCase):

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -728,6 +728,36 @@ class OrganisationModelTests(TestCase):
         organisation_with_zipcode.refresh_from_db()
         self.assertEqual("75015", organisation_with_zipcode.zipcode)
 
+    def test_count_mandats(self):
+        def create_active_mandats(count, organisation):
+            for _ in range(count):
+                MandatFactory(
+                    organisation=organisation,
+                    expiration_date=timezone.now() + timedelta(days=6),
+                )
+
+        def create_expired_mandats(count, organisation):
+            for _ in range(count):
+                MandatFactory(
+                    organisation=organisation,
+                    expiration_date=timezone.now() - timedelta(days=6),
+                )
+
+        org_without_mandats = OrganisationFactory(name="Licornes")
+        self.assertEqual(0, org_without_mandats.num_mandats)
+        self.assertEqual(0, org_without_mandats.num_active_mandats)
+
+        org_with_active_mandats = OrganisationFactory(name="Dragons")
+        create_active_mandats(3, org_with_active_mandats)
+        self.assertEqual(3, org_with_active_mandats.num_mandats)
+        self.assertEqual(3, org_with_active_mandats.num_active_mandats)
+
+        org_with_active_and_inactive_mandats = OrganisationFactory(name="Libellules")
+        create_active_mandats(3, org_with_active_and_inactive_mandats)
+        create_expired_mandats(4, org_with_active_and_inactive_mandats)
+        self.assertEqual(7, org_with_active_and_inactive_mandats.num_mandats)
+        self.assertEqual(3, org_with_active_and_inactive_mandats.num_active_mandats)
+
 
 @tag("models", "aidant")
 class AidantModelTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Donner davantage d'infos aux aidants et respo structure sur leur activité Aidants Connect : 

- nombre de mandats *actifs* (en plus du nombre de mandats total)
- nombre d'usagers accompagnés

## 🔍 Implémentation

- J'ai essayé d'éviter d'ajouter trop de requêtes SQL pour le rendu de la page. On ne fait qu'une seule requête supplémentaire par chiffre (mes premiers essais on ajoutait une requête par mandat, ça finissait par faire beaucoup).
- Il y a une limitation que j'assume : on ne tient pas compte des mandats explicitement révoqués, on ne regarde que leur date d'expiration. Il ne s'agit que de statistiques informatives et pas de vérifier si on peut utiliser le mandat. J'estime qu'on peut se permettre de surestimer de quelques unités le nombre de mandats sur certaines orga, si ça permet d'alléger les requêtes sur l'ensemble des pages.

## 🖼️ Images

![Capture d’écran 2021-09-22 à 10 57 27](https://user-images.githubusercontent.com/1035145/134315080-9e34c257-513d-4b84-9595-756d0747eb2c.png)


