### PR TITLE
Simplification de la page de statistiques publiques

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -402,6 +402,8 @@ CSP_SCRIPT_SRC = (
     "'sha256-p0nVvBQQOY8PrKj8/JWPCKOJU8Iso8I6LIVer817o64='",  # main.html
     "'sha256-ARvyo8AJ91wUvPfVqP2FfHuIHZJN3xaLI7Vgj2tQx18='",  # wait.html
     "'sha256-mXH/smf1qtriC8hr62Qt2dvp/StB/Ixr4xmBRvkCz0U='",  # main-habilitation.html
+    "https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js",
+    "'sha256-wSJM0q2Hy/wlB2+4HmcFtjOB2K4H+MX73ixv1EwGfxw='",  # statistiques.html
 )
 CSP_STYLE_SRC = ("'self'",)
 CSP_OBJECT_SRC = ("'none'",)

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -60,6 +60,24 @@ class OrganisationType(models.Model):
         return f"{self.name}"
 
 
+class OrganisationManager(models.Manager):
+    def accredited(self):
+        return (
+            self.filter(aidants__is_active=True)
+            .filter(aidants__can_create_mandats=True)
+            .filter(aidants__carte_totp__isnull=False)
+            .filter(is_active=True)
+        )
+
+    def not_yet_accredited(self):
+        return (
+            self.filter(aidants__is_active=True)
+            .filter(aidants__can_create_mandats=True)
+            .filter(aidants__carte_totp__isnull=True)
+            .filter(is_active=True)
+        )
+
+
 class Organisation(models.Model):
     data_pass_id = models.PositiveIntegerField("Datapass ID", null=True)
     name = models.TextField("Nom", default="No name provided")
@@ -72,6 +90,8 @@ class Organisation(models.Model):
     city = models.CharField("Ville", max_length=255, null=True)
 
     is_active = models.BooleanField("Est active", default=True, editable=False)
+
+    objects = OrganisationManager()
 
     def __str__(self):
         return f"{self.name}"

--- a/aidants_connect_web/templates/public_website/statistiques.html
+++ b/aidants_connect_web/templates/public_website/statistiques.html
@@ -15,110 +15,123 @@
     <h1 class="section__title">Statistiques d’Aidants Connect</h1>
     <div class="tiles">
 
-      <h2>Déploiement</h2>
+      <h2>Utilisation</h2>
       <div class="grid">
         <div class="tile-box stretch">
           <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Structures</h3>
-            <strong>{{ organisations_count }}</strong>
-          </div>
-        </div>
-        <div class="tile-box stretch">
-          <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Aidants</h3>
-            <strong>{{ aidants_count }}</strong>
+            <h3 class="font-weight-normal">Démarches administratives réalisés</h3>
+            <strong>{{ autorisation_use_count }}</strong>
           </div>
         </div>
         <div class="tile-box stretch">
           <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Aidants en cours d’habilitation</h3>
-            <strong>{{ aidants_habilitating_count }}</strong>
-          </div>
-        </div>
-      </div>
-
-      <br>
-
-      <h2>Mandats</h2>
-      <div class="grid">
-        <div class="tile-box">
-          <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Mandats créés</h3>
-            <strong>{{ mandats_count }}</strong>
-          </div>
-          <p class="tile-subtitle">
-            depuis le 18 mars 2020
-          </p>
-        </div>
-        <div class="tile-box">
-          <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Mandats actifs</h3>
-            <strong>{{ active_mandats_count }}</strong>
-          </div>
-        </div>
-      </div>
-
-      <br>
-
-      <h2>Usagers</h2>
-      <div class="grid">
-        <div class="tile-box">
-          <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Usagers</h3>
+            <h3 class="font-weight-normal">Personnes accompagnées</h3>
             <strong>{{ usagers_with_mandat_count }}</strong>
           </div>
         </div>
-        <div class="tile-box">
+        <div class="tile-box stretch">
           <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">Usagers actifs</h3>
-            <strong>{{ usagers_with_active_mandat_count }}</strong>
+            <h3 class="font-weight-normal">Mandats crées</h3>
+            <strong>{{ mandats_count }}</strong>
           </div>
         </div>
       </div>
 
       <br>
 
-      <h2>Démarches France Connect accompagnées</h2>
+      <h3>Par type de démarche</h3>
+      <div class="container">
+        <canvas id="mandats-chart" aria-label="Les périmètres des mandats" role="img">
+          <table>
+            <tr>
+              <th scope="col">Type de mandat</th>
+              <th scope="col">Nombre des démarches</th>
+            </tr>
+            {% for demarche in demarches_count %}
+            <tr>
+              <th scope="row">{{ demarche.title }}</th>
+              <td>{{ demarche.value }}</td>
+            </tr>
+            {% endfor %}
+          </table>
+        </canvas>
+      </div>
+
+      <br>
+
+      <h2>Déploiement</h2>
       <div class="grid">
         <div class="tile-box">
-            <div class="tile tile-grey text-center">
-              <h3 class="font-weight-normal">Depuis le lancement</h3>
-              <strong>
-                Usagers accompagnés : {{ usagers_helped_count }}
-                <br>
-                Connexions effectuées : {{ autorisation_use_count }}
-                <br>
-              </strong>
-            </div>
+          <div class="tile tile-grey text-center">
+            <h3 class="font-weight-normal">Aidants habilités</h3>
+            <strong>{{ aidants_count }}</strong>
           </div>
+        </div>
         <div class="tile-box">
           <div class="tile tile-grey text-center">
-            <h3 class="font-weight-normal">30 derniers jours</h3>
-            <strong>
-              Usagers accompagnés : {{ usagers_helped_recent_count }}
-              <br>
-              Connexions effectuées : {{ autorisation_use_recent_count }}
-              <br>
-            </strong>
+            <h3 class="font-weight-normal">Aidants en cours d’habilitation</h3>
+            <strong>{{ aidants_accrediting_count }}</strong>
+          </div>
+        </div>
+        <div class="tile-box">
+          <div class="tile tile-grey text-center">
+            <h3 class="font-weight-normal">Structures habilitées</h3>
+            <strong>{{ organisations_accredited_count }}</strong>
+          </div>
+        </div>
+        <div class="tile-box">
+          <div class="tile tile-grey text-center">
+            <h3 class="font-weight-normal">Structures en cours d’habilitation</h3>
+            <strong>{{ organisations_not_accredited_count }}</strong>
           </div>
         </div>
       </div>
-      
-      <h3>Par type de démarche</h3>
-      <div class="grid small-grid">
-        {% for stat_item in demarches_count %}
-          <div class="tile-box">
-            <div class="tile tile-grey text-center">
-              <h4 class="font-weight-normal">
-                <img class="icon-inline" src="{{ stat_item.icon }}" alt="" />
-                {{ stat_item.title }}
-              </h4>
-              <strong>{{ stat_item.value }}</strong>
-            </div>
-          </div>
-        {% endfor %}
-      </div>
+
     </div>
   </div>
 </section>
 {% endblock content %}
+
+{% block extrajs %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js"></script>
+{{ data|json_script:"data" }}
+
+<script>
+  const data = JSON.parse(document.getElementById('data').textContent);
+
+  var ctx = document.getElementById('mandats-chart').getContext('2d');
+
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: data.labels,
+      datasets: [{
+        label: 'Nombre de démarches',
+        backgroundColor: 'blue',
+        data: data.data
+      }]
+    },
+    options: {
+      responsive: true,
+      aspectRatio:2,
+      maintainAspectRatio: true,
+      legend: {
+        position: 'top',
+      },
+      title: {
+        display: true,
+        text: 'Les périmètres des mandats'
+      },
+      scales: {
+        x: {
+          grid: {
+              display:false
+          }
+        }
+      }
+    }
+  });
+
+</script>
+
+{% endblock extrajs %}

--- a/aidants_connect_web/tests/test_functional/test_statistiques.py
+++ b/aidants_connect_web/tests/test_functional/test_statistiques.py
@@ -9,4 +9,4 @@ from aidants_connect.common.tests.testcases import FunctionalTestCase
 class StatistiquesPage(FunctionalTestCase):
     def test_page_loads(self):
         self.open_live_url("/stats/")
-        self.assertEqual(len(self.selenium.find_elements(By.CLASS_NAME, "tile")), 19)
+        self.assertEqual(len(self.selenium.find_elements(By.CLASS_NAME, "tile")), 7)


### PR DESCRIPTION
## 🌮 Objectif

Changements page statistiques publique : simplification de la page (moins d'informations), ajout histogramme type de démarche.

## 🔍 Implémentation

Organisation Manager dans models.py pour compter les structures habilités et en cours d'habilitation.
Changements service.py
Réorganisation statistiques.html
Ajout JS dans statistiques.html pour l'histogramme (Charts.js)

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
