### PR TITLE
Diminuer le nombre d'erreurs 500 en prod

### DIFF
--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -7,6 +7,7 @@ import jwt
 from django.conf import settings
 from django.test import override_settings, tag, TestCase
 from django.test.client import Client
+from django.urls import reverse
 
 from aidants_connect.common.constants import AuthorizationDurationChoices
 from aidants_connect_web.models import Connection, Journal, Usager
@@ -49,6 +50,7 @@ class FCCallback(TestCase):
     def setUp(self):
         self.client = Client()
         self.aidant = AidantFactory()
+        self.client.force_login(self.aidant)
         self.epoch_date = DATE.timestamp()
         self.connection = Connection.objects.create(
             demarches=["argent", "papiers"],
@@ -74,30 +76,37 @@ class FCCallback(TestCase):
         self.usager = UsagerFactory(given_name="Joséphine", sub=self.usager_sub)
 
     @freeze_time(date)
-    def test_no_code_triggers_403(self):
+    def test_no_code_triggers_fc_error(self):
         response = self.client.get("/callback/", data={"state": "test_state"})
-        self.assertEqual(response.status_code, 403)
+        self.check_fc_error_with_message(response)
 
     @freeze_time(date)
-    def test_no_state_triggers_403(self):
+    def test_no_state_triggers_fc_error(self):
         response = self.client.get("/callback/", data={"code": "test_code"})
-        self.assertEqual(response.status_code, 403)
+        self.check_fc_error_with_message(response)
 
     @freeze_time(date)
-    def test_non_existing_state_triggers_403(self):
+    def test_non_existing_state_triggers_fc_error(self):
         response = self.client.get(
             "/callback/", data={"state": "wrong_state", "code": "test_code"}
         )
-        self.assertEqual(response.status_code, 403)
+        self.check_fc_error_with_message(response)
 
     date_expired = DATE + timedelta(seconds=TEST_FC_CONNECTION_AGE + 1)
 
+    def check_fc_error_with_message(self, response):
+        self.assertRedirects(
+            response, reverse("new_mandat"), fetch_redirect_response=False
+        )
+        response = self.client.get(reverse("new_mandat"))
+        self.assertContains(response, "Nous avons rencontré une erreur")
+
     @freeze_time(date_expired)
-    def test_expired_connection_returns_408(self):
+    def test_expired_connection_yields_fc_error(self):
         response = self.client.get(
             "/callback/", data={"state": "test_state", "code": "test_code"}
         )
-        self.assertEqual(response.status_code, 408)
+        self.check_fc_error_with_message(response)
 
     @freeze_time(date)
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.post")
@@ -121,7 +130,7 @@ class FCCallback(TestCase):
         response = self.client.get(
             "/callback/", data={"state": "test_another_state", "code": "test_code"}
         )
-        self.assertEqual(response.status_code, 403)
+        self.check_fc_error_with_message(response)
 
     @freeze_time(date)
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.post")

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -335,6 +335,18 @@ class GetUserInfoTests(TestCase):
         self.assertIn("The FranceConnect ID is not complete:", error)
 
     @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")
+    def test_empty_response_does_not_fail_badly(self, mock_get):
+        mock_response = mock.Mock()
+        mock_response.status_code = 200
+        mock_response.content = "content"
+        mock_response.json = mock.Mock(return_value={})
+        mock_get.return_value = mock_response
+        usager, error = get_user_info(self.connection)
+
+        self.assertIsNone(usager)
+        self.assertIn("Unable to find sub in FC user info", error)
+
+    @mock.patch("aidants_connect_web.views.FC_as_FS.python_request.get")
     def test_formatted_new_user_without_birthplace_outputs_usager(self, mock_get):
         mock_response = mock.Mock()
         mock_response.status_code = 200

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -4,17 +4,14 @@ import jwt
 from jwt.api_jwt import ExpiredSignatureError
 import requests as python_request
 
-
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.db import IntegrityError
-from django.http import HttpResponseForbidden
 from django.shortcuts import redirect, render
 from django.urls import reverse
 
 from aidants_connect_web.models import Connection, Usager, Journal
 from aidants_connect_web.utilities import generate_sha256_hash
-
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()
@@ -80,9 +77,7 @@ def fc_callback(request):
     try:
         connection = Connection.objects.get(state=state)
     except Connection.DoesNotExist:
-        log.info("FC as FS - This state does not seem to exist")
-        log.info(state)
-        return HttpResponseForbidden()
+        return fc_error(f"FC as FS - This state does not seem to exist: {state}")
 
     if request.GET.get("error"):
         return fc_error(
@@ -91,13 +86,11 @@ def fc_callback(request):
         )
 
     if connection.is_expired:
-        log.info("408: FC connection has expired.")
-        return render(request, "408.html", status=408)
+        return fc_error("408: FC connection has expired.")
 
     code = request.GET.get("code")
     if not code:
-        log.info("403: No code has been provided.")
-        return HttpResponseForbidden()
+        return fc_error("FC AS FS: no code has been provided")
 
     token_url = f"{fc_base}/token"
     payload = {
@@ -137,12 +130,10 @@ def fc_callback(request):
             algorithm="HS256",
         )
     except ExpiredSignatureError:
-        log.info("403: token signature has expired.")
-        return HttpResponseForbidden()
+        return fc_error("403: token signature has expired.")
 
     if connection.nonce != decoded_token.get("nonce"):
-        log.info("403: The nonce is different than the one expected.")
-        return HttpResponseForbidden()
+        return fc_error("FC as FS: The nonce is different than the one expected")
 
     if connection.is_expired:
         log.info("408: FC connection has expired.")
@@ -150,8 +141,7 @@ def fc_callback(request):
 
     usager, error = get_user_info(connection)
     if error:
-        django_messages.error(request, error)
-        return redirect("espace_aidant_home")
+        return fc_error(error)
 
     connection.usager = usager
     connection.save()

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -182,8 +182,12 @@ def get_user_info(connection: Connection) -> tuple:
     if user_info.get("birthplace") == "":
         user_info["birthplace"] = None
 
+    user_sub = user_info.get("sub")
+    if not user_sub:
+        return None, "Unable to find sub in FC user info"
+
     usager_sub = generate_sha256_hash(
-        f"{user_info['sub']}{settings.FC_AS_FI_HASH_SALT}".encode()
+        f"{user_sub}{settings.FC_AS_FI_HASH_SALT}".encode()
     )
 
     try:

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -8,7 +8,6 @@ from django.conf import settings
 from django.contrib import messages as django_messages
 from django.db import IntegrityError
 from django.shortcuts import redirect, render
-from django.urls import reverse
 
 from aidants_connect_web.models import Connection, Usager, Journal
 from aidants_connect_web.utilities import generate_sha256_hash
@@ -65,7 +64,7 @@ def fc_callback(request):
             "France Connect. C'est probabablement temporaire. Pouvez-vous réessayer "
             "votre requête ?",
         )
-        return redirect(reverse("new_mandat"))
+        return redirect("new_mandat")
 
     fc_base = settings.FC_AS_FS_BASE_URL
     fc_callback_uri = f"{settings.FC_AS_FS_CALLBACK_URL}/callback"

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -97,7 +97,13 @@ def new_mandat(request):
 @user_is_aidant
 @activity_required
 def new_mandat_recap(request):
-    connection = Connection.objects.get(pk=request.session["connection"])
+    connection_id = request.session.get("connection")
+    if not connection_id:
+        log.error("No connection id found in session")
+        return redirect("espace_aidant_home")
+
+    connection = Connection.objects.get(pk=connection_id)
+
     aidant = request.user
     usager = connection.usager
     demarches_description = [
@@ -209,7 +215,12 @@ def new_mandat_recap(request):
 @user_is_aidant
 @activity_required
 def new_mandat_success(request):
-    connection = Connection.objects.get(pk=request.session["connection"])
+    connection_id = request.session.get("connection")
+    if not connection_id:
+        log.error("No connection id found in session")
+        return redirect("espace_aidant_home")
+
+    connection = Connection.objects.get(pk=connection_id)
     aidant = request.user
     usager = connection.usager
 
@@ -224,7 +235,12 @@ def new_mandat_success(request):
 @user_is_aidant
 @activity_required
 def attestation_projet(request):
-    connection = Connection.objects.get(pk=request.session["connection"])
+    connection_id = request.session.get("connection")
+    if not connection_id:
+        log.error("No connection id found in session")
+        return redirect("espace_aidant_home")
+
+    connection = Connection.objects.get(pk=connection_id)
     aidant = request.user
     usager = connection.usager
     demarches = connection.demarches
@@ -251,7 +267,13 @@ def attestation_projet(request):
 @user_is_aidant
 @activity_required
 def attestation_final(request):
-    connection = Connection.objects.get(pk=request.session["connection"])
+    connection_id = request.session.get("connection")
+    if not connection_id:
+        log.error("No connection id found in session")
+        return redirect("espace_aidant_home")
+
+    connection = Connection.objects.get(pk=connection_id)
+
     aidant: Aidant = request.user
     usager = connection.usager
     demarches = connection.demarches


### PR DESCRIPTION
## 🌮 Objectif

Diminuer l'impact des erreurs FranceConnect en prod qui se manifestent soit par des 500 soit par des 403 "écran blanc".

## 🔍 Implémentation

- Utilisation de `session.get` au lieu de `session["connection"]` pour les `keyError: connection` que je soupçonne d'être dues à des longues sessions
- Idem, gestion intelligente quand on ne trouve pas la clé `sub` dans la réponse FranceConnect.
- MAJ des tests