### PR TITLE
Quelques améliorations et tests unitaires pour OrganisationRequestForm

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -124,16 +124,13 @@ class OrganisationRequestForm(PatchedErrorListForm):
         )
 
     def clean_type(self):
-        try:
-            return OrganisationType.objects.get(pk=int(self.data["type"]))
-        except OrganisationType.DoesNotExist:
-            raise ValidationError("Mauvais type d'organisation soumis")
+        return OrganisationType.objects.get(pk=int(self.data["type"]))
 
     def clean_type_other(self):
-        if (
-            int(self.data["type"]) == RequestOriginConstants.OTHER.value
-            and not self.data["type_other"]
-        ):
+        if int(self.data["type"]) != RequestOriginConstants.OTHER.value:
+            return ""
+
+        if not self.data["type_other"]:
             label = self.fields["type_other"].label
             raise ValidationError(
                 f"Le champ « {label} » doit être rempli si la "

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -1,0 +1,59 @@
+from django.test import TestCase
+
+from aidants_connect.common.constants import RequestOriginConstants
+from aidants_connect_habilitation.forms import OrganisationRequestForm
+from aidants_connect_habilitation.tests.utils import get_form
+from aidants_connect_web.models import OrganisationType
+
+
+class TestOrganisationRequestForm(TestCase):
+    def test_clean_type_passes(self):
+        form = get_form(
+            OrganisationRequestForm,
+            type_id=RequestOriginConstants.MEDIATHEQUE.value,
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["type"],
+            OrganisationType.objects.get(pk=RequestOriginConstants.MEDIATHEQUE.value),
+        )
+
+    def test_clean_type_other_returns_user_value(self):
+        form = get_form(
+            OrganisationRequestForm,
+            type_id=RequestOriginConstants.OTHER.value,
+            type_other="L'organisation des travaillleurs",
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            form.cleaned_data["type_other"], "L'organisation des travaillleurs"
+        )
+
+    def test_clean_type_other_returns_blank_on_specific_org_type(self):
+        form = get_form(
+            OrganisationRequestForm,
+            type_id=RequestOriginConstants.MEDIATHEQUE.value,
+            type_other="L'organisation des travaillleurs",
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["type_other"], "")
+
+    def test_clean_type_other_unspecified_raises_error(self):
+        form = get_form(
+            OrganisationRequestForm,
+            ignore_errors=True,
+            type_id=RequestOriginConstants.OTHER.value,
+            type_other=None,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["type_other"],
+            [
+                f"Le champ « Type de structure si autre » doit être rempli "
+                f"si la structure est de type {RequestOriginConstants.OTHER.label}."
+            ],
+        )

--- a/aidants_connect_habilitation/tests/utils.py
+++ b/aidants_connect_habilitation/tests/utils.py
@@ -11,7 +11,61 @@ from aidants_connect_habilitation.tests import factories
 
 
 @singledispatch
-def get_form(form_cls, **kwargs):
+def get_form(form_cls, ignore_errors=False, **kwargs):
+    """
+    Generates a form ModelForm or FormSet[ModelForm] populated with data.
+
+    In order to correctly perform, the form class you pass as the form_cls
+    parameter needs to inherit from ModelForm or FormSet[ModelForm].
+    The ModelForm needs to map to a django Model that has a corresponding
+    factory in aidants_connect_habilitation.tests.factories.
+
+    For instance:
+
+        # In models.py
+        from django.db import models
+        from django.utils.timezone import now
+
+
+        class TestModel(models.Model):
+            created = models.DateTimeField(default=now)
+
+
+        # In forms.py
+        from django import forms
+        from aidants_connect_habilitation.models import TestModel
+
+        class TestForm(forms.ModelForm):
+            class Meta:
+                model = TestModel
+
+        # in aidants_connect_habilitation/tests/factories.py
+        from factory.django import DjangoModelFactory
+        from aidants_connect_habilitation.models import TestModel
+
+        class TestFactory(DjangoModelFactory)
+            class Meta:
+                model = TestModel
+
+        # Usage
+        form = get_form(TestForm)
+
+    This function will pick to the first factory in factory.py that has
+    the same model as the form requested and build a form using the data
+    generated from that factory.
+
+    By default, it tries to generate valid froms but if your purpose is
+    to generate forms with invalid data, you can skip error checking by
+    setting the ignore_errors parameter to True.
+
+    You can also directly pass data to the factory using **kwargs.
+
+    :param form_cls: The form class to instanciate
+    :param ignore_errors: If set to True get_form() won't perform an is_valid()
+                          call on the generated form.
+    :param kwargs: Supplementary arguments to pass to the factory.
+    :return: The form to generate. Will be an instance of class form_cls.
+    """
     raise NotImplementedError(
         f"{get_form.__name__} is not implemented for type {type(form_cls)}"
     )
@@ -21,17 +75,17 @@ T = TypeVar("T", bound=ModelForm)
 
 
 @get_form.register(type(ModelForm))
-def _(form_cls: Type[T], **kwargs) -> T:
+def _(form_cls: Type[T], ignore_errors=False, **kwargs) -> T:
     form = form_cls(data=__get_form_data(form_cls, **kwargs))
 
-    if not form.is_valid():
+    if not ignore_errors and not form.is_valid():
         raise ValueError(str(form.errors))
 
     return form
 
 
 @get_form.register(type(BaseFormSet))
-def _(form_cls: Type[BaseFormSet], **kwargs) -> BaseFormSet:
+def _(form_cls: Type[BaseFormSet], ignore_errors=False, **kwargs) -> BaseFormSet:
     formset_cls = form_cls
     form_cls = form_cls.form
     form: BaseFormSet = formset_cls(
@@ -52,7 +106,7 @@ def _(form_cls: Type[BaseFormSet], **kwargs) -> BaseFormSet:
 
     form = formset_cls(data=data)
 
-    if not form.is_valid():
+    if not ignore_errors and not form.is_valid():
         raise ValueError(str(form.errors))
 
     return form


### PR DESCRIPTION
## 🌮 Objectif



## 🔍 Implémentation

- À la validation, `type_other` sera toujours vide à moins que l'organisation soit de type « autre ».
- La validation du champ `type` ne vérifie plus que le type d'organisation soumis soit bien enregistré dans la base puisque que le champ lui-même est limité par un paramètre `choice` qui fait cette validation.
- Des tests unitaires ont été rajoutés pour ce formulaire.

## 🏕 Amélioration continue

- La fonction `aidants_connect_habilitation.tests.utils.get_form` est maintenant documentée