### PR TITLE
Faire en sorte que les comptes inactifs ne reçoivent pas de mail de connexion

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -146,8 +146,8 @@ class LoginEmailForm(MagicAuthEmailForm):
         user_email = super().clean_email()
         if not Aidant.objects.filter(email=user_email, is_active=True).exists():
             raise ValidationError(
-                "Votre compte existe mais il n'est pas encore actif. "
-                "Si vous pensez que c'est une erreur, renez contact avec votre "
+                "Votre compte existe mais il n’est pas encore actif. "
+                "Si vous pensez que c’est une erreur, prenez contact avec votre "
                 "responsable ou avec Aidants Connect."
             )
         return user_email

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -8,6 +8,7 @@ from django.forms import EmailField
 from django.utils.translation import gettext_lazy as _
 
 from django_otp import match_token
+from magicauth.forms import EmailForm as MagicAuthEmailForm
 from phonenumber_field.formfields import PhoneNumberField
 from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
@@ -136,6 +137,20 @@ class AidantChangeForm(forms.ModelForm):
                 cleaned_data["username"] = data_email
 
         return cleaned_data
+
+
+class LoginEmailForm(MagicAuthEmailForm):
+    email = forms.EmailField()
+
+    def clean_email(self):
+        user_email = super().clean_email()
+        if not Aidant.objects.filter(email=user_email, is_active=True).exists():
+            raise ValidationError(
+                "Votre compte existe mais il n'est pas encore actif. "
+                "Si vous pensez que c'est une erreur, renez contact avec votre "
+                "responsable ou avec Aidants Connect."
+            )
+        return user_email
 
 
 class MandatForm(forms.Form):

--- a/aidants_connect_web/tests/test_functional/test_view_autorisations.py
+++ b/aidants_connect_web/tests/test_functional/test_view_autorisations.py
@@ -18,7 +18,7 @@ from aidants_connect_web.tests.test_functional.utilities import login_aidant
 @tag("functional")
 class ViewAutorisationsTests(FunctionalTestCase):
     def setUp(self):
-        self.aidant = AidantFactory(email="thierry@thierry.com")
+        self.aidant = AidantFactory(username="thierry@thierry.com")
         device = self.aidant.staticdevice_set.create(id=self.aidant.id)
         device.token_set.create(token="123456")
 

--- a/aidants_connect_web/tests/test_views/test_login.py
+++ b/aidants_connect_web/tests/test_views/test_login.py
@@ -1,0 +1,25 @@
+from django.core import mail
+from django.test import TestCase, tag
+from django.test.client import Client
+
+from aidants_connect_web.tests.factories import AidantFactory
+
+
+@tag("usagers")
+class LoginTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.aidant = AidantFactory(is_active=False, post__with_otp_device=True)
+
+    def test_inactive_aidant_with_valid_totp_cannot_login(self):
+        response = self.client.post(
+            "/accounts/login/", {"email": self.aidant.email, "otp_token": "123456"}
+        )
+        self.assertEqual(response.status_code, 200)
+        # Check explicit message is displayed
+        self.assertContains(
+            response, "Votre compte existe mais il n’est pas encore actif."
+        )
+        # Check no email was sent
+        self.assertEqual(len(mail.outbox), 0)

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 
-from magicauth import views as magicauth_views
 from magicauth.urls import urlpatterns as magicauth_urls
 
 from aidants_connect_web.views import (
@@ -9,6 +8,7 @@ from aidants_connect_web.views import (
     espace_aidant,
     espace_responsable,
     id_provider,
+    login,
     mandat,
     renew_mandat,
     service,
@@ -17,7 +17,7 @@ from aidants_connect_web.views import (
 
 urlpatterns = [
     # service
-    path("accounts/login/", magicauth_views.LoginView.as_view(), name="login"),
+    path("accounts/login/", login.LoginView.as_view(), name="login"),
     path("logout-session/", service.logout_page, name="logout"),
     path("activity_check/", service.activity_check, name="activity_check"),
     # espace aidant : home, organisation

--- a/aidants_connect_web/views/login.py
+++ b/aidants_connect_web/views/login.py
@@ -1,0 +1,7 @@
+from magicauth import views as magicauth_views
+
+from aidants_connect_web.forms import LoginEmailForm
+
+
+class LoginView(magicauth_views.LoginView):
+    form_class = LoginEmailForm


### PR DESCRIPTION
## 🌮 Objectif

Éviter un parcours UX décevant aux aidants dont le compte existe avec une carte TOTP, mais n'a pas été activé : dans l'état actuel des choses, ils reçoivent un lien de connexion mais ils sont ensuite redirigés "muettement" vers la page de login.

On fait en sorte de les prévenir tout de suite que ça ne va pas marcher, en leur expliquant qui contacter (théoriquement leur responsable de structure, mais peut-être directement AC).

## 🔍 Implémentation

- Modification côté aidants connect et non dans django-magicauth qui est plus agnostique que nous
- Ajout d'un test (sans selenium)

## 🖼️ Images

<img width="688" alt="Capture d’écran 2022-02-24 à 15 23 53" src="https://user-images.githubusercontent.com/1035145/155542384-fd4a2d01-609e-4235-aca7-dc49b32bf609.png">


