### PR TITLE
Renommer les "demandes d'habilitation" existantes en "aidants à former"

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -276,7 +276,7 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
             + "</td></tr></table>"
         )
 
-    display_habilitation_requests.short_description = "Demandes d'habilitation"
+    display_habilitation_requests.short_description = "Aidants à former"
 
     def find_zipcode_in_address(self, request, queryset):
         for organisation in queryset:
@@ -681,13 +681,9 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
             for habilitation_request in queryset
             if habilitation_request.validate_and_create_aidant()
         )
-        self.message_user(
-            request, f"{rows_updated} demandes d'habilitation ont été validées."
-        )
+        self.message_user(request, f"{rows_updated} demandes ont été validées.")
 
-    mark_validated.short_description = (
-        "Valider les demandes d’habilitation sélectionnées"
-    )
+    mark_validated.short_description = "Créer les comptes aidants sélectionnés"
 
     def mark_refused(self, request, queryset):
         rows_updated = queryset.filter(
@@ -696,23 +692,17 @@ class HabilitationRequestAdmin(ExportMixin, VisibleToAdminMetier, ModelAdmin):
                 HabilitationRequest.STATUS_NEW,
             )
         ).update(status=HabilitationRequest.STATUS_REFUSED)
-        self.message_user(
-            request, f"{rows_updated} demandes d’habilitation ont été refusées."
-        )
+        self.message_user(request, f"{rows_updated} demandes ont été refusées.")
 
-    mark_refused.short_description = "Refuser les demandes d’habilitation sélectionnées"
+    mark_refused.short_description = "Refuser les demandes sélectionnées"
 
     def mark_processing(self, request, queryset):
         rows_updated = queryset.filter(status=HabilitationRequest.STATUS_NEW).update(
             status=HabilitationRequest.STATUS_PROCESSING
         )
-        self.message_user(
-            request, f"{rows_updated} demandes d’habilitation sont maintenant en cours."
-        )
+        self.message_user(request, f"{rows_updated} demandes sont maintenant en cours.")
 
-    mark_processing.short_description = (
-        "Passer « en cours » les demandes d'habilitation sélectionnées"
-    )
+    mark_processing.short_description = "Passer « en cours » les demandes sélectionnées"
 
     def get_urls(self):
         return [

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -451,8 +451,8 @@ class HabilitationRequest(models.Model):
                 fields=("email", "organisation"), name="unique_email_per_orga"
             ),
         )
-        verbose_name = "demande d’habilitation"
-        verbose_name_plural = "demandes d’habilitation"
+        verbose_name = "aidant à former"
+        verbose_name_plural = "aidants à former"
 
     def __str__(self):
         return f"{self.email}"

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -152,7 +152,7 @@ def notify_new_habilitation_requests():
         recipient_list=recipient_list,
         subject=(
             f"[Aidants Connect] {habilitation_requests_count} "
-            "nouvelles demandes d’habilitation"
+            "nouveaux aidants à former"
         ),
         message=text_message,
         html_message=html_message,

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -38,7 +38,7 @@
   {% endif %}
   {% if treated_emails %}
     <div class="successnote">
-      <p>Les demandes d'habilitation suivantes ont été validées, les comptes aidant ont été créés :</p>
+      <p>Les demandes suivantes ont été validées, les comptes aidant ont été créés :</p>
       <ul>
         {% for email in treated_emails %}
           <li><span aria-hidden="true">✅ </span>{{ email }}</li>

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.html
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.html
@@ -14,14 +14,18 @@
                       <p>Bonjour,</p>
                       <p>
                         Durant les {{ interval }} derniers jours, il y a eu sur Aidants Connect
-                        {{ total_requests }} nouvelles demandes d'habilitation
+                        {{ total_requests }} nouveaux aidants à former
                         dans {{ organisations.count }} structures différentes :
                       </p>
                       <ul>
                         {% for org in organisations %}
-                          <li>{{ org.name }} : {{ org.num_requests }} demandes</li>
+                          <li>{{ org.name }} : {{ org.num_requests }} aidants</li>
                         {% endfor %}
                       </ul>
+                      <p>
+                        Afin de les traiter, vous pouvez les retrouver dans l'administration Django,
+                        dans la rubrique « aidants à former ».
+                      </p>
                       <p>Bonne journée,</p>
                       <p>Le robot Aidants Connect</p>
                     </td>

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.txt
@@ -1,7 +1,7 @@
 Bonjour,
 
 Durant les {{ interval }} derniers jours, il y a eu sur Aidants Connect
-{{ total_requests }} nouvelles demandes d'habilitation
+{{ total_requests }} nouveaux aidants à former
 dans {{ organisations.count }} structures différentes :
 
 {% for org in organisations %}
@@ -9,7 +9,7 @@ dans {{ organisations.count }} structures différentes :
 {% endfor %}
 
 Afin de les traiter, vous pouvez les retrouver dans l'administration Django,
-dans la rubrique « demandes d’habilitation ».
+dans la rubrique « aidants à former ».
 
 Bonne journée,
 

--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -268,8 +268,8 @@ class NewHabilitationRequestsTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         mail_content = mail.outbox[0].body
         mail_subject = mail.outbox[0].subject
-        self.assertIn("3 nouvelles demandes d’habilitation", mail_subject)
-        self.assertIn("3 nouvelles demandes d'habilitation", mail_content)
+        self.assertIn("3 nouveaux aidants à former", mail_subject)
+        self.assertIn("3 nouveaux aidants à former", mail_content)
         self.assertIn("dans 3 structures différentes", mail_content)
 
     def test_counting_of_habilitation_requests(self):
@@ -278,8 +278,8 @@ class NewHabilitationRequestsTests(TestCase):
         self.assertEqual(len(mail.outbox), 1)
         mail_content = mail.outbox[0].body
         mail_subject = mail.outbox[0].subject
-        self.assertIn("4 nouvelles demandes d’habilitation", mail_subject)
-        self.assertIn("4 nouvelles demandes d'habilitation", mail_content)
+        self.assertIn("4 nouveaux aidants à former", mail_subject)
+        self.assertIn("4 nouveaux aidants à former", mail_content)
         self.assertIn("dans 2 structures différentes", mail_content)
 
 

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -586,6 +586,10 @@ class HabilitationRequestAdminPageTests(TestCase):
             )
             self.assertTrue(Aidant.objects.filter(email=email).exists())
         self.assertContains(
-            response, "Les demandes d'habilitation suivantes ont été validées"
+            response,
+            (
+                "Les demandes suivantes ont été validées, les comptes aidant "
+                "ont été créés"
+            ),
         )
         self.assertContains(response, "Nous n'avons pas pu traiter les")


### PR DESCRIPTION
## 🌮 Objectif

Éviter de se retrouver avec deux entrées "demandes d'habilitation" dans l'admin, quand on aura mis en prod le nouveau formulaire d'habilitation.

## 🔍 Implémentation

- Changement de wording pour changer uniquement l'affichage.
- Si l'on veut changer également la classe, j'ai besoin :
     - d'aide pour savoir comment je la renomme (`AidantAFormer` ?)
     - d'aide pour gérer le renommage de la table en douceur lors des prochains déploiements
- Comme cela me semblait un peu risqué, j'ai préféré ne rien tenter, mais vous me dites.


## 🖼️ Images

![Capture d’écran 2022-01-13 à 16 07 35](https://user-images.githubusercontent.com/1035145/149355638-5c9b549d-b5b2-4faa-aed9-1b7aa166718f.png)

