### PR TITLE
Admin "entrées de journal" : enlève le filtre sur "aidant" et répare la recherche par aidant

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -924,8 +924,13 @@ class ConnectionAdmin(ModelAdmin):
 
 class JournalAdmin(VisibleToTechAdmin, ModelAdmin):
     list_display = ("id", "action", "aidant", "creation_date")
-    list_filter = ("action", "aidant")
-    search_fields = ("action", "aidant")
+    list_filter = ("action",)
+    search_fields = (
+        "action",
+        "aidant__first_name",
+        "aidant__last_name",
+        "aidant__email",
+    )
     ordering = ("-creation_date",)
 
     def has_add_permission(self, request, obj=None):


### PR DESCRIPTION
## 🌮 Objectif

Supprimer un bug et alléger l'interface de la page

## 🔍 Implémentation

- Réparation de la recherche : on avait mis "aidant" directement dans la recherche mais ça ne fonctionne pas. J'ai précisé qu'on veut chercher par nom, prénom ou email de l'aidant.
- Suppression du filtre par aidant, qui alourdit considérablement la page maintenant que la base de prod contient pas loin de 5000 aidants.

## 🖼️ Images

Screenshot extrêmement dézoomé de la page des actions admin en prod, juste pour expliquer que ce filtre est davantage nuisible qu'autre chose : 

![Screenshot 2021-12-10 at 15-30-32 Sélectionnez l’objet entrée de journal à changer Site d’administration de Django](https://user-images.githubusercontent.com/1035145/145590445-80796501-8730-4f28-affa-aeaf5caab169.png)

