### PR TITLE
Utilisation de factory.Faker("email") dans AidantFactory

### DIFF
--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -50,8 +50,8 @@ class OrganisationTypeFactory(factory.DjangoModelFactory):
 
 
 class AidantFactory(factory.DjangoModelFactory):
-    username = "thierry@thierry.com"
-    email = "thierry@thierry.com"
+    username = factory.Faker("email")
+    email = factory.SelfAttribute("username")
     password = factory.PostGenerationMethodCall("set_password", "motdepassedethierry")
     last_name = "Goneau"
     first_name = "Thierry"

--- a/aidants_connect_web/tests/test_decorators.py
+++ b/aidants_connect_web/tests/test_decorators.py
@@ -40,7 +40,6 @@ class AidantRequiredTests(TestCase):
     def setUpTestData(cls):
         cls.aidant_thierry = AidantFactory()
         cls.responsable_georges = AidantFactory(
-            username="georges@georges.com",
             organisation=cls.aidant_thierry.organisation,
             can_create_mandats=False,
         )
@@ -63,7 +62,6 @@ class RespoStructureRequiredTests(TestCase):
     def setUpTestData(cls):
         cls.aidant_thierry = AidantFactory()
         cls.responsable_georges = AidantFactory(
-            username="georges@georges.com",
             organisation=cls.aidant_thierry.organisation,
             can_create_mandats=False,
         )

--- a/aidants_connect_web/tests/test_factories.py
+++ b/aidants_connect_web/tests/test_factories.py
@@ -1,0 +1,47 @@
+from django.test import tag, TestCase
+
+from aidants_connect_web.models import (
+    Aidant,
+)
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    CarteTOTPFactory,
+    HabilitationRequestFactory,
+)
+
+
+@tag("factories")
+class AidantFactoryTests(TestCase):
+    def test_email_and_username_generation(self):
+        aidant_a = AidantFactory()
+        aidant_b = AidantFactory()
+        self.assertNotEqual(aidant_a.email, aidant_b.email)
+        self.assertEqual(aidant_a.email, aidant_a.username)
+
+    def test_freeze_username_freezes_email(self):
+        aidant = AidantFactory(username="alban.gulhar@lovejs.org")
+        self.assertEqual(aidant.email, aidant.username)
+        self.assertEqual(aidant.email, "alban.gulhar@lovejs.org")
+
+    def test_fill_database(self):
+        self.assertEqual(0, len(Aidant.objects.all()))
+        for count in range(1, 4):
+            AidantFactory()
+            self.assertEqual(count, len(Aidant.objects.all()))
+
+
+@tag("factories")
+class CarteTotpFactoryTests(TestCase):
+    def test_sn_generation_and_seed_generation(self):
+        card_1 = CarteTOTPFactory()
+        card_2 = CarteTOTPFactory()
+        self.assertNotEqual(card_1.serial_number, card_2.serial_number)
+        self.assertNotEqual(card_1.seed, card_2.seed)
+
+
+@tag("factories")
+class HabilitationRequestFactoryTests(TestCase):
+    def test_email_generation(self):
+        hr_1 = HabilitationRequestFactory()
+        hr_2 = HabilitationRequestFactory()
+        self.assertNotEqual(hr_1.email, hr_2.email)

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -137,7 +137,6 @@ class AidantChangeFormTests(TestCase):
         self.assertEqual(self.aidant2.first_name, "Armand")
         self.assertEqual(self.aidant2.email, "abernart@domain.user")
         self.assertEqual(self.aidant2.username, "abernart@domain.user")
-        self.assertEqual(self.aidant2.first_name, "Armand")
 
         changed_data = {
             "first_name": "Armand",
@@ -165,7 +164,6 @@ class AidantChangeFormTests(TestCase):
         self.assertEqual(self.aidant2.first_name, "Armand")
         self.assertEqual(self.aidant2.email, "abernart@domain.user")
         self.assertEqual(self.aidant2.username, "abernart@domain.user")
-        self.assertEqual(self.aidant2.first_name, "Armand")
 
         changed_data = {
             "first_name": "Armand",

--- a/aidants_connect_web/tests/test_functional/test_admin_transfert_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_admin_transfert_mandat.py
@@ -21,10 +21,7 @@ class ViewAutorisationsTests(FunctionalTestCase):
             is_superuser=True, is_staff=True, is_active=True, post__with_otp_device=True
         )
 
-        self.aidante_fatimah = AidantFactory(
-            username="fatimah@fatimah.com",
-            email="fatimah@fatimah.com",
-        )
+        self.aidante_fatimah = AidantFactory()
 
         self.mandate_1 = MandatFactory(organisation=self.aidant_thierry.organisation)
         self.mandate_2 = MandatFactory(organisation=self.aidant_thierry.organisation)

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -18,16 +18,10 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 @tag("functional")
 class CancelAutorisationTests(FunctionalTestCase):
     def setUp(self):
-        self.aidant_thierry = AidantFactory()
+        self.aidant_thierry = AidantFactory(email="thierry@thierry.com")
         device = self.aidant_thierry.staticdevice_set.create(id=self.aidant_thierry.id)
         device.token_set.create(token="123456")
-        self.aidant_jacqueline = AidantFactory(
-            username="jfremont@domain.user",
-            email="jfremont@domain.user",
-            password="motdepassedejacqueline",
-            first_name="Jacqueline",
-            last_name="Fremont",
-        )
+        self.aidant_jacqueline = AidantFactory()
         self.usager_josephine = UsagerFactory(given_name="Joséphine")
         self.mandat_thierry_josephine = MandatFactory(
             organisation=self.aidant_thierry.organisation,

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -15,7 +15,7 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 @tag("functional", "cancel_mandat")
 class CancelAutorisationTests(FunctionalTestCase):
     def setUp(self):
-        self.aidant_thierry = AidantFactory()
+        self.aidant_thierry = AidantFactory(email="thierry@thierry.com")
         device = self.aidant_thierry.staticdevice_set.create(id=self.aidant_thierry.id)
         device.token_set.create(token="123456")
 

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -19,7 +19,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         super().setUpClass()
 
     def setUp(self) -> None:
-        self.aidant = AidantFactory()
+        self.aidant = AidantFactory(email="thierry@thierry.com")
         device = self.aidant.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="123455")

--- a/aidants_connect_web/tests/test_functional/test_id_provider.py
+++ b/aidants_connect_web/tests/test_functional/test_id_provider.py
@@ -15,7 +15,9 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 class IdProviderTest(FunctionalTestCase):
     def setUp(self):
-        self.aidant = AidantFactory(post__with_otp_device=True)
+        self.aidant = AidantFactory(
+            email="thierry@thierry.com", post__with_otp_device=True
+        )
 
         self.usager_josephine = UsagerFactory(
             given_name="Joséphine", family_name="ST-PIERRE"

--- a/aidants_connect_web/tests/test_functional/test_import_aidant.py
+++ b/aidants_connect_web/tests/test_functional/test_import_aidant.py
@@ -27,7 +27,6 @@ class ImportAidantTests(FunctionalTestCase):
     def setUp(self) -> None:
         self.organisation = OrganisationFactory(id=4444)
         self.aidant = AidantFactory(
-            email="thierry@thierry.com",
             username="thierry@thierry.com",
             is_superuser=True,
             is_staff=True,

--- a/aidants_connect_web/tests/test_functional/test_import_aidant.py
+++ b/aidants_connect_web/tests/test_functional/test_import_aidant.py
@@ -26,7 +26,12 @@ class ImportAidantTests(FunctionalTestCase):
 
     def setUp(self) -> None:
         self.organisation = OrganisationFactory(id=4444)
-        self.aidant = AidantFactory(is_superuser=True, is_staff=True)
+        self.aidant = AidantFactory(
+            email="thierry@thierry.com",
+            username="thierry@thierry.com",
+            is_superuser=True,
+            is_staff=True,
+        )
         self.aidant.set_password("laisser-passer-a38")
         self.aidant.save()
         device = self.aidant.staticdevice_set.create()

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -20,7 +20,7 @@ class CancelAutorisationTests(FunctionalTestCase):
     def test_aidant_can_login(self):
         self.open_live_url("/accounts/login/")
         login_field = self.selenium.find_element_by_id("id_email")
-        login_field.send_keys("thierry@thierry.com")
+        login_field.send_keys(self.aidant_thierry.email)
         otp_field = self.selenium.find_element_by_id("id_otp_token")
         otp_field.send_keys("123456")
         submit_button = self.selenium.find_element_by_xpath("//button")

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -17,7 +17,7 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 @tag("functional", "renew_mandat")
 class RenewMandatTests(FunctionalTestCase):
     def test_renew_mandat(self):
-        self.aidant = AidantFactory()
+        self.aidant = AidantFactory(email="thierry@thierry.com")
         device = self.aidant.staticdevice_set.create(id=1)
         device.token_set.create(token="123456")
         device.token_set.create(token="123455")

--- a/aidants_connect_web/tests/test_functional/test_usagers.py
+++ b/aidants_connect_web/tests/test_functional/test_usagers.py
@@ -10,7 +10,9 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 class UsagersTest(FunctionalTestCase):
     def setUp(self):
-        self.aidant = AidantFactory(post__with_otp_device=True)
+        self.aidant = AidantFactory(
+            email="thierry@thierry.com", post__with_otp_device=True
+        )
 
         self.usager_josephine = UsagerFactory(
             given_name="Joséphine", family_name="ST-PIERRE"

--- a/aidants_connect_web/tests/test_functional/test_use_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_use_autorisation.py
@@ -30,16 +30,10 @@ FC_URL_PARAMETERS = (
 @tag("functional", "id_provider")
 class UseAutorisationTests(FunctionalTestCase):
     def setUp(self):
-        self.aidant_1 = AidantFactory()
+        self.aidant_1 = AidantFactory(email="thierry@thierry.com")
         device = self.aidant_1.staticdevice_set.create(id=self.aidant_1.id)
         device.token_set.create(token="123456")
-        self.aidant_2 = AidantFactory(
-            username="jfremont@domain.user",
-            email="jfremont@domain.user",
-            password="motdepassedejacqueline",
-            first_name="Jacqueline",
-            last_name="Fremont",
-        )
+        self.aidant_2 = AidantFactory()
         self.usager_josephine = UsagerFactory(
             given_name="Joséphine", family_name="ST-PIERRE"
         )

--- a/aidants_connect_web/tests/test_functional/test_view_autorisations.py
+++ b/aidants_connect_web/tests/test_functional/test_view_autorisations.py
@@ -16,7 +16,7 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 @tag("functional")
 class ViewAutorisationsTests(FunctionalTestCase):
     def setUp(self):
-        self.aidant = AidantFactory()
+        self.aidant = AidantFactory(email="thierry@thierry.com")
         device = self.aidant.staticdevice_set.create(id=self.aidant.id)
         device.token_set.create(token="123456")
 

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -799,13 +799,6 @@ class AidantModelTests(TestCase):
         Aidant.objects.create(username="Marge", organisation=self.superuser_org)
         self.assertRaises(IntegrityError, Aidant.objects.create, username="Marge")
 
-    def test_aidant_fills_all_the_information(self):
-        self.assertEqual(len(Aidant.objects.all()), 0)
-        AidantFactory()
-        self.assertEqual(len(Aidant.objects.all()), 1)
-        AidantFactory()
-        self.assertEqual(len(Aidant.objects.all()), 2)
-
     def test_get_aidant_organisation(self):
         orga = OrganisationFactory(
             name="COMMUNE DE HOULBEC COCHEREL",

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -160,7 +160,7 @@ class MandatModelTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.organisation_1 = OrganisationFactory()
-        cls.aidant_1 = AidantFactory(username="aidants1@organisation1.com")
+        cls.aidant_1 = AidantFactory()
 
         cls.usager_1 = UsagerFactory()
         cls.mandat_1 = Mandat.objects.create(
@@ -515,8 +515,8 @@ class MandatModelTests(TestCase):
 class AutorisationModelTests(TestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.aidant_marge = AidantFactory(username="Marge")
-        cls.aidant_patricia = AidantFactory(username="Patricia")
+        cls.aidant_marge = AidantFactory()
+        cls.aidant_patricia = AidantFactory()
         cls.usager_homer = UsagerFactory()
         cls.usager_ned = UsagerFactory(family_name="Flanders", sub="nedflanders")
 
@@ -680,9 +680,9 @@ class OrganisationModelTests(TestCase):
     def test_deactivate_organisation(self):
         orga_one = OrganisationFactory(name="L'Internationale")
         orga_two = OrganisationFactory()
-        aidant_marge = AidantFactory(username="Marge", organisation=orga_one)
-        aidant_lisa = AidantFactory(username="Lisa", organisation=orga_one)
-        aidant_homer = AidantFactory(username="Homer", organisation=orga_two)
+        aidant_marge = AidantFactory(organisation=orga_one)
+        aidant_lisa = AidantFactory(organisation=orga_one)
+        aidant_homer = AidantFactory(organisation=orga_two)
 
         self.assertTrue(orga_one.is_active)
         self.assertTrue(orga_two.is_active)
@@ -801,9 +801,9 @@ class AidantModelTests(TestCase):
 
     def test_aidant_fills_all_the_information(self):
         self.assertEqual(len(Aidant.objects.all()), 0)
-        AidantFactory(username="bhameau@domain.user")
+        AidantFactory()
         self.assertEqual(len(Aidant.objects.all()), 1)
-        AidantFactory(username="cgireau@domain.user")
+        AidantFactory()
         self.assertEqual(len(Aidant.objects.all()), 2)
 
     def test_get_aidant_organisation(self):
@@ -812,12 +812,12 @@ class AidantModelTests(TestCase):
             siret=123,
             address="45 avenue du Général de Gaulle, 90210 Beverly Hills",
         )
-        aidant = AidantFactory(username="bhameau@domain.user", organisation=orga)
+        aidant = AidantFactory(organisation=orga)
         self.assertEqual(aidant.organisation.name, "COMMUNE DE HOULBEC COCHEREL")
 
     def test_get_active_aidants(self):
-        AidantFactory(username="Aidant actif")
-        AidantFactory(username="Aidant inactif", is_active=False)
+        AidantFactory()
+        AidantFactory(is_active=False)
         self.assertEqual(Aidant.objects.active().count(), 1)
 
 
@@ -826,17 +826,15 @@ class AidantModelMethodsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         # Aidants : Marge & Lisa belong to the same organisation, Patricia does not
-        cls.aidant_marge = AidantFactory(username="Marge", validated_cgu_version="0.1")
+        cls.aidant_marge = AidantFactory(validated_cgu_version="0.1")
         cls.aidant_lisa = AidantFactory(
-            username="Lisa",
             organisation=cls.aidant_marge.organisation,
             validated_cgu_version=settings.CGU_CURRENT_VERSION,
         )
-        cls.aidant_patricia = AidantFactory(username="Patricia")
+        cls.aidant_patricia = AidantFactory()
 
         # Juliette is responsible in the same structure as Marge & Lisa
         cls.respo_juliette = AidantFactory(
-            username="Juliette",
             organisation=cls.aidant_marge.organisation,
         )
         cls.respo_juliette.responsable_de.add(cls.aidant_marge.organisation)
@@ -1164,7 +1162,6 @@ class JournalModelTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.aidant_thierry = AidantFactory(
-            username="Thierry",
             email="thierry@thierry.com",
             first_name="Thierry",
             last_name="Martin",
@@ -1331,7 +1328,7 @@ class HabilitationRequestMethodTests(TestCase):
         self.assertEqual(db_hab_request.status, HabilitationRequest.STATUS_VALIDATED)
 
     def test_validate_if_aidant_already_exists(self):
-        aidant = AidantFactory(username="toto@titi.net", email="toto@titi.net")
+        aidant = AidantFactory()
         habilitation_request = HabilitationRequestFactory(
             status=HabilitationRequest.STATUS_PROCESSING, email=aidant.email
         )

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -17,15 +17,15 @@ class EspaceResponsableHomePageTests(TestCase):
     def setUpTestData(cls):
         cls.client = Client()
         # Tom is responsable of 2 structures
-        cls.responsable_tom = AidantFactory(username="tom@baie.fr")
+        cls.responsable_tom = AidantFactory()
         cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
         cls.responsable_tom.responsable_de.add(OrganisationFactory())
         cls.responsable_tom.can_create_mandats = False
         # Tim is responsable of only one structure
-        cls.responsable_tim = AidantFactory(username="tim@oree.fr")
+        cls.responsable_tim = AidantFactory()
         cls.responsable_tim.responsable_de.add(cls.responsable_tim.organisation)
         # John is a simple aidant
-        cls.aidant_john = AidantFactory(username="john@doe.du")
+        cls.aidant_john = AidantFactory()
 
     def test_anonymous_user_cannot_access_espace_aidant_view(self):
         response = self.client.get("/espace-responsable/")
@@ -92,7 +92,7 @@ class EspaceResponsableOrganisationPage(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.client = Client()
-        cls.responsable_tom = AidantFactory(username="georges@plop.net")
+        cls.responsable_tom = AidantFactory()
         cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
         cls.id_organisation = cls.responsable_tom.organisation.id
         cls.autre_organisation = OrganisationFactory()
@@ -130,18 +130,16 @@ class EspaceResponsableAidantPage(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.client = Client()
-        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom = AidantFactory()
         cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
-        cls.aidant_tim = AidantFactory(
-            username="tim@tim.fr", organisation=cls.responsable_tom.organisation
-        )
+        cls.aidant_tim = AidantFactory(organisation=cls.responsable_tom.organisation)
         cls.id_organisation = cls.responsable_tom.organisation.id
         cls.aidant_tim_url = (
             f"/espace-responsable/organisation/{cls.id_organisation}"
             f"/aidant/{cls.aidant_tim.id}/"
         )
         cls.autre_organisation = OrganisationFactory()
-        cls.autre_aidant = AidantFactory(username="random@random.net")
+        cls.autre_aidant = AidantFactory()
 
     def test_espace_responsable_aidant_url_triggers_the_right_view(self):
         self.client.force_login(self.responsable_tom)
@@ -179,7 +177,7 @@ class EspaceResponsableAddAidant(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.client = Client()
-        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom = AidantFactory()
         cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
 
         cls.id_organisation = cls.responsable_tom.organisation.id

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
@@ -17,7 +17,7 @@ class HabilitationRequestsTests(TestCase):
     def setUpTestData(cls):
         cls.client = Client()
         # Tom is responsable of organisations A and B
-        cls.responsable_tom = AidantFactory(username="tom@baie.fr")
+        cls.responsable_tom = AidantFactory()
         cls.org_a = cls.responsable_tom.organisation
         cls.org_b = OrganisationFactory(name="B")
         cls.responsable_tom.responsable_de.add(cls.org_a)
@@ -162,13 +162,13 @@ class HabilitationRequestsTests(TestCase):
     def test_submitting_habilitation_request_if_aidant_already_exists(self):
         self.client.force_login(self.responsable_tom)
 
-        AidantFactory(organisation=self.org_a, email="b@b.fr", username="b@b.fr")
+        existing_aidant = AidantFactory(organisation=self.org_a)
 
         response = self.client.post(
             self.add_aidant_url,
             data={
                 "organisation": self.org_b.id,
-                "email": "b@b.fr",
+                "email": existing_aidant.email,
                 "first_name": "Bob",
                 "last_name": "Dubois",
                 "profession": "Assistant social",
@@ -216,15 +216,13 @@ class HabilitationRequestsTests(TestCase):
     def test_avoid_oracle_for_other_organisations_aidants(self):
         self.client.force_login(self.responsable_tom)
 
-        AidantFactory(
-            organisation=OrganisationFactory(), email="b@b.fr", username="b@b.fr"
-        )
+        other_aidant = AidantFactory()
 
         response = self.client.post(
             self.add_aidant_url,
             data={
                 "organisation": self.org_a.id,
-                "email": "b@b.fr",
+                "email": other_aidant.email,
                 "first_name": "Bob",
                 "last_name": "Dubois",
                 "profession": "Assistant social",
@@ -241,7 +239,7 @@ class HabilitationRequestsTests(TestCase):
             "Confirmation message should be displayed.",
         )
         self.assertIn(
-            "b@b.fr",
+            other_aidant.email,
             response_content,
             "New habilitation request should be displayed on organisation page.",
         )

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -33,9 +33,7 @@ class AuthorizeTests(TestCase):
     def setUpTestData(cls):
         cls.client = Client()
         cls.aidant_thierry = AidantFactory()
-        cls.aidant_jacques = AidantFactory(
-            username="jacques@domain.user", email="jacques@domain.user"
-        )
+        cls.aidant_jacques = AidantFactory()
         cls.usager = UsagerFactory(given_name="Joséphine", sub="123")
 
         mandat_1 = MandatFactory(
@@ -252,7 +250,6 @@ class FISelectDemarcheTests(TestCase):
         cls.client = Client()
         cls.aidant_thierry = AidantFactory()
         cls.aidant_yasmina = AidantFactory(
-            username="yasmina@yasmina.com",
             organisation=cls.aidant_thierry.organisation,
         )
         cls.usager = UsagerFactory(given_name="Joséphine")


### PR DESCRIPTION
## 🌮 Objectif

- Pouvoir utiliser `AidantFactory` sans devoir fournir manuellement un `username` à chaque fois que l'on veut créer > 1 aidant.
- Augmenter la lisibilité des tests en allégeant leur contenu.

## 🔍 Implémentation

- Utilisation de factory.Faker("email") pour les champs username et email.
- On fixe le username à `thierry@thierry.com` là où on veut utiliser la méthode `aidant_login`.
- On supprime l'utilisation de `username=` à divers endroits des tests.