### PR TITLE
Mise à jour des images docker utilisées pour CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,9 @@
 #
 # Check https://circleci.com/docs/2.0/language-python/ for more details
 #
-version: 2
+version: "2.1"
+orbs:
+  browser-tools: circleci/browser-tools@1.2.4
 jobs:
   build:
     docker:
@@ -17,6 +19,8 @@ jobs:
 
     steps:
       - checkout
+      - browser-tools/install-firefox
+      - browser-tools/install-geckodriver
 
       # Download and cache dependencies
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,12 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:3.7.12-browsers
+      - image: cimg/python:3.7.12-browsers
 
-      - image: circleci/postgres:9.6.7
+      - image: cimg/postgres:9.6
         environment:
-            POSTGRES_USER: aidants_connect_team
-            POSTGRES_DB: aidants_connect
+          POSTGRES_USER: aidants_connect_team
+          POSTGRES_DB: aidants_connect
 
     working_directory: ~/repo
 


### PR DESCRIPTION
## 🌮 Objectif

CircleCI a déprécié les images docker que l'on utilise, d'après [ce post](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) et des avertissements sur la page des tests.

## 🔍 Implémentation

- Remplacement du namespace `circleci` par `cimg`
