### PR TITLE
Utilisation d'un Django Form pour le changement d'organisation active

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -270,6 +270,23 @@ class RemoveCardFromAidantForm(forms.Form):
     other_reason = forms.CharField(required=False)
 
 
+class SwitchMainAidantOrganisationForm(forms.Form):
+    organisation = forms.ModelChoiceField(
+        queryset=Organisation.objects.none(),
+        widget=forms.RadioSelect,
+    )
+    next_url = forms.CharField(required=False)
+
+    def __init__(self, aidant: Aidant, next_url="", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aidant = aidant
+        self.fields["organisation"].queryset = Organisation.objects.filter(
+            aidants=self.aidant
+        ).order_by("name")
+        self.initial["organisation"] = self.aidant.organisation
+        self.initial["next_url"] = next_url
+
+
 class AddOrganisationResponsableForm(forms.Form):
     candidate = forms.ModelChoiceField(queryset=Aidant.objects.none())
 

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/switch_main_organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/switch_main_organisation.html
@@ -29,23 +29,23 @@
         </p>
         <fieldset class="grid">
           <legend class="sr-only">Choisir une nouvelle organisation active</legend>
-          {% for organisation in aidant.organisations.all %}
+          {% for value, label in form.organisation.field.choices %}
             <div class="tile">
               <input
-                  id="organisation-{{ organisation.id }}"
+                  id="organisation_{{ value }}"
                   type="radio"
-                  value="{{ organisation.id }}"
+                  value="{{ value }}"
                   name="organisation"
                   class="sr-only"
-                  {% if organisation.id == aidant.organisation.id %}checked{% endif %}
+                  {% if value == aidant.organisation.id %}checked{% endif %}
               />
-              <label class="organisation-label" for="organisation-{{ organisation.id }}">
-                <strong>{{ organisation.name }}</strong>
-                <span>{{ organisation.address }}</span>
+              <label class="organisation-label" for="organisation_{{ value }}">
+                <strong>{{ label }}</strong>
+                <span>{{ value.instance.address }}</span>
               </label>
             </div>
           {% endfor %}
-          <input name="next" value="{{ next_url }}" hidden>
+          {{ form.next_url.as_hidden }}
         </fieldset>
 
         <input

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
@@ -84,8 +84,8 @@
                 <legend>
                   Cochez la ou les organisations auxquelles rattacher {{ aidant }}.
                   Cela lui permettra de créer des mandats en leur nom.
-                  {% if form.errors.organisations %}
-                    {{ form.errors.organisations }}
+                  {% if orga_form.errors.organisations %}
+                    {{ orga_form.errors.organisations }}
                   {% endif %}
                 </legend>
                 <ul class="grid checkbox-list small-checkboxes">

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -109,7 +109,7 @@ class SwitchOrganisationTests(TestCase):
         )
         self.assertRedirects(response, self.url, fetch_redirect_response=False)
         response = self.client.get(self.url)
-        self.assertContains(response, "Il est impossible de vous assigner")
+        self.assertContains(response, "Il est impossible")
         aidant.refresh_from_db()
         self.assertEqual(aidant.organisation.id, orgas[0].id)
 
@@ -126,7 +126,7 @@ class SwitchOrganisationTests(TestCase):
         )
         self.assertRedirects(response, self.url, fetch_redirect_response=False)
         response = self.client.get(self.url)
-        self.assertContains(response, "Il est impossible de vous assigner")
+        self.assertContains(response, "Il est impossible")
         self.assertNotContains(response, unrelated_org.name)
         aidant.refresh_from_db()
         self.assertEqual(aidant.organisation.id, orgas[0].id)


### PR DESCRIPTION
## 🌮 Objectif

Améliorer la lisibilité du code en ne nécessitant pas d'aller voir le template pour savoir à quoi s'attendre dans le post.

## 🔍 Implémentation

- Utilisation d'un form Django

## 🏕 Amélioration continue

- La redirection vers `next` ne fonctionnait pas, c'est réparé
- J'ai réparé un autre truc qui n'avait rien à voir dans le formulaire pour rattacher les aidants à plusieurs organisations
