### PR TITLE
Bugfix - autorise la modification de l'e-mail pour coller avec la valeur du username

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -122,10 +122,15 @@ class AidantChangeForm(forms.ModelForm):
         cleaned_data = self.cleaned_data
         data_email = cleaned_data.get("email")
         initial_email = self.instance.email
+        initial_id = self.instance.id
 
         if data_email != initial_email:
-            claimed_emails = Aidant.objects.all().values_list("username", flat=True)
-            if data_email in claimed_emails:
+            if (
+                Aidant.objects.filter(email=data_email).exists()
+                or Aidant.objects.exclude(id=initial_id)
+                .filter(username=data_email)
+                .exists()
+            ):
                 self.add_error(
                     "email", forms.ValidationError("This email is already taken")
                 )

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -210,6 +210,54 @@ class AidantChangeFormTests(TestCase):
         self.assertEqual(self.aidant2.username, "abernart@domain.user")
         self.assertEqual(form.errors["email"], ["This email is already taken"])
 
+    def test_you_can_update_email_to_match_username(self):
+        aidant = AidantFactory(
+            email="wrong@mail.net",
+            username="good@mail.net",
+        )
+        changed_data = {
+            "username": "good@mail.net",
+            "email": "good@mail.net",
+            "first_name": aidant.first_name,
+            "last_name": aidant.last_name,
+            "profession": "Mediateur",
+            "organisation": str(aidant.organisation.id),
+        }
+        form = AidantChangeForm(
+            data=changed_data,
+            initial=model_to_dict(aidant),
+            instance=aidant,
+        )
+
+        aidant.refresh_from_db()
+        self.assertTrue(form.is_valid())
+        self.assertEqual(aidant.email, "good@mail.net")
+        self.assertEqual(aidant.username, "good@mail.net")
+
+    def test_you_can_update_username_to_match_username(self):
+        aidant = AidantFactory(
+            email="good@mail.net",
+            username="wrong@mail.net",
+        )
+        changed_data = {
+            "username": "good@mail.net",
+            "email": "good@mail.net",
+            "first_name": aidant.first_name,
+            "last_name": aidant.last_name,
+            "profession": "Mediateur",
+            "organisation": str(aidant.organisation.id),
+        }
+        form = AidantChangeForm(
+            data=changed_data,
+            initial=model_to_dict(aidant),
+            instance=aidant,
+        )
+
+        aidant.refresh_from_db()
+        self.assertTrue(form.is_valid())
+        self.assertEqual(aidant.email, "good@mail.net")
+        self.assertEqual(aidant.username, "good@mail.net")
+
 
 class MandatFormTests(TestCase):
     def test_form_renders_item_text_input(self):

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -234,7 +234,7 @@ class AidantChangeFormTests(TestCase):
         self.assertEqual(aidant.email, "good@mail.net")
         self.assertEqual(aidant.username, "good@mail.net")
 
-    def test_you_can_update_username_to_match_username(self):
+    def test_you_can_update_username_to_match_email(self):
         aidant = AidantFactory(
             email="good@mail.net",
             username="wrong@mail.net",


### PR DESCRIPTION
## 🌮 Objectif

Dans le cas très précis et assez courant où l'`email` et l'`username` de l'aidant ont une valeur différente, on ne peut pas modifier l'e-mail pour y mettre la valeur du `username` : on a alors une erreur _This email is already taken_.

<img width="590" alt="Capture d’écran 2022-01-04 à 16 12 35" src="https://user-images.githubusercontent.com/1035145/148080623-fbf8c7b9-7c48-4bef-b1ff-7a18937a2127.png">


## 🔍 Implémentation

- Ajout de deux cas de tests (un seul était en échec avant correction)
- Correction du code fautif (et probablement amélioration de la performance au passage)