### PR TITLE
Résout un bug de comptage des organisations

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -62,20 +62,20 @@ class OrganisationType(models.Model):
 
 class OrganisationManager(models.Manager):
     def accredited(self):
-        return (
-            self.filter(aidants__is_active=True)
-            .filter(aidants__can_create_mandats=True)
-            .filter(aidants__carte_totp__isnull=False)
-            .filter(is_active=True)
-        )
+        return self.filter(
+            aidants__is_active=True,
+            aidants__can_create_mandats=True,
+            aidants__carte_totp__isnull=False,
+            is_active=True,
+        ).distinct()
 
     def not_yet_accredited(self):
-        return (
-            self.filter(aidants__is_active=True)
-            .filter(aidants__can_create_mandats=True)
-            .filter(aidants__carte_totp__isnull=True)
-            .filter(is_active=True)
-        )
+        return self.filter(
+            aidants__is_active=True,
+            aidants__can_create_mandats=True,
+            aidants__carte_totp__isnull=True,
+            is_active=True,
+        ).distinct()
 
 
 class Organisation(models.Model):

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -26,6 +26,7 @@ from aidants_connect_web.tests.factories import (
     AidantFactory,
     AttestationJournalFactory,
     AutorisationFactory,
+    CarteTOTPFactory,
     HabilitationRequestFactory,
     MandatFactory,
     OrganisationFactory,
@@ -657,6 +658,24 @@ class OrganisationModelTests(TestCase):
         self.assertEqual(organisation.name, "Girard S.A.R.L")
         self.assertEqual(organisation.type, o_type)
         self.assertEqual(organisation.address, "3 rue du chat, 27120 Houlbec-Cocherel")
+
+    def test_count_accredited_organisations_for_statistics(self):
+        self.assertEqual(Organisation.objects.accredited().count(), 0)
+        self.assertEqual(Organisation.objects.not_yet_accredited().count(), 0)
+
+        for _ in range(5):  # generate accredited organisations (with valid aidants)
+            orga = OrganisationFactory()
+            for _ in range(3):
+                aidant = AidantFactory(organisation=orga)
+                CarteTOTPFactory(aidant=aidant)
+
+        for _ in range(7):  # generate non-accredited organisations
+            orga = OrganisationFactory()
+            for _ in range(3):
+                AidantFactory(organisation=orga)
+
+        self.assertEqual(Organisation.objects.accredited().count(), 5)
+        self.assertEqual(Organisation.objects.not_yet_accredited().count(), 7)
 
     def test_display_address(self):
         organisation_no_address = Organisation(name="L'Internationale")


### PR DESCRIPTION
## 🌮 Objectif

Résoudre ce bug de comptage sur la page statistiques, remonté par @matteo-goracci : 

![bug-comptage-structure](https://user-images.githubusercontent.com/1035145/157244276-51f39171-890c-4928-b7f6-5eec60237f44.png)


## 🔍 Implémentation

- Ajout d'un test
- Résolution du bug en changeant le mode de filtrage

## 🖼️ Images

La requête SQL avant : on voit les multiples join et outer join qui peuvent mener à des doublons.

<img width="721" alt="Capture d’écran 2022-03-08 à 14 03 12" src="https://user-images.githubusercontent.com/1035145/157244767-7800bcc9-863d-45f6-8dad-11940513e48d.png">

La requête après : elle a une drôle de tête aussi (je n'aurais pas écrit ça pareil) mais elle a moins de jointures et elle donne le bon nombre de lignes. Surtout grâce au distinct au début. 

<img width="692" alt="Capture d’écran 2022-03-08 à 14 03 50" src="https://user-images.githubusercontent.com/1035145/157244921-953451ef-9c7c-4b77-9867-b65ea1247a89.png">
