### PR TITLE
Renforcement de la fiabilité du test fonctionnel 'test_cancel_autorisation'

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -65,7 +65,10 @@
               </thead>
               <tbody>
                 {% for autorisation in mandat.autorisations.all %}
-                  <tr id="active-mandat-autorisation-row">
+                  <tr
+                    id="active-mandat-autorisation-{{ autorisation.demarche }}"
+                    class="active-mandat-autorisation-row"
+                  >
                     <td>{{ autorisation.demarche }}</td>
                     <td>
                       {% if not autorisation.revocation_date %}
@@ -143,7 +146,10 @@
               </thead>
               <tbody>
                 {% for autorisation in mandat.autorisations.all %}
-                  <tr id="inactive-mandat-autorisation-row">
+                  <tr
+                    id="inactive-mandat-autorisation-{{ autorisation.demarche }}"
+                    class="inactive-mandat-autorisation-row"
+                  >
                     <td>{{ autorisation.demarche }}</td>
                     <td>
                       {% if not autorisation.revocation_date %}

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -55,7 +55,7 @@ class CancelAutorisationTests(FunctionalTestCase):
         # See all mandats of usager page
         active_mandats_before = self.selenium.find_elements_by_id("active-mandat-panel")
         self.assertEqual(len(active_mandats_before), 1)
-        active_mandats_autorisations_before = self.selenium.find_elements_by_id(
+        active_mandats_autorisations_before = self.selenium.find_elements_by_class_name(
             "active-mandat-autorisation-row"
         )
         self.assertEqual(len(active_mandats_autorisations_before), 2)
@@ -100,11 +100,16 @@ class CancelAutorisationTests(FunctionalTestCase):
             "active-mandat-panel"
         )
         self.assertEqual(len(active_autorisations_after), 1)
-        active_mandats_autorisations_after = self.selenium.find_elements_by_id(
+
+        active_mandats_autorisations_after = self.selenium.find_elements_by_class_name(
             "active-mandat-autorisation-row"
         )
+        revoked_mandat_autorisation_after = self.selenium.find_element_by_id(
+            f"active-mandat-autorisation-{self.money_authorization.demarche}"
+        )
+
         self.assertEqual(len(active_mandats_autorisations_after), 2)
-        self.assertIn("Révoqué", active_mandats_autorisations_after[0].text)
+        self.assertIn("Révoqué", revoked_mandat_autorisation_after.text)
 
         auth_revocation_attestation_button = (
             self.selenium.find_elements_by_css_selector(
@@ -119,9 +124,9 @@ class CancelAutorisationTests(FunctionalTestCase):
         self.assertEqual(last_journal_entry.action, "cancel_autorisation")
 
         # Cancel second autorisation
-        cancel_mandat_autorisation_button = active_mandats_autorisations_after[
-            1
-        ].find_element_by_tag_name("a")
+        cancel_mandat_autorisation_button = self.selenium.find_element_by_id(
+            f"active-mandat-autorisation-{self.family_authorization.demarche}"
+        ).find_element_by_tag_name("a")
         cancel_mandat_autorisation_button.click()
 
         # Confirm cancellation
@@ -142,8 +147,10 @@ class CancelAutorisationTests(FunctionalTestCase):
             "inactive-mandat-panel"
         )
         self.assertEqual(len(inactive_autorisations_after), 1)
-        inactive_mandats_autorisations_after = self.selenium.find_elements_by_id(
-            "inactive-mandat-autorisation-row"
+        inactive_mandats_autorisations_after = (
+            self.selenium.find_elements_by_class_name(
+                "inactive-mandat-autorisation-row"
+            )
         )
         self.assertEqual(len(inactive_mandats_autorisations_after), 2)
         self.assertIn("Révoqué", inactive_mandats_autorisations_after[0].text)

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -88,8 +88,10 @@ class CancelAutorisationTests(FunctionalTestCase):
 
         inactive_mandats = self.selenium.find_elements_by_id("inactive-mandat-panel")
         self.assertEqual(len(inactive_mandats), 1)
-        inactive_mandats_autorisations_after = self.selenium.find_elements_by_id(
-            "inactive-mandat-autorisation-row"
+        inactive_mandats_autorisations_after = (
+            self.selenium.find_elements_by_class_name(
+                "inactive-mandat-autorisation-row"
+            )
         )
         self.assertEqual(len(inactive_mandats_autorisations_after), 2)
         self.assertIn("Révoqué", inactive_mandats_autorisations_after[0].text)


### PR DESCRIPTION
## 🌮 Objectif

Le test fonctionnel `test_cancel_autorisation` [semble parfois échouer sans raison apparante](https://app.circleci.com/pipelines/github/betagouv/Aidants_Connect/2535/workflows/e9c0044a-514c-4709-b2c8-aaaa82835d1f/jobs/2533). Je pense que c'est lié à la manière de sélectionner certains nœuds HTML dans la page web qui est paresseuse (on sélectionne l'ensemble des nœuds d'une classe et on vérifie le texte présent dans le premier).

Si, pour une raison ou une autre, l'un de ces nœuds s'affiche une nanoseconde trop tard, ou qu'ils ne sont pas triés dans le même ordre d'un exécution à l'autre, le test échouera pour de mauvaises raison.

Cette PR introduit une sélection des nœuds plus stricte dans le test.