### PR TITLE
MAJ du logo CircleCI sur le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aidants Connect
 
-[![CircleCI](https://circleci.com/gh/betagouv/Aidants_Connect/tree/master.svg?style=svg)](https://circleci.com/gh/betagouv/Aidants_Connect/tree/master)
+[![CircleCI](https://circleci.com/gh/betagouv/Aidants_Connect/tree/main.svg?style=svg)](https://circleci.com/gh/betagouv/Aidants_Connect/tree/main)
 
 Aidants Connect est une application web qui propose à des aidants les fonctionnalités suivantes :
 


### PR DESCRIPTION
## 🌮 Objectif

Le logo "circle ci passed" sur notre readme renvoyait en fait vers la branche "master". Cela fait plus d'un an que la branche principale du dépôt a été renommée en "main".

## 🔍 Implémentation

- Modif de l'URL de l'image et de la cible du lien
