### PR TITLE
Esquive le test cassé à cause de l'indispo FranceConnect

### DIFF
--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -25,6 +25,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         device.token_set.create(token="123456")
         device.token_set.create(token="123455")
 
+    @skip("Reactivate when FC public key can be used again")
     def test_create_new_mandat(self):
         wait = WebDriverWait(self.selenium, 10)
 


### PR DESCRIPTION
## 🌮 Objectif

Cf. problème de validité de la clé utilisée actuellement pour se connecter à FranceConnect en local et en test. Un des tests Selenium qui va jusqu'à la connexion FC en tant que FS ne passe pas car nous avons un message d'erreur à la place du sélecteur d'identité.

## 🔍 Implémentation

- Ajout d'un @skip sur le test qui ne passe pas
