### PR TITLE
Désactivation de la collecte des numéros de téléphone usagers sur le mandats à distance

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -182,15 +182,16 @@ class MandatForm(forms.Form):
     def clean(self):
         cleaned = super().clean()
 
-        user_phone = cleaned.get("user_phone", None)
-        if user_phone is not None and cleaned["is_remote"] and len(user_phone) == 0:
-            self.add_error(
-                "user_phone",
-                _(
-                    "Un numéro de téléphone est obligatoire "
-                    "si le mandat est signé à distance."
-                ),
-            )
+        # TODO: Reactivate when SMS consent is a thing
+        # user_phone = cleaned.get("user_phone")
+        # if user_phone is not None and cleaned["is_remote"] and len(user_phone) == 0:
+        #     self.add_error(
+        #         "user_phone",
+        #         _(
+        #             "Un numéro de téléphone est obligatoire "
+        #             "si le mandat est signé à distance."
+        #         ),
+        #     )
 
         return cleaned
 

--- a/aidants_connect_web/static/js/new_mandat.js
+++ b/aidants_connect_web/static/js/new_mandat.js
@@ -8,6 +8,8 @@
         }
 
         function toggle_phone_number_panel(checked) {
+            // TODO: Reactivate when SMS consent is a thing
+            return;
             let phone_number_panel = document.getElementById("phone_number_panel");
 
             if(checked) {

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -232,17 +232,18 @@ class MandatFormTests(TestCase):
             form_3.errors["duree"], ["Veuillez sélectionner la durée du mandat."]
         )
 
-        form_4 = MandatForm(
-            data={"demarche": ["travail"], "duree": "SHORT", "is_remote": True}
-        )
-        self.assertFalse(form_4.is_valid())
-        self.assertEqual(
-            form_4.errors["user_phone"],
-            [
-                "Un numéro de téléphone est obligatoire si "
-                "le mandat est signé à distance."
-            ],
-        )
+        # TODO: Reactivate when SMS consent is a thing
+        # form_4 = MandatForm(
+        #     data={"demarche": ["travail"], "duree": "SHORT", "is_remote": True}
+        # )
+        # self.assertFalse(form_4.is_valid())
+        # self.assertEqual(
+        #     form_4.errors["user_phone"],
+        #     [
+        #         "Un numéro de téléphone est obligatoire si "
+        #         "le mandat est signé à distance."
+        #     ],
+        # )
 
     def test_non_existing_demarche_triggers_error(self):
         form = MandatForm(data={"demarche": ["test"], "duree": "16"})

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -1,4 +1,5 @@
 import time
+from unittest import skip
 
 from django.conf import settings
 from django.test import tag
@@ -125,6 +126,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         ].find_elements_by_css_selector("tbody tr")
         self.assertEqual(len(active_mandats_after), 2)
 
+    @skip("Reactivate when SMS consent is a thing")
     def test_create_new_remote_mandat(self):
         wait = WebDriverWait(self.selenium, 10)
 

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -85,7 +85,9 @@ class NewMandatTests(TestCase):
             "is_remote": True,
         }
         response = self.client.post("/creation_mandat/", data=data)
-        self.assertEqual(response.status_code, 200)
+        # TODO: Reactivate when SMS consent is a thing
+        # self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
 
         data["user_phone"] = self.phone_number
         response = self.client.post("/creation_mandat/", data=data)


### PR DESCRIPTION
## 🌮 Objectif

Puisqu'il est impossible d'utiliser le service de SMS OVH pour le moment, la collecte des numéros de téléphone sur les mandats à distance est inutile. Cette PR la désactive pour le moment.

