### PR TITLE
Ajout de isort aux checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,8 @@ jobs:
             . venv/bin/activate
             black --check .
             flake8
+            isort . --check
+
       - run:
           name: run unit tests
           command: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     rev: v4.1.0
     hooks:
     - id: end-of-file-fixer
+  - repo: https://github.com/pycqa/isort
+    rev: 5.6.4
+    hooks:
+    - id: isort
+      args: ["--check"]

--- a/aidants_connect/admin.py
+++ b/aidants_connect/admin.py
@@ -1,14 +1,12 @@
 import operator
 from functools import reduce
 
-from admin_honeypot.admin import LoginAttemptAdmin as HoneypotLoginAttemptAdmin
-from admin_honeypot.models import LoginAttempt as HoneypotLoginAttempt
 from django.contrib.admin import SimpleListFilter
 from django.db.models import Q
-from django_celery_beat.admin import (
-    ClockedScheduleAdmin,
-    PeriodicTaskAdmin,
-)
+
+from admin_honeypot.admin import LoginAttemptAdmin as HoneypotLoginAttemptAdmin
+from admin_honeypot.models import LoginAttempt as HoneypotLoginAttempt
+from django_celery_beat.admin import ClockedScheduleAdmin, PeriodicTaskAdmin
 from django_celery_beat.models import (
     ClockedSchedule,
     CrontabSchedule,
@@ -18,10 +16,11 @@ from django_celery_beat.models import (
 )
 from django_otp.admin import OTPAdminSite
 from magicauth.models import MagicToken
+
 from aidants_connect_web.models import (
-    DatavizRegion,
     DatavizDepartment,
     DatavizDepartmentsToRegion,
+    DatavizRegion,
 )
 
 admin_site = OTPAdminSite(OTPAdminSite.name)

--- a/aidants_connect/celery.py
+++ b/aidants_connect/celery.py
@@ -6,7 +6,6 @@ import os
 
 from celery import Celery
 
-
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "aidants_connect.settings")
 
 app = Celery("aidants_connect")

--- a/aidants_connect/common/constants.py
+++ b/aidants_connect/common/constants.py
@@ -1,10 +1,9 @@
 from datetime import date, timedelta
-from enum import unique, Enum
+from enum import Enum, unique
 
 from django.conf import settings
-from django.db.models import TextChoices, IntegerChoices
+from django.db.models import IntegerChoices, TextChoices
 from django.utils.timezone import now
-
 
 __all__ = [
     "JournalActionKeywords",

--- a/aidants_connect/common/lookups.py
+++ b/aidants_connect/common/lookups.py
@@ -1,4 +1,4 @@
-from django.db.models import Lookup, CharField
+from django.db.models import CharField, Lookup
 
 
 @CharField.register_lookup

--- a/aidants_connect/management/commands/scss.py
+++ b/aidants_connect/management/commands/scss.py
@@ -1,5 +1,6 @@
 import os
 from shutil import which
+
 from django.core.management.base import BaseCommand, CommandError
 
 

--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -16,7 +16,7 @@ import re
 import sys
 from datetime import datetime, timedelta
 from distutils.util import strtobool
-from typing import Union, Optional
+from typing import Optional, Union
 
 import sentry_sdk
 from dotenv import load_dotenv

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.urls import path, include
+from django.urls import include, path
 
 from aidants_connect import views
 from aidants_connect_web.admin import admin_site

--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -1,12 +1,11 @@
-from django.contrib.admin import ModelAdmin, TabularInline, StackedInline
-
 from django.conf import settings
+from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 
 from aidants_connect.admin import (
-    admin_site,
-    VisibleToAdminMetier,
-    RegionFilter,
     DepartmentFilter,
+    RegionFilter,
+    VisibleToAdminMetier,
+    admin_site,
 )
 from aidants_connect_habilitation.models import (
     AidantRequest,

--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -1,22 +1,23 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms import (
-    formset_factory,
-    ChoiceField,
-    CharField,
     BaseFormSet,
     BooleanField,
+    CharField,
+    ChoiceField,
     FileField,
+    formset_factory,
 )
 from django.urls import reverse
 from django.utils.html import format_html
+
 from phonenumber_field.formfields import PhoneNumberField
 from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
 from aidants_connect.common.constants import RequestOriginConstants
 from aidants_connect.common.forms import (
-    PatchedErrorListForm,
     PatchedErrorList,
+    PatchedErrorListForm,
     PatchedForm,
 )
 from aidants_connect_habilitation import models

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -1,13 +1,14 @@
 from uuid import uuid4
 
 from django.db import models
-from django.db.models import Q, SET_NULL
+from django.db.models import SET_NULL, Q
+
 from phonenumber_field.modelfields import PhoneNumberField
 
 from aidants_connect.common.constants import (
-    RequestStatusConstants,
     MessageStakeholders,
     RequestOriginConstants,
+    RequestStatusConstants,
 )
 from aidants_connect_web.models import OrganisationType
 

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -1,18 +1,18 @@
 from django.conf import settings
 from django.core.exceptions import ValidationError
+
 from factory import Faker, LazyFunction, SubFactory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
-
 from phonenumber_field.phonenumber import to_python
 
 from aidants_connect.common.constants import RequestOriginConstants
 from aidants_connect_habilitation.models import (
     AidantRequest,
     DataPrivacyOfficer,
+    Issuer,
     Manager,
     OrganisationRequest,
-    Issuer,
 )
 
 

--- a/aidants_connect_habilitation/tests/test_functionnal/test_aidants_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_aidants_form.py
@@ -2,12 +2,13 @@ from uuid import uuid4
 
 from django.test import tag
 from django.urls import reverse
+
 from selenium.webdriver.common.by import By
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_habilitation.forms import IssuerForm
 from aidants_connect_habilitation.models import OrganisationRequest
 from aidants_connect_habilitation.tests.factories import OrganisationRequestFactory
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 
 
 @tag("functional")

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -1,5 +1,5 @@
 from django.db import IntegrityError
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 
 from aidants_connect.common.constants import RequestOriginConstants
 from aidants_connect_habilitation.tests.factories import OrganisationRequestFactory

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -6,6 +6,7 @@ from django.http import HttpResponse
 from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import reverse
+
 from factory import Faker
 from faker.config import DEFAULT_LOCALE
 

--- a/aidants_connect_habilitation/tests/utils.py
+++ b/aidants_connect_habilitation/tests/utils.py
@@ -4,6 +4,7 @@ from inspect import getmembers, isclass
 from typing import Type, TypeVar
 
 from django.forms import BaseFormSet, ModelForm
+
 from factory.django import DjangoModelFactory
 
 from aidants_connect_habilitation.tests import factories

--- a/aidants_connect_habilitation/urls.py
+++ b/aidants_connect_habilitation/urls.py
@@ -3,8 +3,8 @@ from django.urls import path
 from aidants_connect_habilitation.views import (
     ModifyIssuerFormView,
     ModifyOrganisationRequestFormView,
-    NewIssuerFormView,
     NewHabilitationView,
+    NewIssuerFormView,
     NewOrganisationRequestFormView,
     PersonnelRequestFormView,
     ValidationRequestFormView,

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -8,11 +8,7 @@ from aidants_connect_habilitation.forms import (
     PersonnelForm,
     ValidationForm,
 )
-from aidants_connect_habilitation.models import (
-    Issuer,
-    OrganisationRequest,
-)
-
+from aidants_connect_habilitation.models import Issuer, OrganisationRequest
 
 __all__ = [
     "NewHabilitationView",

--- a/aidants_connect_overrides/management/commands/createsuperuser.py
+++ b/aidants_connect_overrides/management/commands/createsuperuser.py
@@ -1,11 +1,11 @@
 import os
 import sys
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 
 from django.contrib.auth.management.commands import createsuperuser
 from django.core.management import CommandError
 
-from aidants_connect_web.models import Organisation, Aidant
+from aidants_connect_web.models import Aidant, Organisation
 
 ORGANISATION_NAME_ARG = "--organisation-name"
 ORGANISATION_NAME_DEST = "organisation_name"

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -3,33 +3,34 @@ from collections.abc import Collection
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.admin import ModelAdmin, TabularInline, SimpleListFilter
+from django.contrib.admin import ModelAdmin, SimpleListFilter, TabularInline
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
 from django.db.models import QuerySet
-from django.http import HttpResponseRedirect, HttpResponseNotAllowed, HttpRequest
+from django.http import HttpRequest, HttpResponseNotAllowed, HttpResponseRedirect
 from django.shortcuts import render
-from django.urls import reverse, path
+from django.urls import path, reverse
 from django.utils.html import format_html_join
 from django.utils.safestring import mark_safe
+
 from django_otp.plugins.otp_static.admin import StaticDeviceAdmin
 from django_otp.plugins.otp_static.lib import add_static_token
 from django_otp.plugins.otp_static.models import StaticDevice
 from django_otp.plugins.otp_totp.admin import TOTPDeviceAdmin
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from import_export import resources
-from import_export.admin import ImportMixin, ImportExportMixin
+from import_export.admin import ImportExportMixin, ImportMixin
 from import_export.fields import Field
 from import_export.results import RowResult
-from import_export.widgets import ManyToManyWidget, ForeignKeyWidget
+from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 from nested_admin import NestedModelAdmin, NestedTabularInline
 from tabbed_admin import TabbedModelAdmin
 
 from aidants_connect.admin import (
-    admin_site,
-    VisibleToAdminMetier,
-    VisibleToTechAdmin,
     DepartmentFilter,
     RegionFilter,
+    VisibleToAdminMetier,
+    VisibleToTechAdmin,
+    admin_site,
 )
 from aidants_connect_web.forms import (
     AidantChangeForm,
@@ -39,13 +40,13 @@ from aidants_connect_web.forms import (
 from aidants_connect_web.models import (
     Aidant,
     Autorisation,
+    CarteTOTP,
     Connection,
     HabilitationRequest,
     Journal,
     Mandat,
     Organisation,
     Usager,
-    CarteTOTP,
 )
 
 logger = logging.getLogger()

--- a/aidants_connect_web/apps.py
+++ b/aidants_connect_web/apps.py
@@ -5,5 +5,5 @@ class AidantConnectWebConfig(AppConfig):
     name = "aidants_connect_web"
 
     def ready(self):
-        import aidants_connect_web.signals  # noqa
         import aidants_connect.common.lookups  # noqa
+        import aidants_connect_web.signals  # noqa

--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -1,5 +1,5 @@
-from django.contrib.auth.decorators import user_passes_test
 from django.conf import settings
+from django.contrib.auth.decorators import user_passes_test
 from django.utils import timezone
 
 

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -2,8 +2,8 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import password_validation
 from django.contrib.auth.forms import ReadOnlyPasswordHashField
-from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
-from django.core.validators import RegexValidator, EmailValidator
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
+from django.core.validators import EmailValidator, RegexValidator
 from django.forms import EmailField
 from django.utils.translation import gettext_lazy as _
 

--- a/aidants_connect_web/mail.py
+++ b/aidants_connect_web/mail.py
@@ -2,7 +2,6 @@ import json
 from smtplib import SMTPException
 
 from django.conf import settings
-
 from django.core.mail.backends.smtp import EmailBackend
 from django.core.mail.message import EmailMessage, sanitize_address
 

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -1,36 +1,37 @@
 import logging
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
+from os import walk as os_walk
+from os.path import dirname
+from os.path import join as path_join
+from re import sub as regex_sub
+from typing import Collection, Optional, Union
 
 from django.conf import settings
-from django.contrib.auth.models import AbstractUser, UserManager
 from django.contrib import messages as django_messages
+from django.contrib.auth.models import AbstractUser, UserManager
 from django.contrib.postgres.fields import ArrayField
 from django.db import models, transaction
-from django.db.models import Q, QuerySet, SET_NULL, CASCADE, Value
+from django.db.models import CASCADE, SET_NULL, Q, QuerySet, Value
 from django.db.models.functions import Concat
 from django.dispatch import Signal
-from django.template import loader, defaultfilters
+from django.template import defaultfilters, loader
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
+
 from django_otp.plugins.otp_totp.models import TOTPDevice
-from typing import Union, Optional, Collection
-from os import walk as os_walk
-from os.path import join as path_join, dirname
-from re import sub as regex_sub
 from phonenumber_field.modelfields import PhoneNumberField
 
 from aidants_connect.common.constants import (
     JOURNAL_ACTIONS,
-    JournalActionKeywords,
     AuthorizationDurationChoices,
     AuthorizationDurations,
+    JournalActionKeywords,
 )
 from aidants_connect_web.utilities import (
     generate_attestation_hash,
     mandate_template_path,
 )
-
 
 logger = logging.getLogger()
 

--- a/aidants_connect_web/signals.py
+++ b/aidants_connect_web/signals.py
@@ -1,7 +1,7 @@
+from django.conf import settings
 from django.contrib.auth.signals import user_logged_in
 from django.core.mail import send_mail
 from django.dispatch import receiver
-from django.conf import settings
 from django.template import loader
 
 from django_otp.plugins.otp_totp.models import TOTPDevice

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -1,21 +1,25 @@
 import logging
 from datetime import timedelta
-
-from django.db.models import Count, Q
-from django.template.defaultfilters import pluralize
-from django.core.mail import send_mail
-from django.template import loader
-from django.urls import reverse
-from django.utils import timezone
-from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
-from celery import shared_task
-
-from aidants_connect_web.models import Connection
-from aidants_connect import settings
-from aidants_connect_web.models import Aidant, HabilitationRequest, Mandat, Organisation
-
 from typing import List
 
+from django.core.mail import send_mail
+from django.db.models import Count, Q
+from django.template import loader
+from django.template.defaultfilters import pluralize
+from django.urls import reverse
+from django.utils import timezone
+
+from celery import shared_task
+from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
+
+from aidants_connect import settings
+from aidants_connect_web.models import (
+    Aidant,
+    Connection,
+    HabilitationRequest,
+    Mandat,
+    Organisation,
+)
 
 logger = logging.getLogger()
 

--- a/aidants_connect_web/templatetags/ac_extras.py
+++ b/aidants_connect_web/templatetags/ac_extras.py
@@ -2,7 +2,7 @@ from re import sub as re_sub
 
 from django import template
 from django.template import Library
-from django.template.base import Node, Parser, NodeList, TextNode, Token
+from django.template.base import Node, NodeList, Parser, TextNode, Token
 
 register = template.Library()
 

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
-
 from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.utils.timezone import now
 
@@ -18,11 +18,11 @@ from factory.django import DjangoModelFactory
 
 from aidants_connect_web.models import (
     Autorisation,
-    Connection,
     CarteTOTP,
-    DatavizRegion,
+    Connection,
     DatavizDepartment,
     DatavizDepartmentsToRegion,
+    DatavizRegion,
     HabilitationRequest,
     Journal,
     Mandat,

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -1,4 +1,4 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import RequestFactory
 
 from aidants_connect.admin import DepartmentFilter, RegionFilter

--- a/aidants_connect_web/tests/test_admin_resources.py
+++ b/aidants_connect_web/tests/test_admin_resources.py
@@ -1,5 +1,6 @@
+from django.test import TestCase, tag
+
 import tablib
-from django.test import tag, TestCase
 
 from aidants_connect_web.admin import OrganisationResource
 from aidants_connect_web.models import Organisation

--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -3,22 +3,23 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from django.core import mail
-from django.core.management import call_command, CommandError
-from django.test import tag, TestCase
-from freezegun import freeze_time
+from django.core.management import CommandError, call_command
+from django.test import TestCase, tag
+
 from django_otp.plugins.otp_static.lib import add_static_token
 from django_otp.plugins.otp_static.models import StaticToken
 from django_otp.plugins.otp_totp.models import TOTPDevice
+from freezegun import freeze_time
 
+from aidants_connect import settings
 from aidants_connect_overrides.management.commands.createsuperuser import (
     ERROR_MSG,
     ORGANISATION_ID_ARG,
+    ORGANISATION_ID_ENV,
     ORGANISATION_NAME_ARG,
     ORGANISATION_NAME_ENV,
-    ORGANISATION_ID_ENV,
 )
-from aidants_connect import settings
-from aidants_connect_web.models import Connection, Aidant, HabilitationRequest
+from aidants_connect_web.models import Aidant, Connection, HabilitationRequest
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     CarteTOTPFactory,

--- a/aidants_connect_web/tests/test_decorators.py
+++ b/aidants_connect_web/tests/test_decorators.py
@@ -1,11 +1,10 @@
 from django.conf import settings
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.utils import timezone
 
 from freezegun import freeze_time
 
 from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
-
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 

--- a/aidants_connect_web/tests/test_factories.py
+++ b/aidants_connect_web/tests/test_factories.py
@@ -1,8 +1,6 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 
-from aidants_connect_web.models import (
-    Aidant,
-)
+from aidants_connect_web.models import Aidant
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     CarteTOTPFactory,

--- a/aidants_connect_web/tests/test_fixtures.py
+++ b/aidants_connect_web/tests/test_fixtures.py
@@ -1,4 +1,5 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
+
 from aidants_connect_web.models import Aidant, Autorisation, Usager
 
 

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -1,16 +1,15 @@
 from django.forms.models import model_to_dict
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 
 from aidants_connect_web.forms import (
-    AidantCreationForm,
     AidantChangeForm,
+    AidantCreationForm,
     DatapassHabilitationForm,
-    MassEmailHabilitatonForm,
     MandatForm,
+    MassEmailHabilitatonForm,
     RecapMandatForm,
 )
-
 from aidants_connect_web.models import Aidant
 from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
 

--- a/aidants_connect_web/tests/test_functional/test_404.py
+++ b/aidants_connect_web/tests/test_functional/test_404.py
@@ -1,4 +1,5 @@
 from django.test import tag
+
 from selenium.webdriver.common.by import By
 
 from aidants_connect.common.tests.testcases import FunctionalTestCase

--- a/aidants_connect_web/tests/test_functional/test_a11y.py
+++ b/aidants_connect_web/tests/test_functional/test_a11y.py
@@ -1,8 +1,9 @@
 from django.test import tag
+
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 
 from aidants_connect.common.tests.testcases import FunctionalTestCase
-from selenium.common.exceptions import NoSuchElementException
 
 
 @tag("functional", "a11y")  # nb: a11y stands for "accessibility"

--- a/aidants_connect_web/tests/test_functional/test_admin_transfert_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_admin_transfert_mandat.py
@@ -1,18 +1,19 @@
-from typing import Sequence, Collection
+from typing import Collection, Sequence
 from unittest import mock
 from unittest.mock import Mock
 
 from django.test import tag
 from django.urls import reverse
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.expected_conditions import url_matches
 from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.wait import WebDriverWait
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.admin import MandatAdmin
 from aidants_connect_web.models import Mandat
 from aidants_connect_web.tests.factories import AidantFactory, MandatFactory
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 
 
 @tag("functional")

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -2,17 +2,18 @@ from datetime import timedelta
 
 from django.test import tag
 from django.utils import timezone
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Journal
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    MandatFactory,
     AutorisationFactory,
+    MandatFactory,
     UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -1,15 +1,15 @@
 from django.test import tag
-from selenium.webdriver.common.by import By
 
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Journal
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    MandatFactory,
     AutorisationFactory,
+    MandatFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -3,12 +3,13 @@ from unittest import skip
 
 from django.conf import settings
 from django.test import tag
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.wait import WebDriverWait
-from selenium.webdriver.support.expected_conditions import url_matches
 
-from aidants_connect_web.tests.factories import AidantFactory
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import url_matches
+from selenium.webdriver.support.wait import WebDriverWait
+
 from aidants_connect.common.tests.testcases import FunctionalTestCase
+from aidants_connect_web.tests.factories import AidantFactory
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
+++ b/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
@@ -1,18 +1,19 @@
 from django.conf import settings
 from django.test import tag
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import DatavizRegion
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    DatavizRegionFactory,
     DatavizDepartmentFactory,
     DatavizDepartmentsToRegionFactory,
+    DatavizRegionFactory,
     HabilitationRequestFactory,
     OrganisationFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 
 
 class RegionFilterTestCase(FunctionalTestCase):

--- a/aidants_connect_web/tests/test_functional/test_homepage.py
+++ b/aidants_connect_web/tests/test_functional/test_homepage.py
@@ -1,4 +1,5 @@
 from django.test import tag
+
 from selenium.webdriver.common.by import By
 
 from aidants_connect.common.tests.testcases import FunctionalTestCase

--- a/aidants_connect_web/tests/test_functional/test_id_provider.py
+++ b/aidants_connect_web/tests/test_functional/test_id_provider.py
@@ -1,16 +1,17 @@
 from urllib.parse import urlencode
 
 from django.conf import settings
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.expected_conditions import url_contains
 from selenium.webdriver.support.wait import WebDriverWait
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    UsagerFactory,
     MandatFactory,
+    UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_import_aidant.py
+++ b/aidants_connect_web/tests/test_functional/test_import_aidant.py
@@ -1,20 +1,22 @@
 import os
-from os.path import dirname, join as path_join
+from os.path import dirname
+from os.path import join as path_join
 
 from django.conf import settings
 from django.test import tag
+
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.common.exceptions import NoSuchElementException
 
 import aidants_connect_web
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Aidant
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    OrganisationFactory,
     CarteTOTPFactory,
+    OrganisationFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 
 
 @tag("functional", "import")

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -1,13 +1,11 @@
-from django.test import tag
-from selenium.webdriver.common.by import By
-
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-)
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from django.core import mail
+from django.test import tag
 
+from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+
+from aidants_connect.common.tests.testcases import FunctionalTestCase
+from aidants_connect_web.tests.factories import AidantFactory
 
 
 @tag("functional")

--- a/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
+++ b/aidants_connect_web/tests/test_functional/test_remove_aidant_from_organisation.py
@@ -1,16 +1,14 @@
 from django.test import tag
 from django.urls import reverse
+
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.expected_conditions import url_matches
 from selenium.webdriver.support.wait import WebDriverWait
 
-from aidants_connect_web.models import Aidant
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    OrganisationFactory,
-)
 from aidants_connect.common.tests.testcases import FunctionalTestCase
+from aidants_connect_web.models import Aidant
+from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -1,18 +1,17 @@
 from datetime import timedelta
 
 from django.test import tag
-
 from django.utils import timezone
+
 from selenium.webdriver.common.by import By
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Mandat
-
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     MandatFactory,
     UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_statistiques.py
+++ b/aidants_connect_web/tests/test_functional/test_statistiques.py
@@ -1,4 +1,5 @@
 from django.test import tag
+
 from selenium.webdriver.common.by import By
 
 from aidants_connect.common.tests.testcases import FunctionalTestCase

--- a/aidants_connect_web/tests/test_functional/test_usagers.py
+++ b/aidants_connect_web/tests/test_functional/test_usagers.py
@@ -1,12 +1,12 @@
 from selenium.webdriver.common.by import By
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.factories import (
     AidantFactory,
-    UsagerFactory,
-    MandatFactory,
     ExpiredMandatFactory,
+    MandatFactory,
+    UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/test_use_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_use_autorisation.py
@@ -1,11 +1,13 @@
-from datetime import timedelta
 import time
+from datetime import timedelta
 
 from django.conf import settings
 from django.test import tag
 from django.utils import timezone
+
 from selenium.webdriver.common.by import By
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Mandat
 from aidants_connect_web.tests.factories import (
     AidantFactory,
@@ -13,9 +15,7 @@ from aidants_connect_web.tests.factories import (
     MandatFactory,
     UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
-
 
 FC_URL_PARAMETERS = (
     f"state=34"

--- a/aidants_connect_web/tests/test_functional/test_view_autorisations.py
+++ b/aidants_connect_web/tests/test_functional/test_view_autorisations.py
@@ -2,15 +2,16 @@ from datetime import timedelta
 
 from django.test import tag
 from django.utils import timezone
+
 from selenium.webdriver.common.by import By
 
+from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     AutorisationFactory,
     MandatFactory,
     UsagerFactory,
 )
-from aidants_connect.common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.tests.test_functional.utilities import login_aidant
 
 

--- a/aidants_connect_web/tests/test_functional/utilities.py
+++ b/aidants_connect_web/tests/test_functional/utilities.py
@@ -1,4 +1,5 @@
 from django.core import mail
+
 from selenium.webdriver.common.by import By
 
 

--- a/aidants_connect_web/tests/test_lookups.py
+++ b/aidants_connect_web/tests/test_lookups.py
@@ -1,4 +1,4 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 
 from aidants_connect_web.models import Journal
 from aidants_connect_web.tests.factories import JournalFactory, OrganisationFactory

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1,14 +1,14 @@
-from os.path import join as path_join
 from datetime import date, datetime, timedelta
+from os.path import join as path_join
 from unittest.mock import Mock
 
-import mock
-from django.db.utils import IntegrityError
-from django.test import tag, TestCase
-from django.utils import timezone
 from django.conf import settings
-from django_otp.plugins.otp_totp.models import TOTPDevice
+from django.db.utils import IntegrityError
+from django.test import TestCase, tag
+from django.utils import timezone
 
+import mock
+from django_otp.plugins.otp_totp.models import TOTPDevice
 from freezegun import freeze_time
 from pytz import timezone as pytz_timezone
 

--- a/aidants_connect_web/tests/test_settings.py
+++ b/aidants_connect_web/tests/test_settings.py
@@ -1,6 +1,6 @@
-from unittest import TestCase
 import os
 import uuid
+from unittest import TestCase
 
 from aidants_connect.settings import getenv_bool
 

--- a/aidants_connect_web/tests/test_utilities.py
+++ b/aidants_connect_web/tests/test_utilities.py
@@ -1,4 +1,4 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 
 from aidants_connect_web.utilities import generate_sha256_hash
 

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -1,20 +1,20 @@
 from datetime import datetime, timedelta
-from freezegun import freeze_time
-from pytz import timezone as pytz_timezone
-import mock
-import jwt
 
 from django.conf import settings
-from django.test import override_settings, tag, TestCase
+from django.test import TestCase, override_settings, tag
 from django.test.client import Client
 from django.urls import reverse
+
+import jwt
+import mock
+from freezegun import freeze_time
+from pytz import timezone as pytz_timezone
 
 from aidants_connect.common.constants import AuthorizationDurationChoices
 from aidants_connect_web.models import Connection, Journal, Usager
 from aidants_connect_web.tests.factories import AidantFactory, UsagerFactory
 from aidants_connect_web.utilities import generate_sha256_hash
 from aidants_connect_web.views.FC_as_FS import get_user_info
-
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -1,9 +1,10 @@
-from admin_honeypot.models import LoginAttempt
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory, tag, TestCase
+from django.test import RequestFactory, TestCase, tag
 from django.test.client import Client
 from django.urls import reverse
+
+from admin_honeypot.models import LoginAttempt
 from django_otp import DEVICE_ID_SESSION_KEY
 from django_otp.admin import OTPAdminSite
 from django_otp.plugins.otp_static.models import StaticDevice
@@ -11,11 +12,10 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from import_export.results import Result
 
 from aidants_connect_web.admin import (
+    CarteTOTPAdmin,
     VisibleToAdminMetier,
     VisibleToTechAdmin,
-    CarteTOTPAdmin,
 )
-
 from aidants_connect_web.models import (
     Aidant,
     CarteTOTP,

--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -1,17 +1,18 @@
 from django.conf import settings
 from django.core import mail
-from django.test import tag, TestCase
+from django.test import TestCase, tag
+from django.urls import resolve
+
 from aidants_connect_web.models import (
     HabilitationRequest,
     Organisation,
     OrganisationType,
 )
-from aidants_connect_web.views import datapass
 from aidants_connect_web.tests.factories import (
     HabilitationRequestFactory,
     OrganisationFactory,
 )
-from django.urls import resolve
+from aidants_connect_web.views import datapass
 
 
 class DatapassMixin:

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve, reverse
 

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
@@ -1,20 +1,20 @@
-from datetime import timedelta
 import datetime
-import pytz
+from datetime import timedelta
 
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 from django.utils import timezone
 
+import pytz
+
 from aidants_connect import settings
 from aidants_connect_web.models import Autorisation, Mandat
-
 from aidants_connect_web.tests.factories import (
-    OrganisationFactory,
     AidantFactory,
     AutorisationFactory,
     MandatFactory,
+    OrganisationFactory,
     UsagerFactory,
 )
 from aidants_connect_web.views import usagers

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_associate_totp_card.py
@@ -1,14 +1,11 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    CarteTOTPFactory,
-)
 from aidants_connect_web.models import CarteTOTP, Journal
+from aidants_connect_web.tests.factories import AidantFactory, CarteTOTPFactory
 from aidants_connect_web.views import espace_responsable
 
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
@@ -1,13 +1,10 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    CarteTOTPFactory,
-)
 from aidants_connect_web.models import CarteTOTP, Journal
+from aidants_connect_web.tests.factories import AidantFactory, CarteTOTPFactory
 
 
 @tag("responsable-structure")

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -1,13 +1,10 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    OrganisationFactory,
-)
+from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
 from aidants_connect_web.views import espace_responsable
 
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
@@ -1,4 +1,4 @@
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_remove_from_organisation.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_remove_from_organisation.py
@@ -1,11 +1,8 @@
-from django.test import tag, TestCase
-from django.test.client import Client
 from django.core import mail
+from django.test import TestCase, tag
+from django.test.client import Client
 
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    OrganisationFactory,
-)
+from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
 
 
 @tag("responsable-structure")

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
@@ -1,16 +1,12 @@
-import mock
-
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 
+import mock
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.tests.factories import (
-    AidantFactory,
-    CarteTOTPFactory,
-)
 from aidants_connect_web.models import Journal
+from aidants_connect_web.tests.factories import AidantFactory, CarteTOTPFactory
 from aidants_connect_web.views import espace_responsable
 
 

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -1,5 +1,5 @@
-from datetime import date, datetime, timedelta
 import json
+from datetime import date, datetime, timedelta
 
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
@@ -12,12 +12,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 from pytz import timezone as pytz_timezone
 
-from aidants_connect_web.models import (
-    Aidant,
-    Connection,
-    Journal,
-    Usager,
-)
+from aidants_connect_web.models import Aidant, Connection, Journal, Usager
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     AutorisationFactory,

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -2,8 +2,7 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.contrib import messages as django_messages
-
-from django.test import override_settings, tag, TestCase
+from django.test import TestCase, override_settings, tag
 from django.test.client import Client
 from django.urls import resolve
 from django.utils import timezone
@@ -20,7 +19,6 @@ from aidants_connect_web.tests.factories import (
     UsagerFactory,
 )
 from aidants_connect_web.views import mandat
-
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 

--- a/aidants_connect_web/tests/test_views/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_renew_mandat.py
@@ -1,16 +1,16 @@
 from datetime import timedelta
 
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
 
-from aidants_connect_web.models import Connection, Mandat, Journal
+from aidants_connect_web.models import Connection, Journal, Mandat
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     MandatFactory,
-    RevokedMandatFactory,
     OrganisationFactory,
+    RevokedMandatFactory,
     UsagerFactory,
 )
 

--- a/aidants_connect_web/tests/test_views/test_service.py
+++ b/aidants_connect_web/tests/test_views/test_service.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 
 from django.conf import settings
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 from django.utils import timezone
@@ -19,7 +19,6 @@ from aidants_connect_web.tests.factories import (
     UsagerFactory,
 )
 from aidants_connect_web.views import service
-
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
 

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -1,6 +1,6 @@
 from datetime import timedelta
 
-from django.test import tag, TestCase
+from django.test import TestCase, tag
 from django.urls import reverse
 from django.utils import timezone
 
@@ -10,9 +10,10 @@ from aidants_connect_web.tests.factories import (
     MandatFactory,
     UsagerFactory,
 )
-
-from aidants_connect_web.views.usagers import _get_mandats_for_usagers_index
-from aidants_connect_web.views.usagers import _get_usagers_dict_from_mandats
+from aidants_connect_web.views.usagers import (
+    _get_mandats_for_usagers_index,
+    _get_usagers_dict_from_mandats,
+)
 
 
 @tag("usagers")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -1,17 +1,18 @@
 from django.urls import path
+
 from magicauth import views as magicauth_views
 from magicauth.urls import urlpatterns as magicauth_urls
 
 from aidants_connect_web.views import (
     FC_as_FS,
+    datapass,
+    espace_aidant,
+    espace_responsable,
     id_provider,
     mandat,
     renew_mandat,
     service,
-    espace_aidant,
-    espace_responsable,
     usagers,
-    datapass,
 )
 
 urlpatterns = [

--- a/aidants_connect_web/utilities.py
+++ b/aidants_connect_web/utilities.py
@@ -1,14 +1,13 @@
-import io
 import hashlib
+import io
 from datetime import date, datetime
-from urllib.parse import urlencode, quote
-
-import qrcode
 from pathlib import Path
+from typing import TYPE_CHECKING, Optional, Union
+from urllib.parse import quote, urlencode
 
 from django.conf import settings
 
-from typing import TYPE_CHECKING, Optional, Union
+import qrcode
 
 if TYPE_CHECKING:
     from aidants_connect_web.models import Aidant, Usager

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -1,15 +1,16 @@
 import logging
 from secrets import token_urlsafe
-import jwt
-from jwt.api_jwt import ExpiredSignatureError
-import requests as python_request
 
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.db import IntegrityError
 from django.shortcuts import redirect, render
 
-from aidants_connect_web.models import Connection, Usager, Journal
+import jwt
+import requests as python_request
+from jwt.api_jwt import ExpiredSignatureError
+
+from aidants_connect_web.models import Connection, Journal, Usager
 from aidants_connect_web.utilities import generate_sha256_hash
 
 logging.basicConfig(level=logging.INFO)

--- a/aidants_connect_web/views/datapass.py
+++ b/aidants_connect_web/views/datapass.py
@@ -2,14 +2,14 @@ import logging
 
 from django.conf import settings
 from django.core.mail import send_mail
-from django.http import HttpResponse, HttpResponseForbidden, HttpResponseBadRequest
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
 
-from aidants_connect_web.forms import DatapassHabilitationForm, DatapassForm
+from aidants_connect_web.forms import DatapassForm, DatapassHabilitationForm
 from aidants_connect_web.models import (
+    HabilitationRequest,
     Organisation,
     OrganisationType,
-    HabilitationRequest,
 )
 
 logging.basicConfig(level=logging.INFO)

--- a/aidants_connect_web/views/espace_aidant.py
+++ b/aidants_connect_web/views/espace_aidant.py
@@ -4,13 +4,13 @@ from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpRequest, HttpResponseRedirect
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 
-from aidants_connect_web.forms import ValidateCGUForm, SwitchMainAidantOrganisationForm
-from aidants_connect_web.models import Aidant, Journal
 from aidants_connect_web.decorators import activity_required, user_is_aidant
+from aidants_connect_web.forms import SwitchMainAidantOrganisationForm, ValidateCGUForm
+from aidants_connect_web.models import Aidant, Journal
 
 
 @login_required

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -4,20 +4,14 @@ from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.http import Http404, HttpRequest, HttpResponse
-from django.shortcuts import render, redirect, get_object_or_404
-from django.views.decorators.http import require_http_methods, require_GET, require_POST
+from django.shortcuts import get_object_or_404, redirect, render
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
+
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.models import (
-    Aidant,
-    CarteTOTP,
-    HabilitationRequest,
-    Journal,
-    Organisation,
-)
 from aidants_connect_web.decorators import (
-    user_is_responsable_structure,
     activity_required,
+    user_is_responsable_structure,
 )
 from aidants_connect_web.forms import (
     AddOrganisationResponsableForm,
@@ -26,6 +20,13 @@ from aidants_connect_web.forms import (
     ChangeAidantOrganisationsForm,
     HabilitationRequestCreationForm,
     RemoveCardFromAidantForm,
+)
+from aidants_connect_web.models import (
+    Aidant,
+    CarteTOTP,
+    HabilitationRequest,
+    Journal,
+    Organisation,
 )
 
 

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from secrets import token_urlsafe
 import time
+from secrets import token_urlsafe
 
 from django.conf import settings
 from django.contrib.auth import logout
@@ -16,15 +16,14 @@ from django.http import (
     HttpResponseRedirect,
     JsonResponse,
 )
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.decorators.csrf import csrf_exempt
 
 import jwt
 
 from aidants_connect_web.decorators import activity_required, user_is_aidant
-from aidants_connect_web.models import Connection, Journal, Usager, Aidant
-
+from aidants_connect_web.models import Aidant, Connection, Journal, Usager
 from aidants_connect_web.utilities import generate_sha256_hash
 
 logging.basicConfig(level=logging.INFO)

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -5,29 +5,29 @@ from typing import Collection
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.staticfiles import finders
 from django.db import IntegrityError
 from django.http import HttpResponse
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
-from django.utils import timezone, formats
-from django.contrib.staticfiles import finders
+from django.utils import formats, timezone
 
 from aidants_connect.common.constants import AuthorizationDurations
+from aidants_connect.common.forms import PatchedErrorList
 from aidants_connect_web.decorators import activity_required, user_is_aidant
 from aidants_connect_web.forms import MandatForm, RecapMandatForm
-from aidants_connect.common.forms import PatchedErrorList
 from aidants_connect_web.models import (
+    Aidant,
     Autorisation,
     Connection,
     Journal,
     Mandat,
     Usager,
-    Aidant,
 )
 from aidants_connect_web.utilities import (
     generate_attestation_hash,
-    generate_qrcode_png,
     generate_mailto_link,
+    generate_qrcode_png,
 )
 from aidants_connect_web.views.service import humanize_demarche_names
 

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -1,17 +1,15 @@
 from secrets import token_urlsafe
 
-
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 
-
+from aidants_connect.common.constants import AuthorizationDurations
 from aidants_connect_web.decorators import activity_required, user_is_aidant
 from aidants_connect_web.forms import MandatForm
-from aidants_connect_web.models import Connection, Journal, Aidant, Usager
-from aidants_connect.common.constants import AuthorizationDurations
+from aidants_connect_web.models import Aidant, Connection, Journal, Usager
 
 
 @login_required

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -1,18 +1,17 @@
-from datetime import timedelta
 import logging
+from datetime import timedelta
 
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseNotFound
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 
 from aidants_connect_web.forms import OTPForm
 from aidants_connect_web.models import Aidant, Journal, Mandat, Organisation, Usager
-
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -5,14 +5,13 @@ from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.db.models.functions import Concat
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.utils import timezone
-from django.utils.timezone import timedelta, now
+from django.utils.timezone import now, timedelta
 
 from aidants_connect_web.decorators import activity_required
 from aidants_connect_web.models import Aidant, Autorisation, Journal, Mandat
 from aidants_connect_web.views.service import humanize_demarche_names
-
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,26 @@ exclude = '''
     )/
 )
 '''
+
+[tool.isort]
+profile = "black"
+src_paths = "."
+known_django = "django"
+sections = ["FUTURE", "STDLIB", "DJANGO", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+skip_glob = [
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".tox",
+    ".venv",
+    "venv",
+    ".svn",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "**/migrations",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ pre-commit==2.17.0
 pre-commit-hooks==4.1.0
 black==22.1.0
 flake8==4.0.1
+isort==5.10.1
 
 celery[redis]==5.2.3
 coverage==6.3.1


### PR DESCRIPTION
## 🌮 Objectif

`isort` permet de réordonner les imports selon un ordre standard.

## ⚠️ Informations supplémentaires

Seul le premier commit est intéressant. Le second fait tourner `isort` sur tous les fichiers.