### PR TITLE
Màj de la dépendance whitenoise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,6 @@ requests==2.27.1
 selenium==4.1.0
 sentry-sdk==1.5.5
 sqlparse==0.3.1
-whitenoise==5.3.0
+whitenoise==6.0.0
 
 django-magicauth @ git+https://github.com/betagouv/django-magicauth.git@0.7


### PR DESCRIPTION
## 🌮 Objectif

Les seuls points bloquants sont [la fin du support pour Python 3.5 et 3.6](https://whitenoise.evans.io/en/stable/changelog.html#id1). On devrait survivre pourvu que les tests passent.