### PR TITLE
Màj dépendance django-otp

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-celery-beat==2.2.1
 django-csp==3.7
 django-extensions==3.1.5
 django-nested-admin==3.4.0
-django-otp==0.9.3
+django-otp==1.1.3
 django-referrer-policy==1.0
 django-tabbed-admin==1.0.4
 django-import-export==2.7.1


### PR DESCRIPTION
## 🌮 Objectif

Le seul breaking change renseigné étant [la fin du support de Django 2.2](https://django-otp-official.readthedocs.io/en/stable/changes.html#v1-0-0-august-13-2020-update-supported-django-verisons), ça devrait le faire.