### PR TITLE
Màj de PyJWT

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,4 +17,3 @@ repos:
     rev: 5.6.4
     hooks:
     - id: isort
-      args: ["--check"]

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -182,12 +182,12 @@ class FCCallback(TestCase):
 
         self.assertEqual(connection.access_token, "test_access_token")
         url = (
-            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=b'e"
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=e"
             "yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRi"
             "NDQ4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjox"
             "NTQ3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29u"
             "bmVjdC5nb3V2LmZyIiwic3ViIjoiMTIzIiwibm9uY2UiOiJ0ZXN0X25vbmNlIn0.QGb2uhgG"
-            "wXvKaVT8FXwOzSObtuLrBRKigd7DVJwUG5s'&state=test_state"
+            "wXvKaVT8FXwOzSObtuLrBRKigd7DVJwUG5s&state=test_state"
             "&post_logout_redirect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)
@@ -256,13 +256,13 @@ class FCCallback(TestCase):
         self.assertEqual(connection.usager.given_name, "Joséphine")
 
         url = (
-            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=b'ey"
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=ey"
             "J0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRiND"
             "Q4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ"
             "3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmVj"
             "dC5nb3V2LmZyIiwic3ViIjoiOWI3NTQ3ODI3MDVjNTVlYmZlMTAzNzFjOTA5ZjYyZTczYTNlM"
             "DlmYjU2NmZjNWQyMzA0MGEyOWZhZTRlMGViYiIsIm5vbmNlIjoidGVzdF9ub25jZSJ9.J8048"
-            "J_B5MgwQkLzX28yXTDFPB4mTeoyUGW9RSW5YZ4'&state=test_state&post_logout_redi"
+            "J_B5MgwQkLzX28yXTDFPB4mTeoyUGW9RSW5YZ4&state=test_state&post_logout_redi"
             "rect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date, datetime, timedelta
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.hashers import make_password
@@ -429,7 +430,11 @@ class TokenTests(TestCase):
     date = datetime(2012, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
 
     @freeze_time(date)
-    def test_correct_info_triggers_200(self):
+    @mock.patch(
+        "aidants_connect_web.views.id_provider.get_random_string",
+        return_value="5ieq7Bg173y99tT6MA",
+    )
+    def test_correct_info_triggers_200(self, _):
 
         response = self.client.post("/token/", self.fc_request)
 
@@ -447,7 +452,7 @@ class TokenTests(TestCase):
             "dF9pZCIsImV4cCI6MTMyNjUxMDk5NCwiaWF0IjoxMzI2NTEwNjk0LCJpc3MiOiJsb2NhbGhvc"
             "3QiLCJzdWIiOiJhdmFsaWRzdWI3ODkiLCJub25jZSI6ImF2YWxpZG5vbmNlNDU2In0.a7nbGA"
             "-Ib9I1HaMb5iC9s4fDP1ZbIXUJpU-YbdYFcWA",
-            "refresh_token": "5ieq7Bg173y99tT6MA",
+            "refresh_token": "5ieq7bg173y99tt6ma",
             "token_type": "Bearer",
         }
 

--- a/aidants_connect_web/views/FC_as_FS.py
+++ b/aidants_connect_web/views/FC_as_FS.py
@@ -127,7 +127,7 @@ def fc_callback(request):
             fc_id_token,
             settings.FC_AS_FS_SECRET,
             audience=settings.FC_AS_FS_ID,
-            algorithm="HS256",
+            algorithms=["HS256"],
         )
     except ExpiredSignatureError:
         return fc_error("403: token signature has expired.")

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -18,6 +18,7 @@ from django.http import (
 )
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from django.utils.crypto import get_random_string
 from django.views.decorators.csrf import csrf_exempt
 
 import jwt
@@ -237,6 +238,10 @@ def fi_select_demarche(request):
         )
 
 
+def _mock_refresh_token():
+    return get_random_string(18).lower()
+
+
 # Due to `no_referer` error
 # https://docs.djangoproject.com/en/dev/ref/csrf/#django.views.decorators.csrf.csrf_exempt
 @csrf_exempt
@@ -308,8 +313,8 @@ def token(request):
     response = {
         "access_token": access_token,
         "expires_in": 3600,
-        "id_token": encoded_id_token.decode("utf-8"),
-        "refresh_token": "5ieq7Bg173y99tT6MA",
+        "id_token": encoded_id_token,
+        "refresh_token": _mock_refresh_token(),
         "token_type": "Bearer",
     }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ mock==4.0.3
 Pillow==9.0.1
 psycopg2-binary==2.9.3
 ptpython==3.0.20
-PyJWT==1.7.1
+PyJWT==2.3.0
 python-dotenv==0.13.0
 pytz==2021.3
 qrcode==7.3.1


### PR DESCRIPTION
## 🌮 Objectif

Mise à jour de la dépendance PyJWT.

J'ai fait la màj en 2 étapes : d'abord passage à la version 2.0.0 pour voir ce qui casse. Puis passage à la dernière version. 2 breaking changes notables ici : `jwt.encode` retournes un `str` et plus un `bytes` ce qui a légèrement modifié 2 tests. La signature de `jwt.decode` change avec la paramètre `algorithm` qui devient `algorithms` et prend une liste.

Pas d'autres changements notables pour nous. [Le changelog est là](https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst#v200).