### PR TITLE
Interface pour permettre à un responsable de retirer un aidant d'un organisation

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -335,9 +335,7 @@ class Aidant(AbstractUser):
         except CarteTOTP.DoesNotExist:
             return False
 
-    def remove_user_from_organisation(
-        self, organisation: Organisation
-    ) -> Optional[bool]:
+    def remove_from_organisation(self, organisation: Organisation) -> Optional[bool]:
         if self.organisations.filter(pk=organisation.id).count() == 0:
             return None
 
@@ -347,9 +345,9 @@ class Aidant(AbstractUser):
 
             return self.is_active
 
-        self.organisations.remove(self.organisation)
+        self.organisations.remove(organisation)
         if self.organisations.filter(pk=self.organisation.id).count() == 0:
-            self.organisation = self.organisations.first()
+            self.organisation = self.organisations.order_by("id").first()
             self.save()
 
         return self.is_active

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -335,6 +335,25 @@ class Aidant(AbstractUser):
         except CarteTOTP.DoesNotExist:
             return False
 
+    def remove_user_from_organisation(
+        self, organisation: Organisation
+    ) -> Optional[bool]:
+        if self.organisations.filter(pk=organisation.id).count() == 0:
+            return None
+
+        if self.organisations.count() == 1:
+            self.is_active = False
+            self.save()
+
+            return self.is_active
+
+        self.organisations.remove(self.organisation)
+        if self.organisations.filter(pk=self.organisation.id).count() == 0:
+            self.organisation = self.organisations.first()
+            self.save()
+
+        return self.is_active
+
 
 class HabilitationRequest(models.Model):
     STATUS_NEW = "new"

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -346,7 +346,7 @@ class Aidant(AbstractUser):
             return self.is_active
 
         self.organisations.remove(organisation)
-        if self.organisations.filter(pk=self.organisation.id).count() == 0:
+        if self.organisation not in self.organisations.all():
             self.organisation = self.organisations.order_by("id").first()
             self.save()
 

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/confirm-remove-aidant-from-organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/confirm-remove-aidant-from-organisation.html
@@ -43,7 +43,7 @@
             mesure d'effectuer des démarches pour le compte d'autre personnes au sein de cette organisation.
             {% else %}
             Vous aller désactiver le profil de {{ aidant.get_full_name }}. Cette personne ne sera plus en mesure de
-            se connecter au portail Aidant Connect tant que son profil n'aura pas été réactivé.
+            se connecter au portail Aidants Connect tant que son profil n'aura pas été réactivé.
             {% endif %}
           </p>
           <a

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/confirm-remove-aidant-from-organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/confirm-remove-aidant-from-organisation.html
@@ -1,0 +1,60 @@
+{% extends 'layouts/main.html' %}
+
+{% load static ac_extras %}
+
+{% linebreakless %}
+  {% block title %}
+    Aidants Connect -
+    {% if aidant.organisations|length > 1 %}
+      Retirer l'aidant de {{ organisation.name }}
+    {% else %}
+      Désactiver l'aidant
+    {% endif %}
+  {% endblock %}
+{% endlinebreakless %}
+
+{% block extracss %}
+  <link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+  <section class="section">
+    <div class="container">
+      {% if messages %}
+        {% for message in messages %}
+          <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+      <form method="post">
+        {% csrf_token %}
+        <div class="form__group">
+          {% linebreakless %}
+            <h1>
+              {% if aidant.organisations|length > 1 %}
+                Retirer {{ aidant.get_full_name }} de {{ organisation.name }}
+              {% else %}
+                Désactiver le profil de {{ aidant.get_full_name }}
+              {% endif %}
+            </h1>
+          {% endlinebreakless %}
+          <p>
+            {% if aidant.organisations|length > 1 %}
+            Vous allez retirer {{ aidant.get_full_name }} de {{ organisation.name }}. Cette personne ne sera plus en
+            mesure d'effectuer des démarches pour le compte d'autre personnes au sein de cette organisation.
+            {% else %}
+            Vous aller désactiver le profil de {{ aidant.get_full_name }}. Cette personne ne sera plus en mesure de
+            se connecter au portail Aidant Connect tant que son profil n'aura pas été réactivé.
+            {% endif %}
+          </p>
+          <a
+            href="{% url 'espace_responsable_organisation' organisation_id=organisation.id %}"
+            class="button"
+          >
+            Annuler
+          </a>
+          <button class="button warning float-right" type="submit">Confirmer</button>
+        </div>
+      </form>
+    </div>
+  </section>
+{% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -78,10 +78,21 @@
 
                     {% endif %}
                   {% else %}
-                    <a href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}"
-                       class="button">Lier une carte</a>
+                    <a href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}" class="button">
+                      Lier une carte
+                    </a>
                   {% endif %}
                 {% endwith %}
+                <a
+                  href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
+                  class="button warning"
+                >
+                  {% if aidant.organisations|length > 1 %}
+                    Retirer l'aidant de {{ organisation.name }}
+                  {% else %}
+                    Désactiver l'aidant
+                  {% endif %}
+                </a>
               </td>
             </tr>
           {% endfor %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -85,11 +85,11 @@
                 {% endwith %}
                 {% if aidant.id != responsable.id and aidant.is_active %}
                   <a
-                  id="remove-aidant-{{ aidant.id }}-from-organisation"
-                  href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
-                  class="button warning"
+                    id="remove-aidant-{{ aidant.id }}-from-organisation"
+                    href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
+                    class="button warning"
                   >
-                    {% if aidant.organisations.all|length > 1 %}
+                    {% if aidant.organisations.count > 1 %}
                       Retirer l'aidant de {{ organisation.name }}
                     {% else %}
                       Désactiver l'aidant

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -83,16 +83,19 @@
                     </a>
                   {% endif %}
                 {% endwith %}
-                <a
+                {% if aidant.id != responsable.id and aidant.is_active %}
+                  <a
+                  id="remove-aidant-{{ aidant.id }}-from-organisation"
                   href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
                   class="button warning"
-                >
-                  {% if aidant.organisations|length > 1 %}
-                    Retirer l'aidant de {{ organisation.name }}
-                  {% else %}
-                    Désactiver l'aidant
-                  {% endif %}
-                </a>
+                  >
+                    {% if aidant.organisations.all|length > 1 %}
+                      Retirer l'aidant de {{ organisation.name }}
+                    {% else %}
+                      Désactiver l'aidant
+                    {% endif %}
+                  </a>
+                {% endif %}
               </td>
             </tr>
           {% endfor %}

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -63,10 +63,14 @@ class AidantFactory(factory.DjangoModelFactory):
 
     @factory.post_generation
     def post(self, create, _, **kwargs):
-        if not create or not kwargs.get("with_otp_device", False):
+        if not create:
             return
-        device = self.staticdevice_set.create(id=self.id)
-        device.token_set.create(token="123456")
+        if kwargs.get("with_otp_device", False):
+            device = self.staticdevice_set.create(id=self.id)
+            device.token_set.create(token="123456")
+
+        if kwargs.get("is_organisation_manager", False):
+            self.responsable_de.add(self.organisation)
 
 
 class HabilitationRequestFactory(factory.DjangoModelFactory):

--- a/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
+++ b/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
@@ -1,0 +1,114 @@
+from django.test import tag
+from django.urls import reverse
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.support.expected_conditions import url_matches
+from selenium.webdriver.support.wait import WebDriverWait
+
+from aidants_connect_web.models import Aidant
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    OrganisationFactory,
+)
+from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
+from aidants_connect_web.tests.test_functional.utilities import login_aidant
+
+
+@tag("functional")
+class ViewAutorisationsTests(FunctionalTestCase):
+    def setUp(self):
+        self.organisation = OrganisationFactory()
+        self.aidant_responsable: Aidant = AidantFactory(
+            organisation=self.organisation,
+            post__with_otp_device=True,
+            post__is_organisation_manager=True,
+        )
+
+        self.aidant_with_multiple_orgs = AidantFactory(organisation=self.organisation)
+        self.aidant_with_multiple_orgs.organisations.add(
+            OrganisationFactory(),
+            OrganisationFactory(),
+        )
+
+        self.aidant_with_one_org = AidantFactory(organisation=self.organisation)
+
+    def __get_live_url(self, organisation_id: int):
+        return reverse(
+            "espace_responsable_organisation",
+            kwargs={"organisation_id": organisation_id},
+        )
+
+    def test_grouped_autorisations(self):
+        wait = WebDriverWait(self.selenium, 10)
+        root_path = self.__get_live_url(self.organisation.id)
+
+        self.open_live_url(root_path)
+
+        # Login
+        login_aidant(self, self.aidant_responsable.email)
+        wait.until(url_matches(f"^.+{root_path}$"))
+
+        # Check button text
+        button = self.selenium.find_element_by_id(
+            f"remove-aidant-{self.aidant_with_multiple_orgs.id}-from-organisation"
+        )
+        self.assertEqual(
+            f"Retirer l'aidant de {self.organisation.name}",
+            button.text,
+        )
+
+        button = self.selenium.find_element_by_id(
+            f"remove-aidant-{self.aidant_with_one_org.id}-from-organisation"
+        )
+        self.assertEqual("Désactiver l'aidant", button.text)
+
+        with self.assertRaises(NoSuchElementException):
+            self.selenium.find_element_by_id(
+                f"remove-aidant-{self.aidant_responsable.id}-from-organisation"
+            )
+
+        # Let's try those btns shall we?
+        button.click()
+        path = reverse(
+            "espace_responsable_remove_aidant_from_organisation",
+            kwargs={
+                "organisation_id": self.organisation.id,
+                "aidant_id": self.aidant_with_one_org.id,
+            },
+        )
+        wait.until(url_matches(f"^.+{path}$"))
+
+        self.selenium.find_element_by_xpath(
+            "//button[@type='submit' and normalize-space(text())='Confirmer']"
+        ).click()
+
+        wait.until(url_matches(f"^.+{root_path}$"))
+
+        with self.assertRaises(NoSuchElementException):
+            self.selenium.find_element_by_id(
+                f"remove-aidant-{self.aidant_with_one_org.id}-from-organisation"
+            )
+
+        self.selenium.find_element_by_id(
+            f"remove-aidant-{self.aidant_with_multiple_orgs.id}-from-organisation"
+        ).click()
+        path = reverse(
+            "espace_responsable_remove_aidant_from_organisation",
+            kwargs={
+                "organisation_id": self.organisation.id,
+                "aidant_id": self.aidant_with_multiple_orgs.id,
+            },
+        )
+        wait.until(url_matches(f"^.+{path}$"))
+
+        self.selenium.find_element_by_xpath(
+            "//button[@type='submit' and normalize-space(text())='Confirmer']"
+        ).click()
+
+        wait.until(url_matches(f"^.+{root_path}$"))
+
+        with self.assertRaises(NoSuchElementException):
+            self.selenium.find_element_by_id(
+                f"remove-aidant-{self.aidant_with_multiple_orgs.id}-from-organisation"
+            )
+
+        pass

--- a/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
+++ b/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
@@ -14,7 +14,7 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 
 @tag("functional")
-class ViewAutorisationsTests(FunctionalTestCase):
+class RemoveAidantFromOrganisationTests(FunctionalTestCase):
     def setUp(self):
         self.organisation = OrganisationFactory()
         self.aidant_responsable: Aidant = AidantFactory(

--- a/aidants_connect_web/tests/test_functional/utilities.py
+++ b/aidants_connect_web/tests/test_functional/utilities.py
@@ -1,9 +1,9 @@
 from django.core import mail
 
 
-def login_aidant(self):
+def login_aidant(self, aidant_email: str = "thierry@thierry.com"):
     login_field = self.selenium.find_element_by_id("id_email")
-    login_field.send_keys("thierry@thierry.com")
+    login_field.send_keys(aidant_email)
     otp_field = self.selenium.find_element_by_id("id_otp_token")
     otp_field.send_keys("123456")
     submit_button = self.selenium.find_element_by_xpath("//button")

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1416,8 +1416,8 @@ class HabilitationRequestMethodTests(TestCase):
         aidant.remove_from_organisation(supplementary_organisation_1)
         self.assertTrue(
             aidant.is_active,
-            "L'aidant n'est actif après la tentative de suppression d'une organisation "
-            "surnuméraire",
+            "L'aidant n'est plus actif après la tentative de suppression d'une "
+            "organisation surnuméraire",
         )
         self.assertSequenceEqual(
             [organisation, supplementary_organisation_2],
@@ -1437,8 +1437,8 @@ class HabilitationRequestMethodTests(TestCase):
         aidant.remove_from_organisation(organisation)
         self.assertTrue(
             aidant.is_active,
-            "L'aidant n'est actif après la tentative de suppression d'une organisation "
-            "surnuméraire",
+            "L'aidant n'est plus actif après la tentative de suppression d'une "
+            "organisation surnuméraire",
         )
         self.assertSequenceEqual(
             [supplementary_organisation_1, supplementary_organisation_2],
@@ -1447,6 +1447,6 @@ class HabilitationRequestMethodTests(TestCase):
         self.assertEqual(
             supplementary_organisation_1,
             aidant.organisation,
-            "L'orgnisation principale de l'aidant n'a pas été remplacé par une "
+            "L'organisation principale de l'aidant n'a pas été remplacée par une "
             "organisation valide après que l'aidant en a été retiré",
         )

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -142,22 +142,30 @@ urlpatterns = [
         name="espace_responsable_aidant_new",
     ),
     path(
-        ("espace-responsable/aidant/<int:aidant_id>/supprimer-carte/"),
+        "espace-responsable/aidant/<int:aidant_id>/supprimer-carte/",
         espace_responsable.remove_card_from_aidant,
         name="espace_responsable_aidant_remove_card",
     ),
     path(
-        ("espace-responsable/aidant/<int:aidant_id>/changer-organisations/"),
+        "espace-responsable/aidant/<int:aidant_id>/changer-organisations/",
         espace_responsable.change_aidant_organisations,
         name="espace_responsable_aidant_change_organisations",
     ),
     path(
-        ("espace-responsable/aidant/<int:aidant_id>/lier-carte"),
+        (
+            "espace-responsable/aidant/<int:aidant_id>/"
+            "supprimer-organisation/<int:organisation_id>/"
+        ),
+        espace_responsable.remove_aidant_from_organisation,
+        name="espace_responsable_remove_aidant_from_organisation",
+    ),
+    path(
+        "espace-responsable/aidant/<int:aidant_id>/lier-carte",
         espace_responsable.associate_aidant_carte_totp,
         name="espace_responsable_associate_totp",
     ),
     path(
-        ("espace-responsable/aidant/<int:aidant_id>/valider-carte"),
+        "espace-responsable/aidant/<int:aidant_id>/valider-carte",
         espace_responsable.validate_aidant_carte_totp,
         name="espace_responsable_validate_totp",
     ),

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -229,14 +229,7 @@ def remove_aidant_from_organisation(
     organisation: Organisation = get_object_or_404(Organisation, pk=organisation_id)
 
     if not responsable.can_see_aidant(aidant):
-        django_messages.error(
-            request,
-            f"L'aidant ou aidante avec l'identifiant numéro {aidant_id} ne fait pas "
-            f"partie de {organisation.name}",
-        )
-        return redirect(
-            "espace_responsable_organisation", organisation_id=organisation.id
-        )
+        raise Http404()
 
     if request.method == "GET":
         return render(

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,7 +1,9 @@
+from typing import Collection
+
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
-from django.http import Http404
+from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.views.decorators.http import require_http_methods, require_GET, require_POST
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -60,14 +62,15 @@ def home(request):
 @login_required
 @user_is_responsable_structure
 @activity_required
-def organisation(request, organisation_id):
+def organisation(request: HttpRequest, organisation_id: int):
     responsable: Aidant = request.user
-    organisation = get_object_or_404(Organisation, pk=organisation_id)
+    organisation: Organisation = get_object_or_404(Organisation, pk=organisation_id)
     check_organisation_and_responsable(responsable, organisation)
 
-    aidants = organisation.aidants.order_by("-is_active", "last_name").prefetch_related(
-        "carte_totp"
-    )
+    aidants: Collection[Aidant] = organisation.aidants.order_by(
+        "-is_active", "last_name"
+    ).prefetch_related("carte_totp")
+
     habilitation_requests = organisation.habilitation_requests.exclude(
         status=HabilitationRequest.STATUS_VALIDATED
     ).order_by("status", "last_name")
@@ -212,6 +215,50 @@ def remove_card_from_aidant(request, aidant_id):
         "espace_responsable_aidant",
         aidant_id=aidant.id,
     )
+
+
+@require_http_methods(["GET", "POST"])
+@login_required
+@user_is_responsable_structure
+@activity_required
+def remove_aidant_from_organisation(
+    request: HttpRequest, aidant_id: int, organisation_id: int
+) -> HttpResponse:
+    responsable: Aidant = request.user
+    aidant: Aidant = get_object_or_404(Aidant, pk=aidant_id)
+    organisation: Organisation = get_object_or_404(Organisation, pk=organisation_id)
+
+    if not responsable.can_see_aidant(aidant):
+        django_messages.error(
+            request,
+            f"L'aidant ou aidante avec l'identifiant numéro {aidant_id} ne fait pas "
+            f"partie de {organisation.name}",
+        )
+        return redirect(
+            "espace_responsable_organisation", organisation_id=organisation.id
+        )
+
+    if request.method == "GET":
+        return render(
+            request,
+            "aidants_connect_web/espace_responsable/"
+            "confirm-remove-aidant-from-organisation.html",
+            {"aidant": aidant, "organisation": organisation},
+        )
+
+    result = aidant.remove_user_from_organisation(organisation)
+    if result is True:
+        django_messages.success(
+            request,
+            f"{aidant.get_full_name()} ne fait maintenant plus partie de "
+            f"{organisation.name}",
+        )
+    else:
+        django_messages.success(
+            request, f"Le profil de {aidant.get_full_name()} a été désactivé"
+        )
+
+    return redirect("espace_responsable_organisation", organisation_id=organisation.id)
 
 
 @require_POST

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -246,7 +246,7 @@ def remove_aidant_from_organisation(
             {"aidant": aidant, "organisation": organisation},
         )
 
-    result = aidant.remove_user_from_organisation(organisation)
+    result = aidant.remove_from_organisation(organisation)
     if result is True:
         django_messages.success(
             request,


### PR DESCRIPTION
## 🌮 Objectif

Implémentation d'une interface pour permettre à un responsable de retirer un aidant ou une aidante d'une organisation, alternativement, de désactiver le profil si l'organisation est la seule à laquelle appartient la personne.

## 🏕 Amélioration continue

- Retrait de parenthèses redondantes dans `urls.py`

## 🖼️ Images

![](https://user-images.githubusercontent.com/22097904/141968038-4efecddd-fb3a-47e6-96f9-5ddf443c82c0.png)
![](https://user-images.githubusercontent.com/22097904/141968042-51afb109-794a-4ec9-8f8c-07b7135d6aa4.png)

Lorsqu'un aidant est désactivé, il ne disparaît pas. Il faudra régler ça dans une autre PR.

![](https://user-images.githubusercontent.com/22097904/141968044-c38909ad-d399-4c9c-ac68-8b76b880f292.png)

