### PR TITLE
Ajout de la Corse à la table DatavizDepartment et suppression des département Haute-Corse et Corse-du-Sud

### DIFF
--- a/aidants_connect_web/fixtures/departements_region.json
+++ b/aidants_connect_web/fixtures/departements_region.json
@@ -95,6 +95,11 @@
     "region_name": "Nouvelle-Aquitaine"
   },
   {
+    "zipcode": 20,
+    "dep_name": "Corse",
+    "region_name": "Corse"
+  },
+  {
     "zipcode": 21,
     "dep_name": "Côte-d'Or",
     "region_name": "Bourgogne-Franche-Comté"
@@ -138,16 +143,6 @@
     "zipcode": 29,
     "dep_name": "Finistère",
     "region_name": "Bretagne"
-  },
-  {
-    "zipcode": "2A",
-    "dep_name": "Corse-du-Sud",
-    "region_name": "Corse"
-  },
-  {
-    "zipcode": "2B",
-    "dep_name": "Haute-Corse",
-    "region_name": "Corse"
   },
   {
     "zipcode": 30,

--- a/aidants_connect_web/migrations/0052_add_departements_to_region_table.py
+++ b/aidants_connect_web/migrations/0052_add_departements_to_region_table.py
@@ -7,7 +7,6 @@ from django.db import migrations, models, transaction
 import aidants_connect_web
 
 
-@transaction.atomic
 def populate_departements_to_region_table(apps, _):
     # noinspection PyPep8Naming
     DatavizRegion = apps.get_model("aidants_connect_web", "DatavizRegion")
@@ -41,8 +40,6 @@ def populate_departements_to_region_table(apps, _):
 
 
 class Migration(migrations.Migration):
-    atomic = False
-
     dependencies = [
         ("aidants_connect_web", "0051_mandat_template_path"),
     ]

--- a/aidants_connect_web/migrations/0080_add_corse_departement.py
+++ b/aidants_connect_web/migrations/0080_add_corse_departement.py
@@ -1,0 +1,73 @@
+from os.path import dirname, join as path_join
+from json import loads as json_loads
+
+import django
+from django.db import migrations, models, transaction
+
+import aidants_connect_web
+
+
+def populate_corse_departement(apps, _):
+    DatavizRegion = apps.get_model("aidants_connect_web", "DatavizRegion")
+    DatavizDepartment = apps.get_model("aidants_connect_web", "DatavizDepartment")
+    DatavizDepartmentsToRegion = apps.get_model(
+        "aidants_connect_web", "DatavizDepartmentsToRegion"
+    )
+    departement, _ = DatavizDepartment.objects.get_or_create(
+        zipcode=20, dep_name="Corse"
+    )
+    region = DatavizRegion.objects.get(name="Corse")
+    DatavizDepartmentsToRegion.objects.get_or_create(
+        department=departement, region=region
+    )
+
+    for zipcode in ["2A", "2B"]:
+        try:
+            departement = DatavizDepartment.objects.get(zipcode=zipcode)
+            DatavizDepartmentsToRegion.objects.get(department=departement).delete()
+            departement.delete()
+        except (
+            DatavizDepartment.DoesNotExist,
+            DatavizDepartmentsToRegion.DoesNotExist,
+        ):
+            pass
+
+
+def reverse_populate_corse_departement(apps, _):
+    DatavizRegion = apps.get_model("aidants_connect_web", "DatavizRegion")
+    DatavizDepartment = apps.get_model("aidants_connect_web", "DatavizDepartment")
+    DatavizDepartmentsToRegion = apps.get_model(
+        "aidants_connect_web", "DatavizDepartmentsToRegion"
+    )
+
+    try:
+        departement = DatavizDepartment.objects.get(zipcode=20)
+        DatavizDepartmentsToRegion.objects.get(department=departement).delete()
+        departement.delete()
+    except (
+        DatavizDepartment.DoesNotExist,
+        DatavizDepartmentsToRegion.DoesNotExist,
+    ):
+        pass
+
+    region = DatavizRegion.objects.get(name="Corse")
+    for zipcode, dep_name in [("2A", "Corse-du-Sud"), ("2B", "Haute-Corse")]:
+        departement, _ = DatavizDepartment.objects.get_or_create(
+            zipcode=zipcode, dep_name=dep_name
+        )
+        DatavizDepartmentsToRegion.objects.get_or_create(
+            department=departement, region=region
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("aidants_connect_web", "0079_organisation_city"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            populate_corse_departement,
+            reverse_code=reverse_populate_corse_departement,
+        ),
+    ]

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -15,14 +15,14 @@ class DepartmentFilterTests(TestCase):
 
     def test_generate_filter_list(self):
         result = DepartmentFilter.generate_filter_list()
-        self.assertEqual(len(result), 102)
+        self.assertEqual(len(result), 101)
         self.assertEqual(("01", "Ain (01)"), result[0])
-        self.assertEqual(("20", "Corse-du-Sud (20)"), result[19])
+        self.assertEqual(("20", "Corse (20)"), result[19])
 
     def test_lookup(self):
         request = self.rf.get("/")
         dep_filter = DepartmentFilter(request, {}, Organisation, OrganisationAdmin)
-        self.assertEqual(len(dep_filter.lookups(request, {})), 102)
+        self.assertEqual(len(dep_filter.lookups(request, {})), 101)
 
     def test_lookups_with_selected_region(self):
         params = {"region": "6"}


### PR DESCRIPTION
## 🌮 Objectif

Ça nous évitera d'avoir à nous casser la tête sur le SQL dans Metabase.