### PR TITLE
Ajout d'une migration pour remplir les bases vide

### DIFF
--- a/aidants_connect_web/migrations/0079_populate_database.py
+++ b/aidants_connect_web/migrations/0079_populate_database.py
@@ -1,0 +1,19 @@
+from django.db import migrations
+
+from aidants_connect_web.utilities import create_first_user_organisation_and_token
+
+
+def populate_database(apps, _):
+    create_first_user_organisation_and_token()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("aidants_connect_web", "0078_auto_20211122_1813"),
+        ("otp_static", "__latest__"),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_database, reverse_code=migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
## 🌮 Objectif

On ajoute une migration qui remplie les bases vide avec une orga, un user et un token statique uniquement si les conditions suivantes sont respectées : 
- toutes les données nécessaires sont présente en venv
- la base est vide 

j'ai presque envie que l'on ne merge jamais cette PR et qu'on déploie simplement une fois la branche lorsque nécessaire.

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
