### PR TITLE
Ne pas jeter une exception quand on reçoit une demande habilitation par datapass et sans e-mail

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -396,7 +396,10 @@ class DatapassHabilitationForm(forms.ModelForm):
         self.cleaned_data["organisation"] = organisations[0]
 
     def clean_email(self):
-        return self.cleaned_data.get("email").lower()
+        email = self.cleaned_data.get("email")
+        if email:
+            return email.lower()
+        return email
 
     def save(self, commit=True):
         self.instance.organisation = self.cleaned_data["organisation"]

--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -131,6 +131,14 @@ class HabilitationDatapass(DatapassMixin, TestCase):
             "profession": "",
         }
 
+        cls.without_email = {
+            "data_pass_id": 42,
+            "first_name": "Mario",
+            "last_name": "Brosse",
+            "email": "",
+            "profession": "plombier",
+        }
+
         cls.datapass_key = settings.DATAPASS_KEY
         cls.datapass_url = "/datapass_habilitation/"
 
@@ -153,6 +161,12 @@ class HabilitationDatapass(DatapassMixin, TestCase):
         self.assertEqual(response.status_code, 200)
         response = self.datapass_request(data={})
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(HabilitationRequest.objects.count(), 0)
+
+    def test_body_without_email_dont_raise_exception(self):
+        self.assertEqual(HabilitationRequest.objects.count(), 0)
+        response = self.datapass_request(data=self.without_email)
+        self.assertEqual(response.status_code, 400)
         self.assertEqual(HabilitationRequest.objects.count(), 0)
 
     def test_message_body_can_create_habilitation_request(self):

--- a/aidants_connect_web/views/datapass.py
+++ b/aidants_connect_web/views/datapass.py
@@ -42,8 +42,11 @@ def get_content(request):
 def habilitation_already_exists(content):
     if "email" not in content or "data_pass_id" not in content:
         return False
+    email = content["email"]
+    if email:
+        email = email.lower()
     return HabilitationRequest.objects.filter(
-        email=content["email"].lower(),
+        email=email,
         organisation__data_pass_id=content["data_pass_id"],
     )
 


### PR DESCRIPTION
## 🌮 Objectif

Aujourd'hui une demande d'habilitation envoyé par datapass et ne contenant pas d'email génère une exception. La PR change cela et fait en sorte qu'une erreur 400 soit renvoyé. 

Le choix a été fait de ne pas faire une 200 en ne prenant pas en compte les données. En effet on est dans le cas où la demande d'habilitation n'est pas totalement vide, il manque juste un email. 


## 🔍 Implémentation

gestion des champs emails vide.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
