### PR TITLE
Affichage des infos utiles dans l'admin habilitation

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
 
+from django_reverse_admin import ReverseModelAdmin
+
 from aidants_connect.admin import (
     DepartmentFilter,
     RegionFilter,
@@ -15,19 +17,30 @@ from aidants_connect_habilitation.models import (
 )
 
 
+class OrganisationRequestInline(VisibleToAdminMetier, TabularInline):
+    model = OrganisationRequest
+    show_change_link = True
+    fields = ("id", "status", "name", "type", "address", "zipcode", "city")
+    readonly_fields = fields
+    extra = 0
+    can_delete = False
+
+
 class IssuerAdmin(VisibleToAdminMetier, ModelAdmin):
     list_display = (
         "email",
         "last_name",
         "first_name",
         "phone",
-        "id",
     )
+    readonly_fields = ("issuer_id",)
+    inlines = (OrganisationRequestInline,)
 
 
 class AidantRequestInline(VisibleToAdminMetier, TabularInline):
     model = AidantRequest
     show_change_link = True
+    extra = 0
 
 
 class MessageInline(VisibleToAdminMetier, StackedInline):
@@ -35,14 +48,19 @@ class MessageInline(VisibleToAdminMetier, StackedInline):
     extra = 1
 
 
-class OrganisationRequestAdmin(VisibleToAdminMetier, ModelAdmin):
+class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
     list_filter = ("status", RegionFilter, DepartmentFilter)
     list_display = ("name", "issuer", "status")
     raw_id_fields = ("issuer",)
-    readonly_fields = ("public_service_delegation_attestation",)
+    readonly_fields = ("public_service_delegation_attestation", "draft_id")
     inlines = (
         AidantRequestInline,
         MessageInline,
+    )
+    inline_type = "stacked"
+    inline_reverse = (
+        "manager",
+        "data_privacy_officer",
     )
 
 

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -141,7 +141,9 @@ class IssuerEmailConfirmation(models.Model):
 
 
 class DataPrivacyOfficer(PersonWithResponsibilities):
-    pass
+    class Meta:
+        verbose_name = "DPO"
+        verbose_name_plural = "DPOs"
 
 
 class Manager(PersonWithResponsibilities):
@@ -150,6 +152,10 @@ class Manager(PersonWithResponsibilities):
     city = models.CharField("Ville", max_length=255)
 
     is_aidant = models.BooleanField("C'est aussi un aidant", default=False)
+
+    class Meta:
+        verbose_name = "Responsable structure"
+        verbose_name_plural = "Responsables structure"
 
 
 class OrganisationRequest(models.Model):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-referrer-policy==1.0
 django-tabbed-admin==1.0.4
 django-import-export==2.7.1
 django-debug-toolbar==3.2.4
+django-reverse-admin==2.9.6
 
 phonenumberslite==8.12.43
 django-phonenumber-field==6.0.0


### PR DESCRIPTION
## 🌮 Objectif

Améliorer l'interface d'administration : 
- Afficher au moins les infos "respo structure" et "dpo" sur une demande. Ces infos étaient masquées dans l'état actuel des choses.
- Permettre de voir facilement quelles demandes ont été posées par un demandeur.

## 🔍 Implémentation

- Utilisation de formulaires Inline pour éviter d'avoir à rajouter des pages de liste pour les DPO et les Respo Structure, avec tous les risques que ça supposait sur l'intégrité des données.
- Utilisation du module [django-reverse-admin](https://pypi.org/project/django-reverse-admin/) pour pouvoir utiliser des formulaires Inline sur des champs OneToOneField. Ça donne une drôle de tête au code, mais ça rend exactement comme je veux dans l'admin, donc je ne me plains pas.


## 🖼️ Images

Dans l'accueil de l'admin, on ne liste toujours que les demandes et les demandeurs, rien d'autre : 

<img width="946" alt="Capture d’écran 2022-03-11 à 16 53 22" src="https://user-images.githubusercontent.com/1035145/157902914-79bb9dc9-1e6f-4fe1-a445-3db2a96d12d4.png">

Page d'un demandeur, qui liste ses demandes : 

![Screenshot 2022-03-11 at 16-53-04 Agnès Haasser Modification de Demandeur Site d’administration de Django](https://user-images.githubusercontent.com/1035145/157903052-2d0c6361-4950-4fd7-b0a4-bf5f19a23788.png)

Page d'une demande, qui contient plein d'infos : 

![Screenshot 2022-03-11 at 16-52-29 Modification de Demande d’habilitation Site d’administration de Django](https://user-images.githubusercontent.com/1035145/157903104-b19e0fda-6415-417b-a2a1-e68b07acb518.png)
