### PR TITLE
Ajoute les filtres par région et statut dans l'admin "habilitation"

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -32,6 +32,8 @@ class MessageInline(VisibleToAdminMetier, StackedInline):
 
 
 class OrganisationRequestAdmin(VisibleToAdminMetier, ModelAdmin):
+    list_filter = ("status",)
+    list_display = ("name", "issuer", "status")
     raw_id_fields = ("issuer",)
     readonly_fields = ("public_service_delegation_attestation",)
     inlines = (

--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -2,7 +2,12 @@ from django.contrib.admin import ModelAdmin, TabularInline, StackedInline
 
 from django.conf import settings
 
-from aidants_connect.admin import admin_site, VisibleToAdminMetier
+from aidants_connect.admin import (
+    admin_site,
+    VisibleToAdminMetier,
+    RegionFilter,
+    DepartmentFilter,
+)
 from aidants_connect_habilitation.models import (
     AidantRequest,
     Issuer,
@@ -32,7 +37,7 @@ class MessageInline(VisibleToAdminMetier, StackedInline):
 
 
 class OrganisationRequestAdmin(VisibleToAdminMetier, ModelAdmin):
-    list_filter = ("status",)
+    list_filter = ("status", RegionFilter, DepartmentFilter)
     list_display = ("name", "issuer", "status")
     raw_id_fields = ("issuer",)
     readonly_fields = ("public_service_delegation_attestation",)

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -1,13 +1,13 @@
 from django.test import tag, TestCase
 
-from aidants_connect.admin import DepartmentFilter
+from aidants_connect.admin import DepartmentFilter, RegionFilter
 from aidants_connect_web.admin import OrganisationAdmin
 from aidants_connect_web.models import Organisation
 from aidants_connect_web.tests.factories import OrganisationFactory
 
 
 @tag("admin")
-class DeparmentFilterTests(TestCase):
+class DepartmentFilterTests(TestCase):
     def test_generate_filter_list(self):
         result = DepartmentFilter.generate_filter_list()
         self.assertEqual(len(result), 102)
@@ -39,6 +39,35 @@ class DeparmentFilterTests(TestCase):
 
         other_filter = DepartmentFilter(
             None, {"department": "other"}, Organisation, OrganisationAdmin
+        )
+        queryset_other = other_filter.queryset(None, Organisation.objects.all())
+        self.assertEqual(1, queryset_other.count())
+        self.assertEqual("0", queryset_other[0].zipcode)
+
+
+@tag("admin")
+class RegionFilterTests(TestCase):
+    def test_queryset(self):
+        OrganisationFactory(zipcode="13013")
+        OrganisationFactory(zipcode="13013")
+        OrganisationFactory(zipcode="20000")
+        OrganisationFactory(zipcode="0")
+        corse_filter = RegionFilter(
+            None, {"region": "5"}, Organisation, OrganisationAdmin
+        )
+        queryset_corse = corse_filter.queryset(None, Organisation.objects.all())
+        self.assertEqual(1, queryset_corse.count())
+        self.assertEqual("20000", queryset_corse[0].zipcode)
+
+        paca_filter = RegionFilter(
+            None, {"region": "17"}, Organisation, OrganisationAdmin
+        )
+        queryset_paca = paca_filter.queryset(None, Organisation.objects.all())
+        self.assertEqual(2, queryset_paca.count())
+        self.assertEqual("13013", queryset_paca[0].zipcode)
+
+        other_filter = RegionFilter(
+            None, {"region": "other"}, Organisation, OrganisationAdmin
         )
         queryset_other = other_filter.queryset(None, Organisation.objects.all())
         self.assertEqual(1, queryset_other.count())


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux bizdev de filtrer facilement pour retrouver les demandes d'habilitation qui les concernent plus particulièrement

## 🔍 Implémentation

- Ajout de filtres simples et moins simples

## 🏕 Amélioration continue

- Refactoring du filtre `RegionFilter` pour supprimer du code 🔥 
- Ajout d'un test sur le filtre sus-mentionné

## 🖼️ Images

Ça fait beaucoup de départements tout ça :D 

![Screenshot 2022-01-18 at 11-57-41 Sélectionnez l’objet Demande d’habilitation à changer Site d’administration de Django](https://user-images.githubusercontent.com/1035145/149926805-ac86a435-abc1-44f1-ad49-feb12f616aab.png)

