### PR TITLE
Ne pas générer d'erreur 400 avec un POST habilitation datapass quasi vide

### DIFF
--- a/aidants_connect_web/views/datapass.py
+++ b/aidants_connect_web/views/datapass.py
@@ -98,6 +98,13 @@ def habilitation_receiver(request):
 
     content = get_content(request)
 
+    if (
+        all(value == "" for key, value in content.items() if key != "data_pass_id")
+        or len(content) == 1
+    ):
+        log.warning("Habilitation form is empty.")
+        return HttpResponse(status=200)
+
     if habilitation_already_exists(content):
         log.warning("Habilitation already exists.")
         return HttpResponse(status=200)


### PR DESCRIPTION


## 🌮 Objectif

Pour ne pas bloquer la validation d'une organisation on ne prend pas en compte les formulaires quasi-vide (à savoir uniquement un datapass id)

## 🔍 Implémentation

Ajout d'un test sur le contenu du POST

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
