### PR TITLE
Répare le filtre "Région = autre" sur les aidants et les demandes d'habilitation

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -441,6 +441,9 @@ class AidantRegionFilter(RegionFilter):
         if not region_id:
             return
 
+        if region_id == "other":
+            return queryset.filter(organisations__zipcode=0)
+
         region = DatavizRegion.objects.get(id=region_id)
         d2r = DatavizDepartmentsToRegion.objects.filter(region=region)
         qgroup = reduce(
@@ -642,6 +645,9 @@ class HabilitationRequestRegionFilter(RegionFilter):
 
         if not region_id:
             return
+
+        if region_id == "other":
+            return queryset.filter(organisation__zipcode=0)
 
         region = DatavizRegion.objects.get(id=region_id)
         d2r = DatavizDepartmentsToRegion.objects.filter(region=region)

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -11,6 +11,9 @@ from aidants_connect_web.models import (
     Autorisation,
     Connection,
     CarteTOTP,
+    DatavizRegion,
+    DatavizDepartment,
+    DatavizDepartmentsToRegion,
     HabilitationRequest,
     Journal,
     Mandat,
@@ -166,3 +169,18 @@ class AttestationJournalFactory(JournalFactory):
     is_remote_mandat = False
     access_token = factory.Faker("md5")
     duree = 6
+
+
+class DatavizRegionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DatavizRegion
+
+
+class DatavizDepartmentFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DatavizDepartment
+
+
+class DatavizDepartmentsToRegionFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = DatavizDepartmentsToRegion

--- a/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
+++ b/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
@@ -1,0 +1,194 @@
+from django.conf import settings
+from django.test import tag
+from selenium.webdriver.support.wait import WebDriverWait
+
+from aidants_connect_web.models import DatavizRegion
+from aidants_connect_web.tests.factories import (
+    AidantFactory,
+    DatavizRegionFactory,
+    DatavizDepartmentFactory,
+    DatavizDepartmentsToRegionFactory,
+    HabilitationRequestFactory,
+    OrganisationFactory,
+)
+from aidants_connect_web.tests.test_functional.testcases import FunctionalTestCase
+
+
+class RegionFilterTestCase(FunctionalTestCase):
+    def setUp(self):
+        self.login_url = f"/{settings.ADMIN_URL}login/"
+        self.organisation_url = (
+            f"/{settings.ADMIN_URL}aidants_connect_web/organisation/"
+        )
+        self.login_admin()
+
+        if DatavizRegion.objects.filter(name="Île-de-France").exists():
+            return
+
+        region_idf = DatavizRegionFactory(name="Île-de-France")
+        region_mayotte = DatavizRegionFactory(name="Mayotte")
+        region_grandest = DatavizRegionFactory(name="Grand Est")
+
+        dep_yvelines = DatavizDepartmentFactory(dep_name="Yvelines", zipcode="78")
+        dep_mayotte = DatavizDepartmentFactory(dep_name="Mayotte", zipcode="976")
+        dep_basrhin = DatavizDepartmentFactory(dep_name="Bas-Rhin", zipcode="67")
+        dep_hautrhin = DatavizDepartmentFactory(dep_name="Haut-Rhin", zipcode="68")
+
+        DatavizDepartmentsToRegionFactory(region=region_idf, department=dep_yvelines)
+        DatavizDepartmentsToRegionFactory(department=dep_mayotte, region=region_mayotte)
+        DatavizDepartmentsToRegionFactory(
+            department=dep_basrhin, region=region_grandest
+        )
+        DatavizDepartmentsToRegionFactory(
+            department=dep_hautrhin, region=region_grandest
+        )
+
+    def login_admin(self):
+        self.aidant = AidantFactory(
+            username="thierry@thierry.com",
+            is_superuser=True,
+            is_staff=True,
+        )
+        self.aidant.set_password("laisser-passer-a38")
+        self.aidant.save()
+        device = self.aidant.staticdevice_set.create()
+        device.token_set.create(token="123456")
+        WebDriverWait(self.selenium, 10)
+
+        self.open_live_url(self.login_url)
+        login_field = self.selenium.find_element_by_id("id_username")
+        login_field.send_keys("thierry@thierry.com")
+        otp_field = self.selenium.find_element_by_id("id_otp_token")
+        otp_field.send_keys("123456")
+        pwd_field = self.selenium.find_element_by_id("id_password")
+        pwd_field.send_keys("laisser-passer-a38")
+
+        submit_button = self.selenium.find_element_by_xpath("//input[@type='submit']")
+        submit_button.click()
+        django_admin_title = self.selenium.find_element_by_tag_name("h1").text
+        self.assertEqual(django_admin_title, "Administration de Django")
+
+
+@tag("functional", "import")
+class OrganisationFilterTests(RegionFilterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.organisation_url = (
+            f"/{settings.ADMIN_URL}aidants_connect_web/organisation/"
+        )
+
+        OrganisationFactory(zipcode=78123, name="Orga des Yvelines")
+        OrganisationFactory(zipcode=67999, name="Orga du Bas-Rhin")
+        OrganisationFactory(zipcode=68123, name="Orga du Haut-Rhin")
+        OrganisationFactory(zipcode=0, name="Sans Code Postal")
+
+        OrganisationFactory(data_pass_id=666, name="Avec ID Datapass")
+        OrganisationFactory(name="Sans ID Datapass")
+
+    def test_region_and_other_filter(self):
+        self.open_live_url(self.organisation_url)
+        self.assertTrue("Orga des Yvelines" in self.selenium.page_source)
+        self.assertTrue("Orga du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("Sans Code Postal" in self.selenium.page_source)
+        idf_link = self.selenium.find_element_by_link_text("Île-de-France")
+        idf_link.click()
+
+        self.assertTrue(
+            "Orga des Yvelines" in self.selenium.page_source,
+        )
+        self.assertFalse(
+            "Orga du Bas-Rhin" in self.selenium.page_source,
+        )
+        self.assertFalse("Sans Code Postal" in self.selenium.page_source)
+        grandest_link = self.selenium.find_element_by_link_text("Grand Est")
+        grandest_link.click()
+        self.assertFalse(
+            "Orga des Yvelines" in self.selenium.page_source,
+            "Orga des Yvelines should not appear after filter on grand est",
+        )
+        self.assertTrue(
+            "Orga du Bas-Rhin" in self.selenium.page_source,
+            "Orga du Bas-Rhin is not there, it should",
+        )
+        self.assertTrue(
+            "Orga du Haut-Rhin" in self.selenium.page_source,
+            "Orga du Haut-Rhin is not there, it should",
+        )
+        other_link = self.selenium.find_element_by_link_text("Autre")
+        other_link.click()
+        self.assertFalse("Orga du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("Sans Code Postal" in self.selenium.page_source)
+
+    def test_datapass_id_filter(self):
+        self.open_live_url(self.organisation_url)
+        self.assertTrue("Avec ID Datapass" in self.selenium.page_source)
+        self.assertTrue("Sans ID Datapass" in self.selenium.page_source)
+        idf_link = self.selenium.find_element_by_link_text("Sans n° Datapass")
+        idf_link.click()
+
+        self.assertFalse("Avec ID Datapass" in self.selenium.page_source)
+        self.assertTrue("Sans ID Datapass" in self.selenium.page_source)
+
+
+class AidantFilterTestCase(RegionFilterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.aidant_url = f"/{settings.ADMIN_URL}aidants_connect_web/aidant/"
+
+        orga_basrhin = OrganisationFactory(zipcode=67999, name="Orga du Bas-Rhin")
+        orga_other = OrganisationFactory(zipcode=0, name="Sans Code Postal")
+
+        self.aidant_basrhin = AidantFactory(
+            last_name="Du Bas-Rhin", organisation=orga_basrhin
+        )
+        self.aidant_other = AidantFactory(
+            last_name="D'on ne sait où", organisation=orga_other
+        )
+
+    def test_region_and_other_filter(self):
+        self.open_live_url(self.aidant_url)
+        self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("D'on ne sait où" in self.selenium.page_source)
+        other_link = self.selenium.find_element_by_link_text("Autre")
+        other_link.click()
+        self.assertFalse("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("D'on ne sait où" in self.selenium.page_source)
+        grand_est_link = self.selenium.find_element_by_link_text("Grand Est")
+        grand_est_link.click()
+        self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertFalse("D'on ne sait où" in self.selenium.page_source)
+
+
+class HabilitationRequestTestCase(RegionFilterTestCase):
+    def setUp(self):
+        super().setUp()
+        self.hab_request_url = (
+            f"/{settings.ADMIN_URL}aidants_connect_web/habilitationrequest/"
+        )
+
+        orga_basrhin = OrganisationFactory(zipcode=67999, name="Orga du Bas-Rhin")
+        orga_other = OrganisationFactory(zipcode=0, name="Sans Code Postal")
+
+        self.hab_request_basrhin = HabilitationRequestFactory(
+            last_name="Du Bas-Rhin", organisation=orga_basrhin
+        )
+        self.hab_request_other = HabilitationRequestFactory(
+            last_name="D'on ne sait où", organisation=orga_other
+        )
+
+    def test_region_and_other_filter(self):
+        self.open_live_url(self.hab_request_url)
+        self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("D'on ne sait où" in self.selenium.page_source)
+        # cannot simply click on "Autre" because there is another "Autre" option
+        # (in "origin" filter)
+        other_link = self.selenium.find_element_by_xpath("//a[@href='?region=other']")
+        other_link.click()
+
+        self.assertFalse("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertTrue("D'on ne sait où" in self.selenium.page_source)
+        grand_est_link = self.selenium.find_element_by_link_text("Grand Est")
+        grand_est_link.click()
+
+        self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
+        self.assertFalse("D'on ne sait où" in self.selenium.page_source)


### PR DESCRIPTION
## 🌮 Objectif

Arrêter de recevoir des erreurs 500 quand quelqu'un clique sur le filtre "Autre" dans la rubrique régions

## 🔍 Implémentation

- Réparation du filtre sur les Aidants et les demandes d'habilitation
- Ajout de tests
