### PR TITLE
Permettre d'accepter ou refuser des demandes d'habilitation qui sont en état "nouvelle"

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -715,7 +715,7 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
             status=HabilitationRequest.STATUS_PROCESSING
         )
         self.message_user(
-            request, f"{rows_updated} demandes d’habilitation ont été refusées."
+            request, f"{rows_updated} demandes d’habilitation sont maintenant en cours."
         )
 
     mark_processing.short_description = (

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -702,7 +702,10 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
 
     def mark_refused(self, request, queryset):
         rows_updated = queryset.filter(
-            status=HabilitationRequest.STATUS_PROCESSING
+            status__in=(
+                HabilitationRequest.STATUS_PROCESSING,
+                HabilitationRequest.STATUS_NEW,
+            )
         ).update(status=HabilitationRequest.STATUS_REFUSED)
         self.message_user(
             request, f"{rows_updated} demandes d’habilitation ont été refusées."

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -460,7 +460,7 @@ class HabilitationRequest(models.Model):
         return f"{self.email}"
 
     def validate_and_create_aidant(self):
-        if self.status != self.STATUS_PROCESSING:
+        if self.status not in (self.STATUS_PROCESSING, self.STATUS_NEW):
             return False
 
         if Aidant.objects.filter(username=self.email).count() > 0:

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1545,18 +1545,21 @@ class HabilitationRequestMethodTests(TestCase):
         pass
 
     def test_validate_when_all_is_fine(self):
-        habilitation_request = HabilitationRequestFactory(
-            status=HabilitationRequest.STATUS_PROCESSING
-        )
-        self.assertEqual(
-            0, Aidant.objects.filter(email=habilitation_request.email).count()
-        )
-        self.assertTrue(habilitation_request.validate_and_create_aidant())
-        self.assertEqual(
-            1, Aidant.objects.filter(email=habilitation_request.email).count()
-        )
-        db_hab_request = HabilitationRequest.objects.get(id=habilitation_request.id)
-        self.assertEqual(db_hab_request.status, HabilitationRequest.STATUS_VALIDATED)
+        for habilitation_request in (
+            HabilitationRequestFactory(status=HabilitationRequest.STATUS_PROCESSING),
+            HabilitationRequestFactory(status=HabilitationRequest.STATUS_NEW),
+        ):
+            self.assertEqual(
+                0, Aidant.objects.filter(email=habilitation_request.email).count()
+            )
+            self.assertTrue(habilitation_request.validate_and_create_aidant())
+            self.assertEqual(
+                1, Aidant.objects.filter(email=habilitation_request.email).count()
+            )
+            db_hab_request = HabilitationRequest.objects.get(id=habilitation_request.id)
+            self.assertEqual(
+                db_hab_request.status, HabilitationRequest.STATUS_VALIDATED
+            )
 
     def test_validate_if_aidant_already_exists(self):
         aidant = AidantFactory()


### PR DESCRIPTION
## 🌮 Objectif

Donner un petit droit à l'erreur aux bizdev s'ils ne suivent pas exactement le chemin prévu dans le cheminement des statuts des demandes d'habilitation (Nouvelle → En cours → Acceptée/Refusée)

## 🔍 Implémentation

- Modif des fonctions "valider les demandes d'habilitation" et "refuser les demandes d'habilitation"

## 🏕 Amélioration continue

- Correction d'un bug dans le message de confirmation du passage des demandes à "en cours"

