### PR TITLE
Toujours renvoyer un 200 ou 202 à datapass

### DIFF
--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -166,7 +166,7 @@ class HabilitationDatapass(DatapassMixin, TestCase):
     def test_body_without_email_dont_raise_exception(self):
         self.assertEqual(HabilitationRequest.objects.count(), 0)
         response = self.datapass_request(data=self.without_email)
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(HabilitationRequest.objects.count(), 0)
 
     def test_message_body_can_create_habilitation_request(self):

--- a/aidants_connect_web/views/datapass.py
+++ b/aidants_connect_web/views/datapass.py
@@ -126,4 +126,4 @@ def habilitation_receiver(request):
     for error in form.errors:
         message = f"{error} is invalid in the form @ datapass"
         log.warning(message)
-    return HttpResponseBadRequest()
+    return HttpResponse(status=200)


### PR DESCRIPTION
## 🌮 Objectif

Lorsqu'il y a des données en erreur, on ne les considère pas et on renvoie toujours des 200.

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
