### PR TITLE
Affichage des demandes d'habilitation et des responsables liés à une organisation dans l'admin Django

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -235,7 +235,11 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         "id",
         "data_pass_id",
     )
-    readonly_fields = ("data_pass_id", "display_aidants")
+    readonly_fields = (
+        "data_pass_id",
+        "display_aidants",
+        "display_habilitation_requests",
+    )
     search_fields = ("name", "siret", "data_pass_id")
     list_filter = ("is_active", WithoutDatapassIdFilter, OrganisationRegionFilter)
 
@@ -266,6 +270,30 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         )
 
     display_aidants.short_description = "Aidants"
+
+    def display_habilitation_requests(self, obj):
+        headers = ("Id", "Nom", "Prénom", "Email", "Origine", "État")
+        return mark_safe(
+            '<table><tr><th scope="col">'
+            + '</th><th scope="col">'.join(headers)
+            + "</th></tr><tr><td>"
+            + "</td></tr><tr><td>".join(
+                "</td><td>".join(
+                    (
+                        str(hr.id),
+                        hr.last_name,
+                        hr.first_name,
+                        hr.email,
+                        hr.origin_label,
+                        hr.status_label,
+                    )
+                )
+                for hr in obj.habilitation_requests.order_by("last_name").all()
+            )
+            + "</td></tr></table>"
+        )
+
+    display_habilitation_requests.short_description = "Demandes d'habilitation"
 
     def find_zipcode_in_address(self, request, queryset):
         for organisation in queryset:

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -237,6 +237,7 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
     )
     readonly_fields = (
         "data_pass_id",
+        "display_responsables",
         "display_aidants",
         "display_habilitation_requests",
     )
@@ -258,18 +259,34 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         "activate_organisations",
     )
 
+    def display_responsables(self, obj):
+        return self.format_list_of_aidants(obj.responsables.order_by("last_name").all())
+
+    display_responsables.short_description = "Responsables"
+
     def display_aidants(self, obj):
+        return self.format_list_of_aidants(obj.aidants.order_by("last_name").all())
+
+    display_aidants.short_description = "Aidants"
+
+    def format_list_of_aidants(self, aidants_list):
         return mark_safe(
             "<table><tr>"
             + '<th scope="col">id</th><th scope="col">Nom</th><th>E-mail</th></tr><tr>'
             + "</tr><tr>".join(
-                f"<td>{aidant.id}</td><td>{aidant}</td><td>{aidant.email}</td>"
-                for aidant in obj.aidants.order_by("last_name").all()
+                '<td>{}</td><td><a href="{}">{}</a></td><td>{}</td>'.format(
+                    aidant.id,
+                    reverse(
+                        "otpadmin:aidants_connect_web_aidant_change",
+                        kwargs={"object_id": aidant.id},
+                    ),
+                    aidant,
+                    aidant.email,
+                )
+                for aidant in aidants_list
             )
             + "</tr></table>"
         )
-
-    display_aidants.short_description = "Aidants"
 
     def display_habilitation_requests(self, obj):
         headers = ("Id", "Nom", "Prénom", "Email", "Origine", "État")

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -431,6 +431,10 @@ class HabilitationRequest(models.Model):
     def status_label(self):
         return self.STATUS_LABELS[self.status]
 
+    @property
+    def origin_label(self):
+        return self.ORIGIN_LABELS[self.origin]
+
 
 class UsagerQuerySet(models.QuerySet):
     def active(self):


### PR DESCRIPTION
## 🌮 Objectif

On a beaucoup d'organisations qui sont créées en double ou davantage dans notre base. Pour faciliter la tâche des bizdev qui ne peuvent pas savoir quel doublon supprimer, j'affiche dans l'admin la liste des demandes d'habilitation en-dessous de la liste des aidants.

## 🔍 Implémentation

- Un tableau dans un attribut readonly, comme pour l'affichage des aidants


## 🖼️ Images

![Capture d’écran 2021-11-12 à 15 39 29](https://user-images.githubusercontent.com/1035145/141484539-3bdfab2d-b0f0-4e4f-8b5c-1dfd5c5b7005.png)



