### PR TITLE
Masquer le bouton renouveler si tout les mandats d'un usager sont explicitement révoqués ou expirés depuis plus d'un an

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -601,6 +601,12 @@ class Usager(models.Model):
         )
         entries.delete()
 
+    def all_revoked_mandats(self):
+        for mandat in self.mandats.all():
+            if not mandat.was_explicitly_revoked:
+                return False
+        return True
+
 
 def get_staff_organisation_name_id() -> int:
     try:

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -601,9 +601,12 @@ class Usager(models.Model):
         )
         entries.delete()
 
-    def all_revoked_mandats(self):
+    def has_all_mandats_revoked_or_expired_over_a_year(self):
         for mandat in self.mandats.all():
-            if not mandat.was_explicitly_revoked:
+            if (
+                not mandat.was_explicitly_revoked
+                and timezone.now() < mandat.expiration_date + timedelta(days=365)
+            ):
                 return False
         return True
 

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
@@ -30,5 +30,9 @@
       </ul>
     </td>
   {% endif %}
+  {% if usager.all_revoked_mandats %}
+  <td></td>
+  {% else %}
   <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>
+  {% endif %}
 </tr>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
@@ -30,7 +30,7 @@
       </ul>
     </td>
   {% endif %}
-  {% if usager.all_revoked_mandats %}
+  {% if usager.has_all_mandats_revoked_or_expired_over_a_year %}
   <td></td>
   {% else %}
   <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
@@ -60,7 +60,7 @@
             </thead>
             <tbody>
             {% for usager in usagers_dict.without_valid_mandate %}
-              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False %}
+              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False%}
             {% endfor %}
             </tbody>
           </table>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
@@ -60,7 +60,7 @@
             </thead>
             <tbody>
             {% for usager in usagers_dict.without_valid_mandate %}
-              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False%}
+              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False %}
             {% endfor %}
             </tbody>
           </table>

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -125,6 +125,21 @@ class MandatFactory(factory.DjangoModelFactory):
             )
 
 
+class RevokedMandatFactory(MandatFactory):
+    @factory.post_generation
+    def post(self, create, _, **kwargs):
+        authorisations = kwargs.get("create_authorisations", None)
+        if not create or not isinstance(authorisations, Iterable):
+            return
+
+        for auth in authorisations:
+            Autorisation.objects.create(
+                mandat=self,
+                demarche=str(auth),
+                revocation_date=(now() - timedelta(days=5)),
+            )
+
+
 class ExpiredMandatFactory(MandatFactory):
     expiration_date = factory.LazyAttribute(lambda f: now() - timedelta(days=365))
 

--- a/aidants_connect_web/tests/test_views/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_renew_mandat.py
@@ -9,6 +9,7 @@ from aidants_connect_web.models import Connection, Mandat, Journal
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     MandatFactory,
+    RevokedMandatFactory,
     OrganisationFactory,
     UsagerFactory,
 )
@@ -26,6 +27,22 @@ class RenewMandatTests(TestCase):
         device.token_set.create(token="223456")
 
         cls.usager = UsagerFactory(given_name="Fabrice")
+
+    def test_no_renew_button_displayed_if_should_not(self):
+        mandat = RevokedMandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+        self.assertTrue(
+            mandat.was_explicitly_revoked,
+            "Generated mandat should be explicitly revoked",
+        )
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Mandat.objects.count(), 1)
+        response = self.client.get(reverse("usagers"))
+        self.assertNotContains(response, "Renouveler")
 
     def test_renew_mandat_ok(self):
         MandatFactory(

--- a/aidants_connect_web/tests/test_views/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_renew_mandat.py
@@ -28,21 +28,73 @@ class RenewMandatTests(TestCase):
 
         cls.usager = UsagerFactory(given_name="Fabrice")
 
-    def test_no_renew_button_displayed_if_should_not(self):
-        mandat = RevokedMandatFactory(
+    def test_no_renew_button_displayed_if_expired_over_a_year(self):
+        over_a_year_expired_mandat = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() - timedelta(days=365),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+        self.assertFalse(
+            over_a_year_expired_mandat.is_active,
+            "Generated mandat should not be active",
+        )
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Mandat.objects.count(), 1)
+        response = self.client.get(reverse("usagers"))
+        self.assertNotContains(response, "Renouveler")
+
+    def test_no_renew_button_displayed_if_revoked_mandat(self):
+        revoked_mandat = RevokedMandatFactory(
             organisation=self.aidant_thierry.organisation,
             usager=self.usager,
             expiration_date=timezone.now() + timedelta(days=5),
             post__create_authorisations=["argent", "famille", "logement"],
         )
         self.assertTrue(
-            mandat.was_explicitly_revoked,
+            revoked_mandat.was_explicitly_revoked,
             "Generated mandat should be explicitly revoked",
         )
         self.client.force_login(self.aidant_thierry)
         self.assertEqual(Mandat.objects.count(), 1)
         response = self.client.get(reverse("usagers"))
         self.assertNotContains(response, "Renouveler")
+
+    def test_show_renew_button_if_any_renewable_mandats(self):
+        less_than_a_year_expired_mandat = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() - timedelta(days=5),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+        revoked_mandat = RevokedMandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() + timedelta(days=5),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+        over_a_year_expired_mandat = MandatFactory(
+            organisation=self.aidant_thierry.organisation,
+            usager=self.usager,
+            expiration_date=timezone.now() - timedelta(days=365),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+        self.assertFalse(
+            less_than_a_year_expired_mandat.is_active,
+            "Generated mandat should not be active",
+        )
+        self.assertTrue(
+            revoked_mandat.was_explicitly_revoked,
+            "Generated mandat should be explicitly revoked",
+        )
+        self.assertFalse(
+            over_a_year_expired_mandat.is_active,
+            "Generated mandat should not be active",
+        )
+        self.client.force_login(self.aidant_thierry)
+        self.assertEqual(Mandat.objects.count(), 3)
+        response = self.client.get(reverse("usagers"))
+        self.assertContains(response, "Renouveler")
 
     def test_renew_mandat_ok(self):
         MandatFactory(


### PR DESCRIPTION
## 🌮 Objectif
Masquer le bouton renouveler si tout les mandats d'un usager sont explicitement révoqués ou expirés depuis plus d'un an.

## 🔍 Implémentation
Ajout de la fonction has_all_mandats_revoked_or_expired_over_a_year qui retourne True si tous les mandats d'un usager sont révoqués ou expirés depuis plus d'un an. Changement dans le template usager_row pour cacher le bouton "Renouveler le mandat"

