### PR TITLE
Ajout d'un paramètre par défaut manquant dans Django 3.2

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -64,6 +64,8 @@ def getenv_bool(key: str, default: Optional[bool] = None) -> bool:
 
 
 HOST = os.environ["HOST"]
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
 # FC as FI
 FC_AS_FI_CALLBACK_URL = os.environ["FC_AS_FI_CALLBACK_URL"]
 FC_AS_FI_ID = os.environ["FC_AS_FI_ID"]


### PR DESCRIPTION
## 🌮 Objectif

Éviter de voir ça à chaque fois que l'on exécute une migration : 

<img width="1288" alt="Capture d’écran 2022-01-10 à 15 24 58" src="https://user-images.githubusercontent.com/1035145/148781989-cdfdf183-45ad-4346-ac95-6292772fc979.png">


## 🔍 Implémentation

D'après https://docs.djangoproject.com/en/3.2/releases/3.2/#customizing-type-of-auto-created-primary-keys passage des primary keys en AutoField.

J'estime qu'on n'en est pas encore au point où on a besoin d'un BigAutoField, mais détrompez-moi si je me trompe. :)

