### PR TITLE
Étoffe le mail automatique pour les cartes d'aidants non activées

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
@@ -36,7 +36,17 @@
                         {% endif %}
                         </ul>
                       {% endif %}
-                      <p>Rendez-vous dans <a href="{{ espace_responsable_url }}">votre espace responsable</a> afin de relier un compte aidant à une carte Aidants Connect</p>
+                      <p>Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes suivantes :
+                        <ul>
+                          <li>Le Responsable active son compte administrateur avec le code de 1ère connexion puis se rend sur son espace responsable à l’adresse suivante: <a href="{{ espace_responsable_url }}">votre espace responsable</a> </li>
+                          <li>Il se connecte avec l'adresse e-mail nominative et individuelle renseignée dans le  formulaire d’habilitation et le code à 6 chiffres qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.</li>
+                          <li>Il reçoit un email de connexion valable 45 minutes, clique sur “connexion” et se rend sur son espace Responsable pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion.<br> 
+                            Pour se faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.</li>
+                          </ul>                          
+                       Une fois que le Responsable s’est attribué une carte, il peut effectuer la même démarche pour attribuer une carte à chaque aidant habilité.</p>
+                      <p>Enfin, le Responsable Aidants Connect doit s’inscrire à un webinaire dédié de 30 minutes dont l’objectif est de préciser le rôle de Responsable Aidants Connect. <br>
+                        Si ce n’est pas déjà fait, nous vous invitons à vous y inscrire à l’adresse suivante :<a href="https://app.livestorm.co/incubateur-des-territoires/responsable-aidants-connect?type=detailed"> </p>
+                                          
                     </td>
                   </tr>
                 </table>

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
@@ -1,5 +1,5 @@
 {% extends "layouts/email_base.html" %}
-{%  load ac_extras %}
+{% load ac_extras %}
 
 {% block email_body %}
   <table border="0" cellpadding="0" cellspacing="0" class="body">
@@ -14,39 +14,61 @@
                   <tr>
                     <td>
                       <p>Bonjour,</p>
-                      {% if not users  %}
-                        <p>L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est liée à votre compte.</p>
+                      {% if not users %}
+                        <p>L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est liée à votre
+                          compte.</p>
                       {% else %}
-                        <p>L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est liée aux aidants ou aidantes suivantes&nbsp;:</p>
+                        <p>L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est liée aux aidants
+                          ou aidantes suivantes&nbsp;:</p>
                         <ul>
-                        {% for user in users %}
-                          {% linebreakless %}
-                          <li>
-                            {% if user.full_name is not None %}
-                              {{ user.full_name }}
-                            {% else %}
-                              un aidant ou une aidante possédant l'e-mail {{ user.email }}
-                            {% endif %}
-                            {% list_term additionnal_cond=notify_self %}
-                          </li>
-                          {% endlinebreakless %}
-                        {% endfor %}
-                        {% if notify_self %}
-                          <li>vous-même.</li>
-                        {% endif %}
+                          {% for user in users %}
+                            {% linebreakless %}
+                              <li>
+                                {% if user.full_name is not None %}
+                                  {{ user.full_name }}
+                                {% else %}
+                                  un aidant ou une aidante possédant l'e-mail {{ user.email }}
+                                {% endif %}
+                                {% list_term additionnal_cond=notify_self %}
+                              </li>
+                            {% endlinebreakless %}
+                          {% endfor %}
+                          {% if notify_self %}
+                            <li>vous-même.</li>
+                          {% endif %}
                         </ul>
                       {% endif %}
-                      <p>Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes suivantes :
-                        <ul>
-                          <li>Le Responsable active son compte administrateur avec le code de première connexion puis se rend sur son espace responsable à l’adresse suivante: <a href="{{ espace_responsable_url }}">votre espace responsable</a> </li>
-                          <li>Il se connecte avec l'adresse e-mail nominative et individuelle renseignée dans le  formulaire d’habilitation et le code à 6 chiffres qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.</li>
-                          <li>Il reçoit un email de connexion valable 45 minutes, clique sur “connexion” et se rend sur son espace Responsable pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion.<br> 
-                            Pour se faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.</li>
-                          </ul>                          
-                       Une fois que le Responsable s’est attribué une carte, il peut effectuer la même démarche pour attribuer une carte à chaque aidant habilité.</p>
-                      <p>Enfin, le Responsable Aidants Connect doit s’inscrire à un webinaire dédié de 30 minutes dont l’objectif est de préciser le rôle de Responsable Aidants Connect. <br>
-                        Si ce n’est pas déjà fait, nous vous invitons à vous y inscrire à l’adresse suivante :<a href="https://app.livestorm.co/incubateur-des-territoires/responsable-aidants-connect?type=detailed"> </p>
-                                          
+                      <p>Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes
+                        suivantes :</p>
+                      <ul>
+                        <li>
+                          Le Responsable active son compte administrateur avec le code de première connexion puis se
+                          rend sur son espace responsable à l’adresse suivante : <a href="{{ espace_responsable_url }}">
+                          votre espace responsable</a>.
+                        </li>
+                        <li>
+                          Il se connecte avec l'adresse e-mail nominative et individuelle renseignée dans le
+                          formulaire d’habilitation et le code à 6 chiffres qui figure sur l’enveloppe blanche dans le
+                          Kit de Bienvenue.
+                        </li>
+                        <li>
+                          Il reçoit un email de connexion valable 45 minutes, clique sur “connexion” et se rend sur
+                          son espace Responsable pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa
+                          connexion.<br>
+                          Pour ce faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie
+                          et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même
+                          carte.
+                        </li>
+                      </ul>
+                      <p>Une fois que le Responsable s’est attribué une carte, il peut effectuer la même démarche pour
+                      attribuer une carte à chaque aidant habilité.</p>
+                      <p>Enfin, le Responsable Aidants Connect doit s’inscrire à un webinaire dédié de 30 minutes dont
+                        l’objectif est de préciser le rôle de Responsable Aidants Connect. <br>
+                        Si ce n’est pas déjà fait, nous vous invitons à vous y inscrire en suivant <a
+                            href="https://app.livestorm.co/incubateur-des-territoires/responsable-aidants-connect?type=detailed">
+                          ce lien
+                        </a>.
+                      </p>
                     </td>
                   </tr>
                 </table>

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.html
@@ -38,7 +38,7 @@
                       {% endif %}
                       <p>Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes suivantes :
                         <ul>
-                          <li>Le Responsable active son compte administrateur avec le code de 1ère connexion puis se rend sur son espace responsable à l’adresse suivante: <a href="{{ espace_responsable_url }}">votre espace responsable</a> </li>
+                          <li>Le Responsable active son compte administrateur avec le code de première connexion puis se rend sur son espace responsable à l’adresse suivante: <a href="{{ espace_responsable_url }}">votre espace responsable</a> </li>
                           <li>Il se connecte avec l'adresse e-mail nominative et individuelle renseignée dans le  formulaire d’habilitation et le code à 6 chiffres qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.</li>
                           <li>Il reçoit un email de connexion valable 45 minutes, clique sur “connexion” et se rend sur son espace Responsable pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion.<br> 
                             Pour se faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.</li>

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.txt
@@ -15,4 +15,10 @@ L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est l
 {% endlinebreakless %}{% endfor %}
 {% if notify_self %}- vous-même.{% endif %}
 {% endif %}
-Rendez-vous dans votre espace responsable ({{ espace_responsable_url }}) afin de relier un compte aidant à une carte Aidants Connect.
+Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes suivantes :
+- Le Responsable active son compte administrateur avec le code de 1ère connexion,  se rend sur le site d’Aidants Connect (à l’adresse suivante: https://aidantsconnect.beta.gouv.fr/accounts/login/) puis se connecte avec l’adresse e-mail nominative et individuelle renseignée dans le formulaire d’habilitation et le code à 6 chiffres (attention ce code est à usage unique !) qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.
+- Il reçoit un email de connexion valable 45 minutes et se rend sur son espace Responsable ({{ espace_responsable_url }}) pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion. Pour se faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.
+
+Une fois que le Responsable s’est attribué une carte, il peut effectuer la même démarche pour attribuer une carte à chaque aidant habilité. 
+
+Enfin, le Responsable Aidants Connect doit s’inscrire à un webinaire dédié de 30 minutes dont l’objectif est de préciser le rôle de Responsable Aidants Connect. Si ce n’est pas déjà fait, nous vous invitons à vous y inscrire à l’adresse suivante : https://app.livestorm.co/incubateur-des-territoires/responsable-aidants-connect?type=detailed

--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_no_totp_workers.txt
@@ -16,8 +16,8 @@ L’équipe Aidants Connect vous informe qu'aucune carte Aidants Connect n'est l
 {% if notify_self %}- vous-même.{% endif %}
 {% endif %}
 Pour activer les comptes des aidants, le Responsable Aidants Connect doit suivre les étapes suivantes :
-- Le Responsable active son compte administrateur avec le code de 1ère connexion,  se rend sur le site d’Aidants Connect (à l’adresse suivante: https://aidantsconnect.beta.gouv.fr/accounts/login/) puis se connecte avec l’adresse e-mail nominative et individuelle renseignée dans le formulaire d’habilitation et le code à 6 chiffres (attention ce code est à usage unique !) qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.
-- Il reçoit un email de connexion valable 45 minutes et se rend sur son espace Responsable ({{ espace_responsable_url }}) pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion. Pour se faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.
+- Le Responsable active son compte administrateur avec le code de première connexion,  se rend sur le site d’Aidants Connect (à l’adresse suivante: https://aidantsconnect.beta.gouv.fr/accounts/login/) puis se connecte avec l’adresse e-mail nominative et individuelle renseignée dans le formulaire d’habilitation et le code à 6 chiffres (attention ce code est à usage unique !) qui figure sur l’enveloppe blanche dans le Kit de Bienvenue.
+- Il reçoit un email de connexion valable 45 minutes et se rend sur son espace Responsable ({{ espace_responsable_url }}) pour s’attribuer une carte Aidants Connect et ainsi pérenniser sa connexion. Pour ce faire, il renseigne d’abord le numéro de série qui figure au dos de la carte choisie et ensuite le code à 6 chiffres qui apparaît lorsqu’il appuie sur le bouton press de la même carte.
 
 Une fois que le Responsable s’est attribué une carte, il peut effectuer la même démarche pour attribuer une carte à chaque aidant habilité. 
 


### PR DESCRIPTION
## 🌮 Objectif

Modifier le mail automatique à destination des Aidants n'ayant pas activé pas leur carte.

- _Une liste des modifications_

Corps de l'e-mail

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_



