### PR TITLE
Suppression du calendrier de déploiement

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -76,37 +76,6 @@
             FAQ.</a></strong></p><br>
       </div>
 
-      <h2>Calendrier du déploiement</h2>
-
-      <p><strong>Le déploiement de l'outil va s'effectuer par vagues territoriales progressives selon le calendrier
-        suivant :</strong></p>
-
-      <h3>Première vague : Mars - avril 2021</h3>
-      <ul>
-        <li>Hauts-de-France ;
-        <li>La Réunion & Mayotte ;
-        <li>Bretagne ;
-        <li>Auvergne-Rhône Alpes.
-      </ul>
-      <h3>Deuxième vague : Mai - août 2021</h3>
-      <ul>
-        <li>Guadeloupe, Martinique & Guyane ;
-        <li>Nouvelle-Aquitaine ;
-        <li>Bourgogne-Franche-Comté ;
-        <li>Île-de-France.
-      </ul>
-      <h3>Troisième vague : Septembre - décembre 2021</h3>
-      <ul>
-        <li>Provence-Alpes-Côte d'Azur & Corse ;
-        <li>Centre-Val-de-Loire ;
-        <li>Normandie ;
-        <li>Occitanie ;
-        <li>Grand Est ;
-        <li>Pays-de-la-Loire.
-      </ul>
-      <br>
-
-      <p><strong>Les demandes d'habilitation seront traitées en priorité par ordre de déploiement.</strong></p>
-    </div>
+         </div>
   </section>
 {% endblock %}


### PR DESCRIPTION
## 🌮 Objectif

Supprimer le calendrier de déploiement, car il s'est terminé en Décembre 2021

