### PR TITLE
Vue "lecture seule" d'une demande d'habilitation

### DIFF
--- a/aidants_connect_habilitation/templates/edito/_aide_etats_demandes_habilitation.html
+++ b/aidants_connect_habilitation/templates/edito/_aide_etats_demandes_habilitation.html
@@ -1,0 +1,14 @@
+{% if status == "NEW" %}{# Brouillon #}
+  Votre demande n'a pas encore été envoyée à Aidants Connect. Si elle est prête, vous pouvez la valider.
+  {% elif status == "AC_VALIDATION_PROCESSING" %}{# En attente de validation par AC #}
+  L’équipe Aidants Connect a bien reçu votre demande d’habilitation, et procède à son analyse.
+  {% elif status == "VALIDATED" %}{# Acceptée #}
+  Votre demande d'habilitation a été acceptée par Aidants Connect, félicitations !
+  L'espace "responsable structure" sera bientôt créé et les aidants seront bientôt contactés pour leur formation.
+  {% elif status == "REFUSED" %}{# Refusée #}
+  {% elif status == "CLOSED" %}{# Clôturée #}
+  {% elif status == "CHANGES_REQUIRED" %}{# Changements demandés par AC #}
+  {% elif status == "CHANGES_PROPOSED" %}{# Changements proposés par AC #}
+  L'équipe Aidants Connect a apporté des corrections à votre demande.
+  Si elles vous conviennent, votre demande pourra être acceptée.
+{% endif %}

--- a/aidants_connect_habilitation/templates/issuer_space.html
+++ b/aidants_connect_habilitation/templates/issuer_space.html
@@ -75,7 +75,10 @@
                   <a href="{% url "habilitation_validation" issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}"
                      class="button primary">Soumettre la demande</a>
                 {% else %}
-                  <a class="button primary" href="#TODO">Voir</a>
+                  <a class="button primary"
+                     href="{% url "habilitation_organisation_view" issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
+                    Voir
+                  </a>
                 {% endif %}
               </div>
             </div>

--- a/aidants_connect_habilitation/templates/view_organisation_request.html
+++ b/aidants_connect_habilitation/templates/view_organisation_request.html
@@ -2,18 +2,22 @@
 {% load static form_extras %}
 
 {% block title %}
-  Aidants Connect — Récapitulatif pour {{ organisation.name }}
+  Aidants Connect — Demande d'habilitation pour {{ organisation.name }}
 {% endblock %}
 
 {% block content %}
   <div class="fr-container">
-    {% include 'edito/_titre_formulaire_habilitation.html' %}
-    {% include 'layouts/_breadcrumbs.html' %}
-    <h2>Récapitulatif de la demande</h2>
+    <h1>Demande d’habilitation n° {{ organisation.id }}</h1>
     <p class="subtitle">
-      Vous retrouverez ici les informations principales saisies dans le formulaire.
-      Il est possible de les modifier si besoin.
+
     </p>
+    <h2>Votre demande</h2>
+    <p>
+      Votre demande est actuellement dans l'état <strong>«&nbsp;{{ organisation.status_label }}&nbsp;»</strong>.
+      <br>
+      {% include "edito/_aide_etats_demandes_habilitation.html" with status=organisation.status %}
+    </p>
+    <h2>Rappel de votre saisie</h2>
     <h3>Informations générales</h3>
     <div class="form-in-3-cols">
       <div class="fr-grid-row fr-grid-row--gutters">
@@ -29,10 +33,6 @@
                 {{ issuer.email }}<br>{{ issuer.phone }}
               </p>
             </div>
-            <div class="button-box">
-              <a class="button primary"
-                 href="{% url 'habilitation_modify_issuer' issuer_id=issuer.issuer_id %}">Éditer</a>
-            </div>
           </div>
         </div>
         <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
@@ -46,12 +46,6 @@
                 {{ organisation.city }}
               </p>
               <p>SIRET : {{ organisation.siret }}</p>
-            </div>
-            <div class="button-box">
-              <a class="button primary"
-                 href="{% url 'habilitation_modify_organisation' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
-                Éditer
-              </a>
             </div>
           </div>
         </div>
@@ -71,12 +65,6 @@
             <li>Nombre de démarches traitées par semaine : {{ organisation.avg_nb_demarches }}</li>
             <li>Label France Services : {{ organisation.france_services_label|yesno:"Oui,Non" }}</li>
           </ul>
-          <div class="button-box">
-            <a class="button primary"
-               href="{% url 'habilitation_modify_organisation' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
-              Éditer
-            </a>
-          </div>
         </div>
       </div>
     </div>
@@ -103,10 +91,6 @@
               </p>
               <p>Ce responsable est aussi aidant : {{ organisation.manager.is_aidant|yesno:"Oui,Non" }}</p>
             </div>
-            <div class="button-box">
-              <a class="button primary"
-                 href="{% url 'habilitation_new_aidants' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">Éditer</a>
-            </div>
           </div>
         </div>
         {% if organisation.data_privacy_officer %}
@@ -121,12 +105,6 @@
                 <p>
                   {{ organisation.data_privacy_officer.email }}<br>{{ organisation.data_privacy_officer.phone }}
                 </p>
-              </div>
-              <div class="button-box">
-                <a class="button primary"
-                   href="{% url 'habilitation_new_aidants' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
-                  Éditer
-                </a>
               </div>
             </div>
           </div>
@@ -149,41 +127,18 @@
                 </p>
                 <p>{{ aidant_request.email }}</p>
               </div>
-              <div class="button-box">
-                <a class="button primary"
-                   href="{% url 'habilitation_new_aidants' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
-                  Éditer
-                </a>
-              </div>
             </div>
           </div>
         {% endfor %}
         </div>
     </div>
-    {# personnes impliquées #}
-    <h3>Validation de la demande</h3>
+
     <div class="fr-grid-row fr-grid-row--gutters">
-      <div class="fr-col-12 fr-col-md-8">
-        <div class="shadowed">
-          <h4 class="h2">Modalités d'utilisation</h4>
-          <form method="post">
-            {% csrf_token %}
-            {{ form.non_field_errors }}
-            {% checkbox_fr_grid_row form.cgu %}
-            {% checkbox_fr_grid_row form.dpo %}
-            {% checkbox_fr_grid_row form.professionals_only %}
-            {% checkbox_fr_grid_row form.without_elected %}
-            <div class="button-box">
-              <a class="button"
-                 href="{% url 'habilitation_new_aidants' issuer_id=issuer.issuer_id draft_id=organisation.draft_id %}">
-                Revenir à l’étape précédente
-              </a>
-              <button class="primary" type="submit">Soumettre la demande</button>
-            </div>
-          </form>
-        </div>
-      </div>
+      <p class="fr-col more-info">
+        Pour modifier cette demande, envoyez un e-mail à l'équipe Aidants Connect : contact@aidantsconnect.beta.gouv.fr
+        en précisant le n° de votre demande d'habilitation : {{ organisation.id }}
+      </p>
     </div>
-    {% include "_more-info.html" %}
+
   </div>{# fr-container #}
 {% endblock %}

--- a/aidants_connect_habilitation/urls.py
+++ b/aidants_connect_habilitation/urls.py
@@ -10,6 +10,7 @@ from aidants_connect_habilitation.views import (
     NewIssuerFormView,
     NewOrganisationRequestFormView,
     PersonnelRequestFormView,
+    ReadonlyRequestView,
     ValidationRequestFormView,
 )
 
@@ -42,7 +43,7 @@ urlpatterns = [
         name="habilitation_new_organisation",
     ),
     path(
-        "demandeur/<str:issuer_id>/organisation/<str:draft_id>/",
+        "demandeur/<str:issuer_id>/organisation/<str:draft_id>/infos-generales/",
         ModifyOrganisationRequestFormView.as_view(),
         name="habilitation_modify_organisation",
     ),
@@ -55,5 +56,10 @@ urlpatterns = [
         "demandeur/<str:issuer_id>/organisation/<str:draft_id>/validation/",
         ValidationRequestFormView.as_view(),
         name="habilitation_validation",
+    ),
+    path(
+        "demandeur/<str:issuer_id>/organisation/<str:draft_id>/voir/",
+        ReadonlyRequestView.as_view(),
+        name="habilitation_organisation_view",
     ),
 ]

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -297,3 +297,14 @@ class ValidationRequestFormView(LateStageRequestView, HabilitationStepMixin, For
 
     def get_success_url(self):
         return reverse("habilitation_new_issuer")
+
+
+class ReadonlyRequestView(LateStageRequestView, TemplateView):
+    template_name = "view_organisation_request.html"
+
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "organisation": self.organisation,
+            "aidants": self.organisation.aidant_requests,
+        }


### PR DESCRIPTION
## 🌮 Objectif

Permettre à un demandeur de revoir l'intégralité de sa demande sur une seule page, sans pour autant pouvoir modifier celle-ci au cas où il l'aurait déjà envoyée à AC.

On ajoutera sûrement des moyens d'effectuer certains correctifs ciblés (ajouter des aidants, échanger par message…) mais ce ne sera pas de l'open bar. Dans un premier temps ça passera par des mails et des interventions dans l'admin.

## 🔍 Implémentation

- Ajout d'une vue
- Redirection des vues "formulaire" vers cette vue pour les demandes d'habilitation qui ne sont plus des "brouillons"
- Tests de la nouvelle vue et de la redirection.

## 🏕 Amélioration continue

- J'ai introduit une méthode `get_url` dans les classes de test que j'ai modifiées, parce que ça m'énerve de lire 5 lignes de code pour juste comprendre qu'on voulait récupérer l'URL qu'on est en train de tester.

## ⚠️ Informations supplémentaires

À prévoir avant mise en prod : décider d'une règle de calcul et d'affichage pour les numéros des demandes (celui que l'on copiera dans le data_pass_id de l'organisation aidants_connect_web quand la demande sera validée et qui servira de référence pour les bizdev et demandeurs). Je crois que les bizdev avaient convenu de numéroter les demandes "hors datapass" à partir de 10000, à voir…

## 🖼️ Images

![Screenshot 2022-03-08 at 11-27-02 Aidants Connect](https://user-images.githubusercontent.com/1035145/157218550-911572d3-4d0c-4640-9d2f-9ec9b9d94d0b.png)

