### PR TITLE
Mise à jour des version mineures et patch des dépendances

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ ptpython==3.0.20
 pudb==2019.2
 PyJWT==1.7.1
 python-dotenv==0.13.0
-pytz==2020.1
+pytz==2021.3
 qrcode==6.1
 requests==2.27.1
 selenium==3.141.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,41 +2,41 @@ Django==3.2.11
 
 django-admin-honeypot==1.1.0
 django-celery-beat==2.2.1
-django-csp==3.6
-django-extensions==3.0.1
-django-nested-admin==3.3.2
+django-csp==3.7
+django-extensions==3.1.5
+django-nested-admin==3.4.0
 django-otp==0.9.3
 django-referrer-policy==1.0
 django-tabbed-admin==1.0.4
 django-import-export==2.5.0
-django-debug-toolbar==3.2.1
+django-debug-toolbar==3.2.4
 
-phonenumberslite==8.12.21
-django-phonenumber-field==5.0.0
+phonenumberslite==8.12.41
+django-phonenumber-field==6.0.0
 
 black==21.12b0
-celery[redis]==5.2.2
-coverage==5.1
+celery[redis]==5.2.3
+coverage==6.2
 entrypoints==0.3
 factory-boy==2.12.0
 flake8==3.8.3
 freezegun==0.3.15
-gunicorn==20.0.4
+gunicorn==20.1.0
 ipython==7.16.3
-mock==4.0.2
+mock==4.0.3
 Pillow==9.0.0
-pre-commit==2.11.1
-psycopg2-binary==2.8.5
-ptpython==3.0.2
+pre-commit==2.17.0
+psycopg2-binary==2.9.3
+ptpython==3.0.20
 pudb==2019.2
 PyJWT==1.7.1
 python-dotenv==0.13.0
 pytz==2020.1
 qrcode==6.1
-requests==2.24.0
+requests==2.27.1
 selenium==3.141.0
-sentry-sdk==1.0.0
+sentry-sdk==1.5.3
 sqlparse==0.3.1
-whitenoise==5.1.0
+whitenoise==5.3.0
 
 django-magicauth @ git+https://github.com/betagouv/django-magicauth.git@0.7


### PR DESCRIPTION
## 🌮 Objectif

Mise à jour des dépendances. Les dépendances qui avaient une mise à jour en version mineure ou patch (`x.*`, `x.*.*` ou `x.y.*`) ont été mises à jour. Les versions majeures n'ont pas été touchées, de même que les versions `0.*` qui ont le droit de casser entre les versions selon la spécification *semver*.

`coverage` a été mise à jour même si c'est une màj majeure parce que c'est une dépendance de test relativement annexe. La criticité est très, très faible.

` django-phonenumber-field` est aussi mis à jour en version majeure pour son [breaking change très anodin](https://github.com/stefanfoulis/django-phonenumber-field/releases/tag/6.0.0).