### PR TITLE
Suppression des références au numéro "solidarité numérique"

### DIFF
--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -66,30 +66,3 @@
     </form>
   </div>
 </section>
-<section class="section">
-  <div class="container">
-    <h2>Vous cherchez de l’aide ?</h2>
-    <div class="row">
-      <div class="min-width-35 background-color-grey text-center">
-        <img src="{% static 'images/solidarite-numerique-illu_home.svg' %}" alt="">
-      </div>
-      <div>
-        <p>
-          <strong><a href="https://solidarite-numerique.fr">Solidarité Numérique</a> est le centre d’aide pour les démarches en ligne essentielles.</strong>
-          Le service est joignable par téléphone, du lundi au vendredi, de 9h à 18h.
-        </p>
-        <p class="text-center">
-          <img class="vertical-align-middle" src="{% static 'images/solidarite-numerique-phoneheart.svg' %}" alt="">
-          <span id="tel_solidarite_numerique"><a class="no-decoration" href="tel:0170772372" title="Numéro de téléphone Solidarité numérique 01 70 772 372">01 70 772 372</a></span>
-          <span><small>(appel non surtaxé)</small></span>
-        </p>
-        <p>
-          Vous pouvez aussi consulter <a href="https://solidarite-numerique.fr">solidarite-numerique.fr</a>
-          où vous trouverez des explications sur de nombreuses démarches.
-        </p>
-      </div>
-    </div>
-  </div>
-</section>
-{% include 'public_website/section_link_faq_partial.html' %}
-{% endblock content %}

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -66,3 +66,5 @@
     </form>
   </div>
 </section>
+{% include 'public_website/section_link_faq_partial.html' %}
+{% endblock content %}

--- a/aidants_connect_web/templates/public_website/resource_list.html
+++ b/aidants_connect_web/templates/public_website/resource_list.html
@@ -25,7 +25,6 @@
         <div class="card__meta"><span>Mission Société Numérique</span></div>
         <p>
           Solidarité Numérique est le centre d’aide pour les démarches en ligne essentielles.
-          le service est joignable du lundi au vendredi, de 9h à 18h, par téléphone au <a href="tel:0170772372" title="Numéro de téléphone Solidarité numérique 01 70 772 372">01 70 772 372</a> (appel non surtaxé).
         </p>
       </div>
     <div class="card__extra" aria-hidden="true">{# hidden because it is a redundant link vs the one in the title #}


### PR DESCRIPTION
## 🌮 Objectif

Supprimer l'encart "Vous cherchez de l’aide ?" car le numéro solidarité numérique n'est plus en fonctionnement.




## 🖼️ Images

![image](https://user-images.githubusercontent.com/98959078/155571365-9fe57eac-8b90-4bbc-8b99-09d8081dc827.png)

<img width="1146" alt="Capture d’écran 2022-02-24 à 19 37 57" src="https://user-images.githubusercontent.com/1035145/155586753-724d3e6c-70ae-4bc6-884b-9de2380eb762.png">


