### PR TITLE
Fonctionnalité pour rajouter un formulaire aidant sur la page personnel

### DIFF
--- a/aidants_connect_habilitation/static/js/personnel_form.js
+++ b/aidants_connect_habilitation/static/js/personnel_form.js
@@ -1,0 +1,56 @@
+"use strict";
+
+(function () {
+    const PersonnelForm = Object.extendClass(Stimulus.Controller);
+
+    Object.assign(PersonnelForm.prototype, {
+        "connect": function connect() {
+            this.formCountValue = this.managmentFormCountTarget.value;
+            this.formMaxCountValue = this.managmentFormMaxCountTarget.value;
+            this.mutateAddAidantButtonVisibility();
+        },
+
+        "formCountValueChanged": function formCountValueChanged() {
+            this.managmentFormCountTarget.value = this.formCountValue;
+        },
+
+        "onAddAidantButtonClicked": function onAddAidantButtonClicked() {
+            const template = this.aidantFormTemplateTarget.innerHTML.replace(
+                /__prefix__/gm, String(this.formCountValue + 1)
+            );
+
+            this.aidantFormsetTarget.insertAdjacentHTML("beforeend", template);
+            this.formCountValue++;
+            this.mutateAddAidantButtonVisibility();
+        },
+
+        "mutateAddAidantButtonVisibility": function mutateAddAidantButtonVisibility() {
+            if (this.formCountValue >= this.formMaxCountValue) {
+                this.addAidantButtonContainerTarget.setAttribute("hidden", "hidden");
+            } else {
+                this.addAidantButtonContainerTarget.removeAttribute("hidden");
+            }
+        }
+    });
+
+    /* Static fields */
+    PersonnelForm.targets = [
+        "managmentFormCount",
+        "managmentFormMaxCount",
+        "addAidantButtonContainer",
+        "aidantFormTemplate",
+        "aidantFormset",
+    ];
+
+    PersonnelForm.values = {
+        formCount: Number,
+        formMaxCount: Number,
+    };
+
+    function init() {
+        const application = Stimulus.Application.start();
+        application.register("personnel-form", PersonnelForm);
+    }
+
+    window.addEventListener("load", init);
+})();

--- a/aidants_connect_habilitation/templates/_aidant_form.html
+++ b/aidants_connect_habilitation/templates/_aidant_form.html
@@ -1,10 +1,15 @@
 {% load static form_extras %}
 
-<fieldset>
-  <legend class="sr-only">Aidant</legend>
-  {% field_as_narrow_fr_grid_row form.email %}
-  <h5 class="h3">Identité</h5>
-  {% field_as_narrow_fr_grid_row form.last_name %}
-  {% field_as_narrow_fr_grid_row form.first_name %}
-  {% field_as_narrow_fr_grid_row form.profession %}
-</fieldset>
+<div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+  <section class="shadowed aidant-form-container">
+    <h4 class="h2">Aidant</h4>
+    <fieldset>
+      <legend class="sr-only">Aidant</legend>
+      {% field_as_narrow_fr_grid_row form.email %}
+      <h5 class="h3">Identité</h5>
+      {% field_as_narrow_fr_grid_row form.last_name %}
+      {% field_as_narrow_fr_grid_row form.first_name %}
+      {% field_as_narrow_fr_grid_row form.profession %}
+    </fieldset>
+  </section>
+</div>

--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -1,14 +1,18 @@
 {% extends 'layouts/main-habilitation.html' %}
-{% load static form_extras %}
+{% load static form_extras ac_common %}
 
 {% block title %}
   Aidants Connect - Personnes impliquées dans la structure {{ organisation }}
 {% endblock %}
 
 {% block content %}
-  <div class="fr-container">
+  <div
+    class="fr-container"
+    data-controller="personnel-form"
+  >
     {% include 'edito/_titre_formulaire_habilitation.html' %}
     {% include "layouts/_breadcrumbs.html" %}
+
     <h2>Personnes impliquées</h2>
     <p class="subtitle">Saisissez ici les informations relatives aux personnes qui utiliseront Aidants Connect</p>
 
@@ -19,6 +23,7 @@
       {{ form.non_field_errors }}
 
       {{ form.aidants_formset.management_form }}
+
       <h3>Responsables</h3>
 
       <div class="fr-grid-row fr-grid-row--gutters">
@@ -58,10 +63,12 @@
 
               {% with errors=form.manager_form.zipcode.errors|add:form.manager_form.city.errors %}
                 <div
-                    class="form-grid-row fr-grid-row form-grid-row-narrow fr-grid-row--gutters {% if errors %}form-grid-row-error{% endif %}">
+                  class="form-grid-row fr-grid-row form-grid-row-narrow fr-grid-row--gutters {% if errors %}form-grid-row-error{% endif %}"
+                >
                   <div class="fr-col-12 fr-col-md-5 fr-col-lg-12">
-                    <label
-                        for="{{ form.manager_form.zipcode.id_for_label }}">{{ form.manager_form.zipcode.label }}</label>&nbsp;/&nbsp;
+                    <label for="{{ form.manager_form.zipcode.id_for_label }}">
+                      {{ form.manager_form.zipcode.label }}
+                    </label>&nbsp;/&nbsp;
                     <label for="{{ form.manager_form.city.id_for_label }}">{{ form.manager_form.city.label }}</label>
                   </div>
                   <div class="fr-col-4 fr-col-md-2 fr-col-lg-4 zipcode-container">
@@ -104,21 +111,24 @@
       </div>
 
 
-      <h3>Aidants</h3>
-      <div class="fr-grid-row fr-grid-row--gutters">
-        {% for aidant_form in form.aidants_formset %}
-          <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-            <section class="shadowed">
-              <h4 class="h2">Aidant</h4>
-              {% include "_aidant_form.html" with form=aidant_form %}
-            </section>
-          </div>
-        {% endfor %}
-        <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-          <button class="shadowed grey" type="button">
+      <h3>
+        Aidants
+        <span data-personnel-form-target="addAidantButtonContainer">
+          <button
+            id="add-aidant-btn"
+            class="primary"
+            type="button"
+            data-action="click->personnel-form#onAddAidantButtonClicked"
+          >
             Ajouter un aidant
           </button>
-        </div>
+        </span>
+      </h3>
+
+      <div class="fr-grid-row fr-grid-row--gutters" data-personnel-form-target="aidantFormset">
+        {% for aidant_form in form.aidants_formset %}
+          {% include "_aidant_form.html" with form=aidant_form %}
+        {% endfor %}
       </div>
 
       <div class="button-box standalone">
@@ -132,5 +142,14 @@
 
     {% include "_more-info.html" %}
 
+    <template data-personnel-form-target="aidantFormTemplate" hidden>
+      {% include "_aidant_form.html" with form=form.aidants_formset.empty_form %}
+    </template>
   </div>
+{% endblock %}
+
+{% block extrajs %}
+  {% stimulusjs %}
+  <script src="{% static 'js/utils.js' %}"></script>
+  <script src="{% static 'js/personnel_form.js' %}"></script>
 {% endblock %}

--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -68,8 +68,9 @@
                   <div class="fr-col-12 fr-col-md-5 fr-col-lg-12">
                     <label for="{{ form.manager_form.zipcode.id_for_label }}">
                       {{ form.manager_form.zipcode.label }}
-                    </label>&nbsp;/&nbsp;
-                    <label for="{{ form.manager_form.city.id_for_label }}">{{ form.manager_form.city.label }}</label>
+                    </label>&nbsp;/&nbsp;<label for="{{ form.manager_form.city.id_for_label }}">
+                      {{ form.manager_form.city.label }}
+                    </label>
                   </div>
                   <div class="fr-col-4 fr-col-md-2 fr-col-lg-4 zipcode-container">
                     {{ form.manager_form.zipcode }}

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
@@ -117,6 +119,10 @@ class OrganisationRequestFactory(DjangoModelFactory):
 
     class Meta:
         model = OrganisationRequest
+
+
+class DraftOrganisationRequestFactory(OrganisationRequestFactory):
+    draft_id = uuid4()
 
 
 class AidantRequestFactory(DjangoModelFactory):

--- a/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
@@ -1,0 +1,130 @@
+from django.test import tag
+from django.urls import reverse
+
+from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
+
+from aidants_connect.common.tests.testcases import FunctionalTestCase
+from aidants_connect_habilitation.forms import AidantRequestForm, PersonnelForm
+from aidants_connect_habilitation.models import Issuer, OrganisationRequest
+from aidants_connect_habilitation.tests.factories import (
+    DraftOrganisationRequestFactory,
+    IssuerFactory,
+)
+
+
+@tag("functional")
+class PersonnelRequestFormViewTests(FunctionalTestCase):
+    def test_js_managment_form_aidant_count_is_modified(self):
+        issuer: Issuer = IssuerFactory()
+        organisation: OrganisationRequest = DraftOrganisationRequestFactory(
+            issuer=issuer
+        )
+        self.__open_form_url(issuer, organisation)
+
+        input_el = self.selenium.find_element(
+            By.CSS_SELECTOR, "input[name$='TOTAL_FORMS']"
+        )
+
+        for i in range(0, 5):
+            self.assertEqual(str(i), input_el.get_attribute("value"))
+            self.selenium.find_element(By.CSS_SELECTOR, "#add-aidant-btn").click()
+            self.assertEqual(str(i + 1), input_el.get_attribute("value"))
+
+    def test_js_aidant_form_is_added_to_formset(self):
+        issuer: Issuer = IssuerFactory()
+        organisation: OrganisationRequest = DraftOrganisationRequestFactory(
+            issuer=issuer
+        )
+        self.__open_form_url(issuer, organisation)
+
+        for i in range(1, 5):
+            input_el = self.selenium.find_elements(
+                By.CSS_SELECTOR, ".aidant-form-container"
+            )
+            self.assertEqual(i, len(input_el))
+            self.selenium.find_element(By.CSS_SELECTOR, "#add-aidant-btn").click()
+            input_el = self.selenium.find_elements(
+                By.CSS_SELECTOR, ".aidant-form-container"
+            )
+            self.assertEqual(i + 1, len(input_el))
+
+    def test_js_hide_add_aidant_form_button_on_max(self):
+        issuer: Issuer = IssuerFactory()
+        organisation: OrganisationRequest = DraftOrganisationRequestFactory(
+            issuer=issuer
+        )
+        self.__open_form_url(issuer, organisation)
+
+        add_aidant_button = self.selenium.find_element(
+            By.CSS_SELECTOR, "#add-aidant-btn"
+        )
+
+        max_value = self.selenium.find_element(
+            By.CSS_SELECTOR, "input[name$='MAX_NUM_FORMS']"
+        ).get_attribute("value")
+
+        # Manually set the number of forms to the max - 1 for the Stimulus controller
+        self.selenium.execute_script(
+            """document.querySelector("[data-controller='personnel-form']")"""
+            f""".dataset.personnelFormFormCountValue = {int(max_value) - 1}"""
+        )
+
+        self.assertTrue(add_aidant_button.is_displayed())
+        add_aidant_button.click()
+        self.assertFalse(add_aidant_button.is_displayed())
+
+    def test_js_added_aidant_form_has_correct_id(self):
+        """
+        This test verifies that the JS code generates forms exactly like
+        AidantRequestFormSet would.
+        """
+        issuer: Issuer = IssuerFactory()
+        organisation: OrganisationRequest = DraftOrganisationRequestFactory(
+            issuer=issuer
+        )
+
+        self.__open_form_url(issuer, organisation)
+
+        self.selenium.find_element(By.CSS_SELECTOR, "#add-aidant-btn").click()
+        self.selenium.find_element(By.CSS_SELECTOR, "#add-aidant-btn").click()
+        self.selenium.find_element(By.CSS_SELECTOR, "#add-aidant-btn").click()
+
+        form_elts = self.selenium.find_elements(
+            By.CSS_SELECTOR, ".aidant-form-container"
+        )
+
+        self.assertEqual(len(form_elts), 4)
+
+        form = AidantRequestForm()
+
+        for i, _ in enumerate(form_elts):
+            for field_name, field in form.fields.items():
+                html_id = f"id_{PersonnelForm.AIDANTS_FORMSET_PREFIX}-{i}-{field_name}"
+
+                try:
+                    field_label = self.selenium.find_element(
+                        By.CSS_SELECTOR, f'[for="{html_id}"]'
+                    )
+                except NoSuchElementException:
+                    self.fail(
+                        f"Label for form element {html_id} not found. "
+                        "Was form 'prefix' or 'auto_id' modified?"
+                    )
+
+                self.assertEqual(field_label.text, field.label)
+
+    def __open_form_url(
+        self,
+        issuer: Issuer,
+        organisation_request: OrganisationRequest,
+    ):
+        self.open_live_url(
+            reverse(
+                "habilitation_new_aidants",
+                kwargs={
+                    "issuer_id": issuer.issuer_id,
+                    "draft_id": organisation_request.draft_id,
+                },
+            )
+        )


### PR DESCRIPTION
## 🌮 Objectif

Le bouton « + Ajouter un aidant » sur le formulaire de personnel de l'organisation peut maintenant rajouter des formuaires d'aidant jusqu'à la limite paramétrée dans le `aidants_connect_habilitation.forms.AidantRequestFormSet` (1000, par défaut, ce qui est confortables, vous en conviendrez). Au-delà, le bouton est caché.

Les tests sont écrits.

Par contre… Heu… Le CSS est cassé. Pardon @tut-tuuut :pray: 

## 🔍 Implémentation

- Un controlleur Stimulus plus simple que ce que je pensais

## 🖼️ Images

![Screenshot 2022-03-03 at 15-04-58 Aidants Connect](https://user-images.githubusercontent.com/22097904/156580300-bbc73071-df63-46dd-8f30-bf0cb0ec380d.png)

