### PR TITLE
Suppression de la dépendance mock

### DIFF
--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1,13 +1,12 @@
 from datetime import date, datetime, timedelta
 from os.path import join as path_join
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from django.conf import settings
 from django.db.utils import IntegrityError
 from django.test import TestCase, tag
 from django.utils import timezone
 
-import mock
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from freezegun import freeze_time
 from pytz import timezone as pytz_timezone
@@ -1283,7 +1282,7 @@ class AidantModelMethodsTests(TestCase):
 
         self.assertEqual(aidant.organisation, supplementary_organisation_1)
 
-    @mock.patch("aidants_connect_web.models.aidants__organisations_changed.send")
+    @patch("aidants_connect_web.models.aidants__organisations_changed.send")
     def test_remove_user_from_organisation_sends_signal(self, send: Mock):
         aidant: Aidant = AidantFactory()
         supplementary_organisation_1 = OrganisationFactory()
@@ -1367,7 +1366,7 @@ class AidantModelMethodsTests(TestCase):
 
         self.assertEqual(aidant.organisation, supplementary_organisation_1)
 
-    @mock.patch("aidants_connect_web.models.aidants__organisations_changed.send")
+    @patch("aidants_connect_web.models.aidants__organisations_changed.send")
     def test_set_organisations_sends_signal(self, send: Mock):
         aidant: Aidant = AidantFactory()
         previous_organisation = aidant.organisation

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 from django.conf import settings
 from django.test import TestCase, override_settings, tag
@@ -6,7 +7,6 @@ from django.test.client import Client
 from django.urls import reverse
 
 import jwt
-import mock
 from freezegun import freeze_time
 from pytz import timezone as pytz_timezone
 

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_validate_totp_card.py
@@ -1,8 +1,9 @@
+from unittest import mock
+
 from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 
-import mock
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
 from aidants_connect_web.models import Journal

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ entrypoints==0.3
 factory-boy==3.2.1
 freezegun==1.1.0
 gunicorn==20.1.0
-mock==4.0.3
 Pillow==9.0.1
 psycopg2-binary==2.9.3
 ptpython==3.0.20


### PR DESCRIPTION
## 🌮 Objectif

`mock` a été intégré au module `unittest` depuis Python 3.3.