### PR TITLE
Suppression des mandats révoqués et expirés sur l'espace aidant au bout d'un an

### DIFF
--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -149,7 +149,26 @@ class RevokedMandatFactory(MandatFactory):
             )
 
 
+class RevokedOverYearMandatFactory(MandatFactory):
+    @post_generation
+    def post(self, create, _, **kwargs):
+        authorisations = kwargs.get("create_authorisations", None)
+        if not create or not isinstance(authorisations, Iterable):
+            return
+
+        for auth in authorisations:
+            Autorisation.objects.create(
+                mandat=self,
+                demarche=str(auth),
+                revocation_date=(now() - timedelta(days=365)),
+            )
+
+
 class ExpiredMandatFactory(MandatFactory):
+    expiration_date = LazyAttribute(lambda f: now() - timedelta(days=5))
+
+
+class ExpiredOverYearMandatFactory(MandatFactory):
     expiration_date = LazyAttribute(lambda f: now() - timedelta(days=365))
 
 

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -7,7 +7,9 @@ from django.utils import timezone
 from aidants_connect_web.tests.factories import (
     AidantFactory,
     AutorisationFactory,
+    ExpiredOverYearMandatFactory,
     MandatFactory,
+    RevokedOverYearMandatFactory,
     UsagerFactory,
 )
 from aidants_connect_web.views.usagers import (
@@ -33,6 +35,10 @@ class ViewAutorisationsTests(TestCase):
         )
         cls.usager_philomene = UsagerFactory(
             given_name="Philomène", family_name="Smith"
+        )
+
+        cls.usager_pierre = UsagerFactory(
+            given_name="Pierre", family_name="Etienne", preferred_username="PE"
         )
 
         cls.mandat_aidant_phillomene = MandatFactory(
@@ -108,6 +114,23 @@ class ViewAutorisationsTests(TestCase):
             expiration_date=timezone.now() + timedelta(days=366),
         )
 
+        cls.mandat_aidant_pierre_revoked_over_a_year = RevokedOverYearMandatFactory(
+            organisation=cls.aidant.organisation,
+            usager=cls.usager_pierre,
+            expiration_date=timezone.now() + timedelta(days=5),
+            post__create_authorisations=["argent", "famille", "logement"],
+        )
+
+        cls.mandat_aidant_pierre_expired_over_a_year = ExpiredOverYearMandatFactory(
+            organisation=cls.aidant.organisation,
+            usager=cls.usager_pierre,
+        )
+
+        AutorisationFactory(
+            mandat=cls.mandat_aidant_pierre_expired_over_a_year,
+            demarche="famille",
+        )
+
     def test__get_mandats_for_usagers_index(self):
         mandats = _get_mandats_for_usagers_index(self.aidant)
         self.assertEqual(
@@ -119,6 +142,8 @@ class ViewAutorisationsTests(TestCase):
                 self.mandat_aidant_josephine_1,
                 self.mandat_aidant_josephine_6,
                 self.mandat_aidant_alice_no_autorisation,
+                self.mandat_aidant_pierre_expired_over_a_year,
+                self.mandat_aidant_pierre_revoked_over_a_year,
                 self.mandat_aidant_phillomene,
             ],
         )

--- a/aidants_connect_web/views/usagers.py
+++ b/aidants_connect_web/views/usagers.py
@@ -75,6 +75,20 @@ def _get_usagers_dict_from_mandats(mandats: Mandat) -> dict:
     usagers_without_mandats = set()
     delta = settings.MANDAT_EXPIRED_SOON
     for mandat in mandats:
+        expired_over_a_year = mandat.expiration_date < now() - timedelta(365)
+
+        if expired_over_a_year:
+            continue
+
+        revoked_over_a_year = (
+            mandat.was_explicitly_revoked
+            and mandat.revocation_date is not None
+            and mandat.revocation_date < now() - timedelta(365)
+        )
+
+        if revoked_over_a_year:
+            continue
+
         expired = mandat.expiration_date if mandat.expiration_date < now() else False
         if expired:
             usagers_without_mandats.add(mandat.usager)


### PR DESCRIPTION
## 🌮 Objectif

Suppression des mandats révoqués et expirés sur l'espace aidant au bout d'un an.

## 🔍 Implémentation

Actualisation de la fonction inactive dans models pour ne pas retourner les mandats expirés ou révoqués depuis un an. Également pour la fonction _get_usagers_dict_from_mandats dans usagers.py
Création de RevokedOverYearMandatFactory et ExpiredOverYearMandatFactory pour les tests.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
