### PR TITLE
Modification import automatique des demandes d'habilitation

### DIFF
--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -7,7 +7,10 @@ from aidants_connect_web.models import (
     OrganisationType,
 )
 from aidants_connect_web.views import datapass
-from aidants_connect_web.tests.factories import OrganisationFactory
+from aidants_connect_web.tests.factories import (
+    HabilitationRequestFactory,
+    OrganisationFactory,
+)
 from django.urls import resolve
 
 
@@ -116,6 +119,15 @@ class HabilitationDatapass(DatapassMixin, TestCase):
     def test_datapass_url_triggers_the_good_view(self):
         found = resolve(self.datapass_url)
         self.assertEqual(found.func, datapass.habilitation_receiver)
+
+    def test_datapass_dont_recreate_habilitation_request(self):
+        HabilitationRequestFactory(
+            organisation=self.organisation, email="mario.brossse@world.fr"
+        )
+        self.assertEqual(HabilitationRequest.objects.count(), 1)
+        response = self.datapass_request(data=self.good_data_from_datapass)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(HabilitationRequest.objects.count(), 1)
 
     def test_message_body_can_create_habilitation_request(self):
         self.assertEqual(HabilitationRequest.objects.count(), 0)


### PR DESCRIPTION
## 🌮 Objectif

L'appel au endpoint de création des demandes d'habilitation pouvait créer des demandes en doublons dans le cas où on l'appelle plusieurs fois. Cette PR corrige cela

## 🔍 Implémentation

vérification de l'existence d'une demande d'habilitation avant de la création de celle-ci. 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
