### PR TITLE
Ajout d'un filtre pour détecter les organisations sans id datapass

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -205,6 +205,24 @@ class OrganisationRegionFilter(RegionFilter):
         return queryset.filter(qgroup)
 
 
+class WithoutDatapassIdFilter(SimpleListFilter):
+    title = "Numéro de demande Datapass"
+
+    parameter_name = "datapass_id"
+
+    def lookups(self, request, model_admin):
+        return (("without", "Sans n° Datapass"),)
+
+    def queryset(self, request, queryset):
+        datapass_id = self.value()
+
+        if not datapass_id:
+            return
+
+        if datapass_id == "without":
+            return queryset.filter(data_pass_id=None)
+
+
 class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
     list_display = (
         "name",
@@ -219,7 +237,7 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
     )
     readonly_fields = ("data_pass_id", "display_aidants")
     search_fields = ("name", "siret", "data_pass_id")
-    list_filter = ("is_active", OrganisationRegionFilter)
+    list_filter = ("is_active", WithoutDatapassIdFilter, OrganisationRegionFilter)
 
     # For bulk import
     resource_class = OrganisationResource


### PR DESCRIPTION
## 🌮 Objectif

On peut rechercher les orga par id datapass, mais on ne peut pas facilement repérer les organisations sans id datapass.

## 🔍 Implémentation

- Ajout d'un filtre

## 🖼️ Images

<img width="250" alt="Capture d’écran 2021-11-12 à 10 26 47" src="https://user-images.githubusercontent.com/1035145/141443824-d264eb17-599c-4940-a83e-7f0ad7000d4e.png">

