### PR TITLE
Affichage du datapass ID sur l'espace aidant et responsable

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -1,11 +1,23 @@
 <div class="tiles">
   <div class="grid">
     <div class="tile background-color-grey">
-      <h3>Adresse</h3>
+      <h3>
+        <span aria-hidden="true">📍</span>
+        Adresse
+      </h3>
       <p>
-        {{ organisation.address }}
+        {{ organisation.address }}<br>
+        {{ organisation.zipcode }} {{ organisation.city }}
       </p>
     </div>
+    {% if organisation.data_pass_id %}
+    <div class="tile background-color-grey">
+      <h3>Numéro d’habilitation</h3>
+      <p>
+        {{ organisation.data_pass_id }}
+      </p>
+    </div>
+    {% endif %}
     <div class="tile background-color-grey">
       <h3>Aidants actifs</h3>
       <p class="font-weight-bold">{{ organisation.num_active_aidants }}</p>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -26,7 +26,7 @@
               <h3>{{ org.name }}</h3>
               <p>
                 <span aria-hidden="true">📍</span>
-                {{ org.address }}
+                {{ org.address }} {{ org.zipcode }} {{ org.city }}
               </p>
               <p>
                 <span aria-hidden="true">🏢</span>

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -139,6 +139,23 @@ class EspaceResponsableOrganisationPage(TestCase):
         self.assertContains(response, aidant_a.first_name)
         self.assertContains(response, aidant_b.first_name)
 
+    def test_display_data_pass_id(self):
+        self.client.force_login(self.responsable_tom)
+        self.responsable_tom.organisation.data_pass_id = 4242
+        self.responsable_tom.organisation.save()
+        response = self.client.get(
+            f"/espace-responsable/organisation/{self.id_organisation}/"
+        )
+        self.assertContains(response, "Numéro d’habilitation")
+        self.assertContains(response, "4242")
+
+    def test_hide_block_if_no_data_pass_id(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get(
+            f"/espace-responsable/organisation/{self.id_organisation}/"
+        )
+        self.assertNotContains(response, "Numéro d’habilitation")
+
 
 @tag("responsable-structure")
 class EspaceResponsableAidantPage(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

L'id datapass (ou numéro de demande) est assez important à la fois pour les bizdev et pour beaucoup d'intervenants concernés par Aidants Connect. On permet donc aux aidants et aux responsables de les retrouver facilement.

## 🔍 Implémentation

- Modification du template
- et ajout d'un petit test

## 🏕 Amélioration continue

- J'affiche également le code postal et la ville en plus de l'adresse seule. (La présente est PR à merger après #478 donc.)

## 🖼️ Images

![Capture d’écran 2021-12-09 à 11 40 46](https://user-images.githubusercontent.com/1035145/145382396-01e0d33f-2ad9-4fdc-8734-4f1d5638b769.png)

