### PR TITLE
Mise en place du SMTP Dolist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ EMAIL_BACKEND=django.core.mail.backends.filebased.EmailBackend
 # EMAIL_HOST_USER=<insert_your_data>
 # EMAIL_HOST_PASSWORD=<insert_your_data>
 
+# if you use the specific backend which forces sender address & adds extra headers
+# EMAIL_BACKEND=aidants_connect_web.mail.ForceSpecificSenderBackend
+# EMAIL_SENDER=environment@sub.domain.fr
+# EMAIL_EXTRA_HEADERS='{"X-Account-ID":1234}'
+
 # The email address the connection email is sent from
 MAGICAUTH_FROM_EMAIL=test@domain.user
 

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -370,6 +370,8 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", None)
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)
 
+DOLIST_ACCOUNT = os.getenv("DOLIST_ACCOUNT", None)
+
 ## Emails from the server
 SERVER_EMAIL = os.getenv("SERVER_EMAIL", os.getenv("ADMIN_EMAIL"))
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", SERVER_EMAIL)

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -370,8 +370,9 @@ EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD", None)
 EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)
 
-DOLIST_ACCOUNT = os.getenv("DOLIST_ACCOUNT", None)
-DOLIST_SENDER = os.getenv("DOLIST_SENDER", os.getenv("ADMIN_EMAIL"))
+## if email backend is aidants_connect_web.mail.ForceSpecificSenderBackend
+EMAIL_EXTRA_HEADERS = os.getenv("EMAIL_EXTRA_HEADERS", None)
+EMAIL_SENDER = os.getenv("EMAIL_SENDER", os.getenv("ADMIN_EMAIL"))
 
 ## Emails from the server
 SERVER_EMAIL = os.getenv("SERVER_EMAIL", os.getenv("ADMIN_EMAIL"))

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -371,6 +371,7 @@ EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", None)
 EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", None)
 
 DOLIST_ACCOUNT = os.getenv("DOLIST_ACCOUNT", None)
+DOLIST_SENDER = os.getenv("DOLIST_SENDER", os.getenv("ADMIN_EMAIL"))
 
 ## Emails from the server
 SERVER_EMAIL = os.getenv("SERVER_EMAIL", os.getenv("ADMIN_EMAIL"))

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -1,3 +1,4 @@
+import json
 from smtplib import SMTPException
 
 from django.conf import settings
@@ -6,9 +7,11 @@ from django.core.mail.backends.smtp import EmailBackend
 from django.core.mail.message import EmailMessage, sanitize_address
 
 
-class DolistBackend(EmailBackend):
+class ForceSpecificSenderBackend(EmailBackend):
     """
-    An email backend dedicated to DoList, with an extra header to provide account id
+    An email backend which forces sender email to settings.EMAIL_SENDER,
+    leaving original sender email in header "reply-to",
+    and add extra headers to emails (provided in JSON in settings.EMAIL_EXTRA_HEADERS).
     """
 
     def _send(self, email_message: EmailMessage):
@@ -16,13 +19,14 @@ class DolistBackend(EmailBackend):
         if not email_message.recipients():
             return False
         encoding = email_message.encoding or settings.DEFAULT_CHARSET
-        # Dolist specific
-        email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
+        # Specific
         email_message.extra_headers["Reply-To"] = sanitize_address(
             email_message.from_email, encoding
         )
-        email_message.from_email = settings.DOLIST_SENDER
-        # /Dolist specific
+        email_message.from_email = settings.EMAIL_SENDER
+        for key, value in json.loads(settings.EMAIL_EXTRA_HEADERS).items():
+            email_message.extra_headers[key] = value
+        # /Specific
         from_email = sanitize_address(email_message.from_email, encoding)
         recipients = [
             sanitize_address(addr, encoding) for addr in email_message.recipients()

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -1,0 +1,33 @@
+from smtplib import SMTPException
+
+from django.conf import settings
+
+from django.core.mail.backends.smtp import EmailBackend
+from django.core.mail.message import EmailMessage, sanitize_address
+
+
+class DolistBackend(EmailBackend):
+    """
+    An email backend dedicated to DoList, with an extra header to provide account id
+    """
+
+    def _send(self, email_message: EmailMessage):
+        """A helper method that does the actual sending."""
+        if not email_message.recipients():
+            return False
+        encoding = email_message.encoding or settings.DEFAULT_CHARSET
+        from_email = sanitize_address(email_message.from_email, encoding)
+        recipients = [
+            sanitize_address(addr, encoding) for addr in email_message.recipients()
+        ]
+        email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
+        message = email_message.message()
+        try:
+            self.connection.sendmail(
+                from_email, recipients, message.as_bytes(linesep="\r\n")
+            )
+        except SMTPException:
+            if not self.fail_silently:
+                raise
+            return False
+        return True

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -18,7 +18,7 @@ class DolistBackend(EmailBackend):
         encoding = email_message.encoding or settings.DEFAULT_CHARSET
         # Dolist specific
         email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
-        email_message.reply_to = sanitize_address(email_message.from_email, encoding)
+        # email_message.reply_to = sanitize_address(email_message.from_email, encoding)
         email_message.from_email = settings.DOLIST_SENDER
         # /Dolist specific
         from_email = sanitize_address(email_message.from_email, encoding)

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -18,7 +18,9 @@ class DolistBackend(EmailBackend):
         encoding = email_message.encoding or settings.DEFAULT_CHARSET
         # Dolist specific
         email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
-        # email_message.reply_to = sanitize_address(email_message.from_email, encoding)
+        email_message.extra_headers["Reply-To"] = sanitize_address(
+            email_message.from_email, encoding
+        )
         email_message.from_email = settings.DOLIST_SENDER
         # /Dolist specific
         from_email = sanitize_address(email_message.from_email, encoding)

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -15,12 +15,12 @@ class DolistBackend(EmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
+        encoding = email_message.encoding or settings.DEFAULT_CHARSET
         # Dolist specific
         email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
-        email_message.reply_to = email_message.from_email
+        email_message.reply_to = sanitize_address(email_message.from_email, encoding)
         email_message.from_email = settings.DOLIST_SENDER
         # /Dolist specific
-        encoding = email_message.encoding or settings.DEFAULT_CHARSET
         from_email = sanitize_address(email_message.from_email, encoding)
         recipients = [
             sanitize_address(addr, encoding) for addr in email_message.recipients()

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -15,12 +15,16 @@ class DolistBackend(EmailBackend):
         """A helper method that does the actual sending."""
         if not email_message.recipients():
             return False
+        # Dolist specific
+        email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
+        email_message.reply_to = email_message.from_email
+        email_message.from_email = settings.DOLIST_SENDER
+        # /Dolist specific
         encoding = email_message.encoding or settings.DEFAULT_CHARSET
         from_email = sanitize_address(email_message.from_email, encoding)
         recipients = [
             sanitize_address(addr, encoding) for addr in email_message.recipients()
         ]
-        email_message.extra_headers["X-Account-ID"] = settings.DOLIST_ACCOUNT
         message = email_message.message()
         try:
             self.connection.sendmail(


### PR DESCRIPTION
## 🌮 Objectif

Utiliser Dolist à la place de Mailjet pour l'envoi des mails transactionnels.

## 🔍 Implémentation

- Utilisation d'un backend spécial pour Dolist, qui requiert plusieurs conditions techniques pour que les mails soient bien envoyés : 
   - l'adresse e-mail de l'expéditeur doit avoir un sous-domaine précis décidé avec Dolist, à laquelle on ne peut pas envoyer de message (on peut déclarer une autre adresse "reply-to" pour permettre aux internautes de répondre aux mails) ;
   - le mail doit contenir un en-tête "X-Account" contenant notre numéro de compte Dolist ;
   - les adresses d'expéditeur et de réponse doivent être déclarées dans l'interface Dolist.

## 🏕 Amélioration continue

- On pourra envisager d'extraire cette classe Backend Dolist pour la partager avec les autres startups

## ⚠️ Informations supplémentaires

Il faut deux nouvelles variables d'environnement : 
- `EMAIL_EXTRA_HEADERS` contenant du json avec l'identifiant du compte à la clé x-account-id.
- `EMAIL_SENDER` pour l'adresse expéditeur avec le sous-domaine idoine

Il faut aussi utiliser le nouveau Backend : 
```
EMAIL_BACKEND=aidants_connect_web.mail.ForceSpecificSenderBackend
```

Et il faudra également basculer les variables `EMAIL_HOST`, `EMAIL_HOST_USER` et `EMAIL_HOST_PASSWORD` pour utiliser respectivement `$DOLIST_HOST`, `$DOLIST_USER` et `$DOLIST_PASSWORD`.

Toutes ces variables sont déjà prêtes à l'emploi sur préprod et prod, il reste à effectuer la bascule après avoir poussé cette PR en prod.

Il faut aussi aller dans l'interface de Dolist pour déclarer à la fois l'adresse "sender" et toutes les adresses "reply-to".