### PR TITLE
N'afficher que les départements relatifs à la région sélectionnée, si pertinent

### DIFF
--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -1,4 +1,5 @@
 from django.test import tag, TestCase
+from django.test.client import RequestFactory
 
 from aidants_connect.admin import DepartmentFilter, RegionFilter
 from aidants_connect_web.admin import OrganisationAdmin
@@ -8,6 +9,10 @@ from aidants_connect_web.tests.factories import OrganisationFactory
 
 @tag("admin")
 class DepartmentFilterTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.rf = RequestFactory()
+
     def test_generate_filter_list(self):
         result = DepartmentFilter.generate_filter_list()
         self.assertEqual(len(result), 102)
@@ -15,8 +20,15 @@ class DepartmentFilterTests(TestCase):
         self.assertEqual(("20", "Corse-du-Sud (20)"), result[19])
 
     def test_lookup(self):
-        dep_filter = DepartmentFilter(None, {}, Organisation, OrganisationAdmin)
-        self.assertEqual(len(dep_filter.lookups(None, {})), 102)
+        request = self.rf.get("/")
+        dep_filter = DepartmentFilter(request, {}, Organisation, OrganisationAdmin)
+        self.assertEqual(len(dep_filter.lookups(request, {})), 102)
+
+    def test_lookups_with_selected_region(self):
+        params = {"region": "6"}
+        request = self.rf.get("/", params)
+        dep_filter = DepartmentFilter(request, params, Organisation, OrganisationAdmin)
+        self.assertEqual(len(dep_filter.lookups(request, {})), 10)
 
     def test_queryset(self):
         OrganisationFactory(zipcode="13013")
@@ -24,23 +36,25 @@ class DepartmentFilterTests(TestCase):
         OrganisationFactory(zipcode="20000")
         OrganisationFactory(zipcode="0")
         corse_filter = DepartmentFilter(
-            None, {"department": "20"}, Organisation, OrganisationAdmin
+            self.rf.get("/"), {"department": "20"}, Organisation, OrganisationAdmin
         )
         queryset_corse = corse_filter.queryset(None, Organisation.objects.all())
         self.assertEqual(1, queryset_corse.count())
         self.assertEqual("20000", queryset_corse[0].zipcode)
 
         bdc_filter = DepartmentFilter(
-            None, {"department": "13"}, Organisation, OrganisationAdmin
+            self.rf.get("/"), {"department": "13"}, Organisation, OrganisationAdmin
         )
         queryset_bdc = bdc_filter.queryset(None, Organisation.objects.all())
         self.assertEqual(2, queryset_bdc.count())
         self.assertEqual("13013", queryset_bdc[0].zipcode)
 
         other_filter = DepartmentFilter(
-            None, {"department": "other"}, Organisation, OrganisationAdmin
+            self.rf.get("/"), {"department": "other"}, Organisation, OrganisationAdmin
         )
-        queryset_other = other_filter.queryset(None, Organisation.objects.all())
+        queryset_other = other_filter.queryset(
+            self.rf.get("/"), Organisation.objects.all()
+        )
         self.assertEqual(1, queryset_other.count())
         self.assertEqual("0", queryset_other[0].zipcode)
 


### PR DESCRIPTION
## 🌮 Objectif

Quand on sélectionne un filtre par région dans l'admin, (par ex. grand est) on a toujours les 102 départements qui sont affichés dans le filtre éponyme. Ce serait plus malin de n'afficher que les départements de la région sélectionnée.

## 🔍 Implémentation

- Utilisation de l'objet `request` pour modifier ce qu'on va chercher dans les lookups.
- Ajout de tests (avec utilisation d'une `RequestFactory` parce que `None` ne passe plus comme paramètre `request`)

## 🖼️ Images

C'est quand même plus sympa comme ça : 

<img width="487" alt="Capture d’écran 2022-01-18 à 12 28 59" src="https://user-images.githubusercontent.com/1035145/149929319-5323af62-c3b2-48df-8bd6-31b5edae4d85.png">

