### PR TITLE
Répare l'envoi des mails aux aidants lors des changements d'organisation

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -353,7 +353,9 @@ class Aidant(AbstractUser):
             self.save()
 
         aidants__organisations_changed.send(
-            sender=self.__class__, diff={"removed": [organisation], "added": []}
+            sender=self.__class__,
+            instance=self,
+            diff={"removed": [organisation], "added": []},
         )
 
         return self.is_active
@@ -383,6 +385,7 @@ class Aidant(AbstractUser):
 
         aidants__organisations_changed.send(
             sender=self.__class__,
+            instance=self,
             diff={
                 "removed": sorted(to_remove, key=lambda org: org.pk),
                 "added": sorted(to_add, key=lambda org: org.pk),

--- a/aidants_connect_web/signals.py
+++ b/aidants_connect_web/signals.py
@@ -27,8 +27,8 @@ def lower_totp_tolerance_on_login(sender, user: Aidant, request, **kwargs):
 
 
 @receiver(aidants__organisations_changed)
-def send_mail_aidant__organisations_changed(sender: Aidant, diff: dict, **_):
-    context = {"aidant": sender, **diff}
+def send_mail_aidant__organisations_changed(instance: Aidant, diff: dict, **_):
+    context = {"aidant": instance, **diff}
     text_message = loader.render_to_string(
         "signals/aidant__organisations_changed.txt", context
     )
@@ -38,7 +38,7 @@ def send_mail_aidant__organisations_changed(sender: Aidant, diff: dict, **_):
 
     send_mail(
         from_email=settings.AIDANTS__ORGANISATIONS_CHANGED_EMAIL_FROM,
-        recipient_list=[sender.email],
+        recipient_list=[instance.email],
         subject=settings.AIDANTS__ORGANISATIONS_CHANGED_EMAIL_SUBJECT,
         message=text_message,
         html_message=html_message,

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1293,6 +1293,7 @@ class AidantModelMethodsTests(TestCase):
 
         send.assert_called_once_with(
             sender=aidant.__class__,
+            instance=aidant,
             diff={"removed": [supplementary_organisation_1], "added": []},
         )
 
@@ -1381,6 +1382,7 @@ class AidantModelMethodsTests(TestCase):
 
         send.assert_called_once_with(
             sender=aidant.__class__,
+            instance=aidant,
             diff={
                 "removed": [previous_organisation, organisation_to_remove],
                 "added": [organisation_to_set_1, organisation_to_set_2],

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_remove_from_organisation.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_remove_from_organisation.py
@@ -1,0 +1,62 @@
+from django.test import tag, TestCase
+from django.test.client import Client
+from django.core import mail
+
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    OrganisationFactory,
+)
+
+
+@tag("responsable-structure")
+class EspaceResponsableRemoveAidantOrganisationsTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+
+        organisation = OrganisationFactory(name="Beta Gouv")
+        responsable = AidantFactory(organisation=organisation)
+        responsable.responsable_de.add(responsable.organisation)
+        responsable.responsable_de.add(OrganisationFactory())
+        cls.responsable_of_2 = responsable
+
+        aidant = AidantFactory(organisation=responsable.organisation)
+        aidant.organisations.set(responsable.responsable_de.all())
+        aidant.organisations.add(OrganisationFactory())
+        cls.aidant = aidant
+
+    def get_form_url(self, aidant, organisation):
+        return (
+            f"/espace-responsable/aidant/{aidant.id}/"
+            f"supprimer-organisation/{organisation.id}/"
+        )
+
+    def get_organisation_url(self, organisation):
+        return f"/espace-responsable/organisation/{organisation.id}/"
+
+    def test_remove_from_organisation(self):
+        responsable = self.responsable_of_2
+        aidant = self.aidant
+        self.client.force_login(responsable)
+
+        self.assertEqual(len(aidant.organisations.all()), 3)
+        response = self.client.post(
+            self.get_form_url(aidant, responsable.organisation),
+        )
+        self.assertRedirects(
+            response, self.get_organisation_url(responsable.organisation)
+        )
+        aidant.refresh_from_db()
+        self.assertEqual(len(aidant.organisations.all()), 2)
+
+        self.assertEqual(len(mail.outbox), 1)
+        mail_content = mail.outbox[0].body
+        mail_subject = mail.outbox[0].subject
+        mail_recipient = mail.outbox[0].recipients()
+        self.assertIn(aidant.email, mail_recipient)
+        self.assertIn(
+            "La liste des organisations dont vous faites partie a changé", mail_subject
+        )
+        self.assertIn(
+            "Vous ne pouvez plus créer des mandats pour Beta Gouv", mail_content
+        )

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -244,11 +244,11 @@ def remove_aidant_from_organisation(
         django_messages.success(
             request,
             f"{aidant.get_full_name()} ne fait maintenant plus partie de "
-            f"{organisation.name}",
+            f"{organisation.name}.",
         )
     else:
         django_messages.success(
-            request, f"Le profil de {aidant.get_full_name()} a été désactivé"
+            request, f"Le profil de {aidant.get_full_name()} a été désactivé."
         )
 
     return redirect("espace_responsable_organisation", organisation_id=organisation.id)


### PR DESCRIPTION
## 🌮 Objectif

Résoudre les erreurs `SMTPRecipientsRefused` qui arrivent en prod.

Le problème venait du fait que le serveur SMTP pensait que `"django.db.models.query_utils.DeferredAttribute object at 0x7f62f2598990"` n'était pas une adresse mail valide, et je ne peux que lui donner raison !

## 🔍 Implémentation

- Modification du signal pour qu'il accepte une instance d'aidant, et non seulement une classe.
- Ajout d'un petit test pour vérifier que l'adresse destinataire est la bonne.
