### PR TITLE
Faire tourner scss --watch en même temps qu'on lance le serveur

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -100,6 +100,9 @@ SECRET_KEY = os.getenv("APP_SECRET")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = getenv_bool("DEBUG", False)
 
+# Launch sass --watch alongside with the server
+WITH_SCSS_WATCH = getenv_bool("WITH_SCSS_WATCH", False)
+
 # We support a comma-separated list of allowed hosts.
 ENV_SEPARATOR = ","
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost").split(ENV_SEPARATOR)

--- a/aidants_connect_web/apps.py
+++ b/aidants_connect_web/apps.py
@@ -7,3 +7,10 @@ class AidantConnectWebConfig(AppConfig):
     def ready(self):
         import aidants_connect_web.signals  # noqa
         import aidants_connect.lookups  # noqa
+
+        from django.conf import settings
+
+        if settings.DEBUG and settings.WITH_SCSS_WATCH:
+            from django.core.management import call_command
+
+            call_command("scss", "--watch")


### PR DESCRIPTION
## 🌮 Objectif

Permettre d'avoir en même temps le serveur et le watch SCSS qui tournent quand on lance la commande suivante : 

```
WITH_SCSS_WATCH=True mana runserver 3000
```

## 🔍 Implémentation

- Branchement dans apps.py
- …sauf que ça marche pas 🤷 : le scss se lance bien, mais pas le serveur. Peut-être qu'il faudrait détacher le process scss, mais comment faire pour l'arrêter ensuite en même temps que le serveur quand on ctrl-C ?

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
