### PR TITLE
Bump celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ phonenumberslite==8.12.21
 django-phonenumber-field==5.0.0
 
 black==20.8b1
-celery[redis]==5.2
+celery[redis]==5.2.2
 coverage==5.1
 entrypoints==0.3
 factory-boy==2.12.0


### PR DESCRIPTION
## 🌮 Objectif

Il fallait celery >=5.2.2 et dans ma précédente PR, j'avais demandé celery==5.2… Mea culpa

## 🔍 Implémentation

- Forcage à celery 5.2.2
