### PR TITLE
Réparer la CI en utilisant le protocole https:// à la place de git+git://

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,4 @@ sentry-sdk==1.0.0
 sqlparse==0.3.1
 whitenoise==5.1.0
 
-git+git://github.com/betagouv/django-magicauth@0.7
+django-magicauth @ git+https://github.com/betagouv/django-magicauth.git@0.7


### PR DESCRIPTION
## 🌮 Objectif

Réparer la CI, cassée car nous utilisons un protocole non chiffré pour aller chercher notre dépendance à `django-magicauth`. 

Il se trouve que [Github avait prévenu](https://github.blog/2021-09-01-improving-git-protocol-security-github/#when-are-these-changes-effective
) que ça allait casser aujourd'hui (c'est un jour _brown out_) si on utilisait ce protocole non chiffré. Si on n'avait pas essayé de faire tourner la CI pile aujourd'hui on n'aurait rien remarqué jusqu'à la fin officielle du support.

## 🔍 Implémentation

- Dans requirements.txt, remplacement du protocole `git+git://` par sa variante `git+https://` + [ajustement de la syntaxe](https://www.python.org/dev/peps/pep-0440/#direct-references) pour que pip y comprenne quelque chose
