### PR TITLE
Permettre l'habilitation en masse à partir d'une liste d'adresses e-mail

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -692,6 +692,9 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
     )
     ordering = ("email",)
     resource_class = HabilitationRequestResource
+    change_list_template = (
+        "aidants_connect_web/admin/habilitation_request/change_list.html"
+    )
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -745,6 +745,39 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
         "Passer « en cours » les demandes d'habilitation sélectionnées"
     )
 
+    def get_urls(self):
+        return [
+            path(
+                "validate-from-emails/",
+                self.admin_site.admin_view(self.validate_from_email),
+                name="aidants_connect_web_habilitation_request_mass_validate",
+            ),
+            *super().get_urls(),
+        ]
+
+    def validate_from_email(self, request):
+        if request.method not in ["GET", "POST"]:
+            return HttpResponseNotAllowed(["GET", "POST"])
+        elif request.method == "GET":
+            return self.__validate_from_email_get(request)
+        else:
+            return self.__validate_from_email_post(request)
+
+    def __validate_from_email_get(self, request):
+        context = {
+            **self.admin_site.each_context(request),
+            "media": self.media,
+        }
+
+        return render(
+            request,
+            "aidants_connect_web/admin/habilitation_request/mass-habilitation.html",
+            context,
+        )
+
+    def __validate_from_email_post(self, request):
+        pass
+
 
 class UsagerAutorisationInline(VisibleToTechAdmin, NestedTabularInline):
     model = Autorisation

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -810,7 +810,7 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
             self.message_user(
                 request,
                 f"Les {len(treated_emails)} demandes ont bien été validées.",
-                messages.ERROR,
+                messages.SUCCESS,
             )
             return HttpResponseRedirect(
                 reverse("otpadmin:aidants_connect_web_habilitationrequest_changelist")

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib.auth import password_validation
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
 from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
-from django.core.validators import RegexValidator
+from django.core.validators import RegexValidator, EmailValidator
 from django.forms import EmailField
 from django.forms.utils import ErrorList
 from django.utils.html import format_html
@@ -407,3 +407,24 @@ class DatapassHabilitationForm(forms.ModelForm):
         self.instance.organisation = self.cleaned_data["organisation"]
         self.instance.origin = HabilitationRequest.ORIGIN_DATAPASS
         return super().save(commit)
+
+
+class MassEmailHabilitatonForm(forms.Form):
+    email_list = forms.Field(widget=forms.Textarea)
+
+    def clean_email_list(self):
+        email_list = self.cleaned_data.get("email_list")
+        validate_email = EmailValidator(
+            message="Veuillez saisir uniquement des adresses e-mail valides."
+        )
+
+        def is_email_valid(value):
+            validate_email(value)
+            return True
+
+        return set(
+            filter(
+                is_email_valid,
+                (filter(None, (email.strip() for email in email_list.splitlines()))),
+            )
+        )

--- a/aidants_connect_web/static/css/admin/aidants-connect.css
+++ b/aidants_connect_web/static/css/admin/aidants-connect.css
@@ -1,0 +1,9 @@
+.successnote {
+    font-size: 14px;
+    padding: 10px 12px;
+    margin: 0 0 10px 0;
+    color: #008628;
+    border: 1px solid #008628;
+    background: #ebffed;
+    border-radius: 4px;
+}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/change_list.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/import_export/change_list.html" %}
+
+{% block object-tools-items %}
+  <li>
+    <a href="#">
+      <span aria-hidden="true">📧</span>
+      Habiliter à partir d’adresses e-mail
+    </a>
+  </li> 
+  {% include "admin/import_export/change_list_import_item.html" %}
+  {% include "admin/import_export/change_list_export_item.html" %}
+  {{ block.super }}
+{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/change_list.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/change_list.html
@@ -2,11 +2,10 @@
 
 {% block object-tools-items %}
   <li>
-    <a href="#">
-      <span aria-hidden="true">📧</span>
+    <a class="viewsitelink" href="{% url "otpadmin:aidants_connect_web_habilitation_request_mass_validate" %}">
       Habiliter à partir d’adresses e-mail
     </a>
-  </li> 
+  </li>
   {% include "admin/import_export/change_list_import_item.html" %}
   {% include "admin/import_export/change_list_export_item.html" %}
   {{ block.super }}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -16,17 +16,49 @@
 {% block content %}
   <h1>Habilitation en masse à partir des adresses e-mail</h1>
 
-  <p>Collez ci-dessous une liste d'adresses mail d'aidants dont vous voulez valider la demande d'habilitation.</p>
-
+  <p>
+    Collez ci-dessous une liste d'adresses mail d'aidants dont vous voulez valider la demande
+    d'habilitation.
+  </p>
+  {% if ignored_emails %}
+    <div class="errornote">
+      {% blocktranslate count counter=ignored_emails|length %}
+        Nous n'avons pas pu traiter l'adress e-mail suivante : aucune demande
+        ne correspond, ou alors elle a déjà été annulée ou validée.
+        {% plural %}
+        Nous n'avons pas pu traiter les {{ counter }} e-mails suivants : aucune demande ne correspond,
+        ou alors elles ont déjà été validées/annulées.
+      {% endblocktranslate %}
+      <ul>
+        {% for email in ignored_emails %}
+          <li>{{ email }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  {% if treated_emails %}
+    <p>Les demandes d'habilitation suivantes ont été validées, les comptes aidant ont été créés :</p>
+    <ul>
+      {% for email in treated_emails %}
+        <li>{{ email }}</li>
+      {% endfor %}
+    </ul>
+  {% endif %}
   <form action="{% url "otpadmin:aidants_connect_web_habilitation_request_mass_validate" %}" method="POST">
-    <fieldset class="module aligned">
-      <label for="emails">Liste des e-mails (un par ligne)</label>
-      <textarea name="emails" id="emails" cols="30" rows="10"></textarea>
-    </fieldset>
+    {% if form.errors %}
+      <p>Des erreurs se sont produites dans le formulaire.</p>
+    {% endif %}
+    <div class="module aligned">
+      <label for="{{ form.email_list.id_for_label }}">Liste des e-mails (un par ligne)</label>
+      {{ form.email_list }}
+      {% if form.errors.email_list %}
+        {{ form.errors.email_list }}
+      {% endif %}
+    </div>
     <div class="submit-row">
       <input type="submit" value="Valider" class="default" name="_save">
       <p class="deletelink-box">
-        <a href="{% url 'otpadmin:aidants_connect_web_mandat_changelist' %}" class="closelink">Annuler</a>
+        <a href="{% url 'otpadmin:aidants_connect_web_habilitationrequest_changelist' %}" class="closelink">Annuler</a>
       </p>
     </div>
     {% csrf_token %}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -1,0 +1,36 @@
+{% extends "admin/base_site.html" %}
+{% load static ac_extras i18n %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+  {{ media.css }}
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media.js }}
+{% endblock %}
+
+{% block content %}
+  <h1>Habilitation en masse à partir des adresses e-mail</h1>
+
+  <p>Collez ci-dessous une liste d'adresses mail d'aidants dont vous voulez valider la demande d'habilitation.</p>
+
+  <form action="{% url "otpadmin:aidants_connect_web_habilitation_request_mass_validate" %}" method="POST">
+    <fieldset class="module aligned">
+      <label for="emails">Liste des e-mails (un par ligne)</label>
+      <textarea name="emails" id="emails" cols="30" rows="10"></textarea>
+    </fieldset>
+    <div class="submit-row">
+      <input type="submit" value="Valider" class="default" name="_save">
+      <p class="deletelink-box">
+        <a href="{% url 'otpadmin:aidants_connect_web_mandat_changelist' %}" class="closelink">Annuler</a>
+      </p>
+    </div>
+    {% csrf_token %}
+  </form>
+
+
+{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -5,6 +5,7 @@
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
   <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+  <link rel="stylesheet" type="text/css" href="{% static "css/admin/aidants-connect.css" %}">
   {{ media.css }}
 {% endblock %}
 
@@ -15,7 +16,6 @@
 
 {% block content %}
   <h1>Habilitation en masse à partir des adresses e-mail</h1>
-
   <p>
     Collez ci-dessous une liste d'adresses mail d'aidants dont vous voulez valider la demande
     d'habilitation.
@@ -37,12 +37,14 @@
     </div>
   {% endif %}
   {% if treated_emails %}
-    <p>Les demandes d'habilitation suivantes ont été validées, les comptes aidant ont été créés :</p>
-    <ul>
-      {% for email in treated_emails %}
-        <li>{{ email }}</li>
-      {% endfor %}
-    </ul>
+    <div class="successnote">
+      <p>Les demandes d'habilitation suivantes ont été validées, les comptes aidant ont été créés :</p>
+      <ul>
+        {% for email in treated_emails %}
+          <li><span aria-hidden="true">✅ </span>{{ email }}</li>
+        {% endfor %}
+      </ul>
+    </div>
   {% endif %}
   <form action="{% url "otpadmin:aidants_connect_web_habilitation_request_mass_validate" %}" method="POST">
     {% if form.errors %}

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -6,6 +6,7 @@ from aidants_connect_web.forms import (
     AidantCreationForm,
     AidantChangeForm,
     DatapassHabilitationForm,
+    MassEmailHabilitatonForm,
     MandatForm,
     RecapMandatForm,
 )
@@ -338,3 +339,54 @@ class DatapassAccreditationFormTests(TestCase):
         self.assertEqual(habilitation.last_name, "Brosse")
         self.assertEqual(habilitation.email, "mario.brossse@world.fr")
         self.assertEqual(habilitation.profession, "plombier")
+
+
+@tag("forms")
+class MassEmailHabilitatonFormTests(TestCase):
+    def test_filter_empty_values(self):
+        form = MassEmailHabilitatonForm(
+            data={
+                "email_list": """toto@tata.net
+
+                titi@lala.net""",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["email_list"], {"toto@tata.net", "titi@lala.net"}
+        )
+
+    def test_ok_with_only_one_email(self):
+        form = MassEmailHabilitatonForm(
+            data={
+                "email_list": "toto@tata.net",
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["email_list"], {"toto@tata.net"})
+
+    def test_reject_non_email_strings(self):
+        form = MassEmailHabilitatonForm(
+            data={
+                "email_list": """gabuzomeu
+                titi@lala.net""",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["email_list"],
+            ["Veuillez saisir uniquement des adresses e-mail valides."],
+        )
+
+    def test_reject_invalid_emails(self):
+        form = MassEmailHabilitatonForm(
+            data={
+                "email_list": """josée@accent.com
+                titi@lala.net""",
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["email_list"],
+            ["Veuillez saisir uniquement des adresses e-mail valides."],
+        )

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -133,7 +133,14 @@ class VisibleToAdminMetierTests(TestCase):
 @tag("admin")
 class VisibilityAdminPageTests(TestCase):
     only_by_atac_models = [Mandat, Usager, Connection, Journal]
-    amac_models = [Organisation, Aidant, StaticDevice, TOTPDevice, HabilitationRequest]
+    amac_models = [
+        Aidant,
+        CarteTOTP,
+        HabilitationRequest,
+        StaticDevice,
+        TOTPDevice,
+        Organisation,
+    ]
 
     @classmethod
     def setUpTestData(cls):

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -29,6 +29,7 @@ from aidants_connect_web.models import (
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     CarteTOTPFactory,
+    HabilitationRequestFactory,
     TOTPDeviceFactory,
     UsagerFactory,
 )
@@ -511,3 +512,73 @@ class TotpCardsImportTests(TestCase):
         a.generate_log_entries(result, request)
 
         self.assertEqual(Journal.objects.count(), 1 + initial_count)
+
+
+@tag("admin")
+class HabilitationRequestAdminPageTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.admin = OTPAdminSite(OTPAdminSite.name)
+        cls.url = reverse(
+            "otpadmin:aidants_connect_web_habilitation_request_mass_validate"
+        )
+        cls.list_url = reverse(
+            "otpadmin:aidants_connect_web_habilitationrequest_changelist"
+        )
+        cls.bizdev_user = AidantFactory(
+            is_staff=True,
+            is_superuser=False,
+        )
+        cls.bizdev_user.set_password("password")
+        cls.bizdev_user.save()
+        cls.bizdev_device = StaticDevice.objects.create(
+            user=cls.bizdev_user, name="Device"
+        )
+
+        cls.bizdev_client = Client()
+        cls.bizdev_client.force_login(cls.bizdev_user)
+        bizdev_session = cls.bizdev_client.session
+        bizdev_session[DEVICE_ID_SESSION_KEY] = cls.bizdev_device.persistent_id
+        bizdev_session.save()
+
+    def test_mass_habilitation_page_is_available(self):
+        response = self.bizdev_client.get(self.url)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Habilitation en masse à partir des adresses e-mail"
+        )
+
+    def test_mass_habilitation_on_only_valid_addresses(self):
+        for _ in range(2):
+            HabilitationRequestFactory()
+        emails = tuple(obj.email for obj in HabilitationRequest.objects.all())
+        response = self.bizdev_client.post(self.url, {"email_list": "\n".join(emails)})
+        self.assertRedirects(response, self.list_url, fetch_redirect_response=False)
+        response = self.bizdev_client.get(self.list_url)
+        self.assertContains(response, "Les 2 demandes ont bien été validées.")
+        for email in emails:
+            habilitation_request = HabilitationRequest.objects.get(email=email)
+            self.assertEqual(
+                habilitation_request.status, HabilitationRequest.STATUS_VALIDATED
+            )
+            self.assertTrue(Aidant.objects.filter(email=email).exists())
+
+    def test_mass_habilitation_with_valid_and_invalid_addresses(self):
+        for _ in range(5):
+            HabilitationRequestFactory()
+        valid_emails = (obj.email for obj in HabilitationRequest.objects.all())
+        invalid_emails = ("jlfqksjqsdf@com.com", "qlfqf@non.net")
+        emails = "\n".join(invalid_emails) + "\n" + "\n".join(valid_emails)
+        response = self.bizdev_client.post(self.url, {"email_list": emails})
+        self.assertEqual(response.status_code, 200)  # no redirection
+        for email in valid_emails:
+            habilitation_request = HabilitationRequest.objects.get(email=email)
+            self.assertEqual(
+                habilitation_request.status, HabilitationRequest.STATUS_VALIDATED
+            )
+            self.assertTrue(Aidant.objects.filter(email=email).exists())
+        self.assertContains(
+            response, "Les demandes d'habilitation suivantes ont été validées"
+        )
+        self.assertContains(response, "Nous n'avons pas pu traiter les")


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux bizdev de valider encore plus facilement des habilitations en cours, avec un simple copier-coller de la colonne "adresses mail" de excel

## 🔍 Implémentation

- Un formulaire dans l'admin qui prend une liste d'adresses e-mail et valide les demandes d'habilitation correspondantes

## 🏕 Amélioration continue

- Un ajout dans un test qui manquait dans un coin


## 🖼️ Images


📷  Un bouton dans l'écran "requêtes d'habilitation" : 

![Capture d’écran 2021-12-17 à 15 48 43](https://user-images.githubusercontent.com/1035145/146572304-87c0dd24-9b21-4e37-b3a6-adda3869629c.png)

-------

🚢  On y colle des adresses mail depuis excel : 

![Capture d’écran 2021-12-17 à 15 45 38](https://user-images.githubusercontent.com/1035145/146572385-023d1c19-1d36-4e01-8127-2881a5bc71e6.png)

-------
🍌  C'est tolérant aux lignes vides ou avec des espaces : 

![Capture d’écran 2021-12-17 à 15 48 09](https://user-images.githubusercontent.com/1035145/146572434-7c883a8b-bf3a-422d-bac0-0e7e541b42f8.png)

-------

✅ Si tout se passe bien, on retourne à la liste des demandes avec un message rassurant : 

![Capture d’écran 2021-12-17 à 15 48 26](https://user-images.githubusercontent.com/1035145/146572631-3b65f402-3d28-437a-ba6b-30e1a258350c.png)

-------

🌵 Et si tout ne se passe pas bien, on détaille quelles adresses posent problème et lesquelles ont fonctionné : 

![Capture d’écran 2021-12-17 à 15 45 51](https://user-images.githubusercontent.com/1035145/146572778-8dba8c76-f963-4f78-b216-1a225a0b0aff.png)

