### PR TITLE
Fix pour Python 3.10

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -1,6 +1,6 @@
 import logging
 import operator
-from collections import Collection
+from collections.abc import Collection
 from functools import reduce
 
 from admin_honeypot.admin import LoginAttemptAdmin as HoneypotLoginAttemptAdmin

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 import factory
 from datetime import timedelta


### PR DESCRIPTION
## 🏕 Amélioration continue

- `Collection` ne semble plus se trouver dans le module `collections` dans Python 3.10. D'ailleurs, [il n'a jamais eu l'air de s'y trouver](https://docs.python.org/fr/3.6/library/collections.html). J'ai aucune idée de pourquoi ça fonctionnait jusqu'ici…
