### PR TITLE
Nettoyage des jetons à usage unique

### DIFF
--- a/aidants_connect_web/management/commands/delete_duplicated_static_tokens.py
+++ b/aidants_connect_web/management/commands/delete_duplicated_static_tokens.py
@@ -1,0 +1,13 @@
+from django.core.management.base import BaseCommand
+
+from aidants_connect_web.tasks import delete_duplicated_static_tokens
+
+
+class Command(BaseCommand):
+    help = (
+        "Deletes duplicated static tokens of aidants and static tokens of aidants "
+        "with confirmed totp cards"
+    )
+
+    def handle(self, *args, **options):
+        delete_duplicated_static_tokens()

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -322,13 +322,7 @@ class Aidant(AbstractUser):
 
     @cached_property
     def has_a_totp_device(self):
-        try:
-            TOTPDevice.objects.get(user=self, confirmed=True)
-            return True
-        except TOTPDevice.MultipleObjectsReturned:
-            return True
-        except TOTPDevice.DoesNotExist:
-            return False
+        return self.totpdevice_set.filter(confirmed=True).exists()
 
     @cached_property
     def has_a_carte_totp(self):

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -7,7 +7,7 @@ from django.core.mail import send_mail
 from django.template import loader
 from django.urls import reverse
 from django.utils import timezone
-
+from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
 from celery import shared_task
 
 from aidants_connect_web.models import Connection
@@ -37,6 +37,37 @@ def delete_expired_connections():
         logger.info("No connection to delete.")
 
     return deleted_connections_count
+
+
+@shared_task
+def delete_duplicated_static_tokens():
+    logger.info("Deleting duplicated tokens...")
+    devices_with_duplicated_tokens = (
+        StaticDevice.objects.filter(user__is_staff=False)
+        .filter(user__is_superuser=False)
+        .values()
+        .annotate(token_count=Count("token_set"))
+        .filter(token_count__gte=2)
+    )
+
+    for device in devices_with_duplicated_tokens:
+        device_id = device["id"]
+        token_values = (
+            StaticToken.objects.filter(device__id=device_id)
+            .values_list("token", flat=True)
+            .distinct()
+        )
+        for value in token_values:
+            tokens_to_delete = StaticToken.objects.filter(device__id=device_id).filter(
+                token=value
+            )
+            count_tokens = tokens_to_delete.count()
+            if count_tokens > 1:
+                tokens_to_delete = StaticToken.objects.filter(
+                    device__id=device_id
+                ).filter(token=value)[: count_tokens - 1]
+                for token in tokens_to_delete:
+                    token.delete()
 
 
 @shared_task

--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -84,7 +84,7 @@ class DeleteDuplicatedAndObsoleteTokensTests(TestCase):
     def setUpTestData(cls):
         cls.command_name = "delete_duplicated_static_tokens"
 
-    def test_delete_duplicated_tokens_for_standard_aidant(self):
+    def test_delete_duplicated_tokens_for_aidant(self):
         aidant = AidantFactory()
         for _ in range(5):
             add_static_token(aidant.username, 123456)
@@ -92,7 +92,7 @@ class DeleteDuplicatedAndObsoleteTokensTests(TestCase):
         call_command(self.command_name)
         self.assertEqual(StaticToken.objects.count(), 1)
 
-    def test_keep_one_token_of_every_value_for_standard_aidant(self):
+    def test_keep_one_token_of_every_value_for_aidant(self):
         aidant = AidantFactory()
         for _ in range(5):
             add_static_token(aidant.username, 123456)


### PR DESCRIPTION
## 🌮 Objectif

- Éviter d'autoriser plusieurs autorisations du même jeton à usage unique en cas d'import excel malheureux.
- Supprimer la possibilité d'utiliser le token une fois que la carte TOTP d'un aidant (non admin) a été confirmée.

## 🔍 Implémentation

- Une tâche qui tournerait une fois par jour pour nettoyer les jetons en double ou les jetons obsolètes

## 🏕 Amélioration continue

- Amélioration de la méthode `has_a_totp_device`

## ⚠️ Informations supplémentaires

- Il ne faudra pas oublier de la planifier, cette fois…
