### PR TITLE
Mise en place du processus métier de ValidationForm

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -376,3 +376,11 @@ class ValidationForm(PatchedForm):
         super().__init__(**kwargs)
         cgu = self["cgu"]
         cgu.label = format_html(cgu.label, url=reverse("cgu"))
+
+    def save(
+        self, organisation: OrganisationRequest, commit=True
+    ) -> OrganisationRequest:
+        organisation.prepare_request_for_ac_validation(self.cleaned_data)
+        return organisation
+
+    save.alters_data = True

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -264,6 +264,14 @@ class OrganisationRequest(models.Model):
             kwargs={"issuer_id": self.issuer.issuer_id, "uuid": self.uuid},
         )
 
+    def prepare_request_for_ac_validation(self, form_data: dict):
+        self.cgu = form_data["cgu"]
+        self.dpo = form_data["dpo"]
+        self.professionals_only = form_data["professionals_only"]
+        self.without_elected = form_data["without_elected"]
+        self.status = RequestStatusConstants.AC_VALIDATION_PROCESSING.name
+        self.save()
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -2,15 +2,22 @@ from unittest.mock import Mock, patch
 
 from django.test import TestCase
 
-from aidants_connect.common.constants import RequestOriginConstants
+from aidants_connect.common.constants import (
+    RequestOriginConstants,
+    RequestStatusConstants,
+)
 from aidants_connect_habilitation.forms import (
     AidantRequestFormSet,
     ManagerForm,
     OrganisationRequestForm,
     PersonnelForm,
+    ValidationForm,
 )
 from aidants_connect_habilitation.models import OrganisationRequest
-from aidants_connect_habilitation.tests.factories import DraftOrganisationRequestFactory
+from aidants_connect_habilitation.tests.factories import (
+    DraftOrganisationRequestFactory,
+    ManagerFactory,
+)
 from aidants_connect_habilitation.tests.utils import get_form
 from aidants_connect_web.models import OrganisationType
 
@@ -180,3 +187,43 @@ class TestPersonnelForm(TestCase):
         self.assertEqual(organisation.manager.email, manager_data["email"])
         self.assertEqual(organisation.aidant_requests.count(), len(aidants_form.forms))
         self.assertNotEqual(organisation.aidant_requests.count(), 0)
+
+
+class TestValidationFormForm(TestCase):
+
+    names_attr = ["cgu", "dpo", "professionals_only", "without_elected"]
+
+    def test_form_valid_only_with_four_enabled_choices(self):
+        form = ValidationForm()
+        self.assertFalse(form.is_valid())
+
+        form = ValidationForm(data={"cgu": True})
+        self.assertFalse(form.is_valid())
+
+        form = ValidationForm(
+            data={name: True for name in TestValidationFormForm.names_attr}
+        )
+        self.assertTrue(form.is_valid())
+
+    def test_form_valid_works(self):
+        orga_request = DraftOrganisationRequestFactory(
+            cgu=False,
+            dpo=False,
+            professionals_only=False,
+            without_elected=False,
+            manager=ManagerFactory(),
+        )
+
+        form = ValidationForm(
+            data={name: True for name in TestValidationFormForm.names_attr}
+        )
+        form.is_valid()
+
+        orga = form.save(organisation=orga_request)
+        self.assertEqual(
+            orga.status, RequestStatusConstants.AC_VALIDATION_PROCESSING.name
+        )
+        [
+            self.assertTrue(getattr(orga, name))
+            for name in TestValidationFormForm.names_attr
+        ]

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -352,7 +352,17 @@ class ValidationRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, Form
         }
 
     def get_success_url(self):
-        return reverse("habilitation_new_issuer")
+        return reverse(
+            "habilitation_organisation_view",
+            kwargs={
+                "issuer_id": str(self.issuer.issuer_id),
+                "uuid": str(self.organisation.uuid),
+            },
+        )
+
+    def form_valid(self, form):
+        form.save(self.organisation)
+        return super().form_valid(form)
 
 
 class ReadonlyRequestView(LateStageRequestView, TemplateView):


### PR DESCRIPTION
## 🌮 Objectif

Pour l'instant il n'y a qu'un commit, la première étape, qui ajoute la logique métier sur le formulaire et la vue. Il manque la partie afficher ensuite un message au demandeur, qu'il faut que je rajoute dans un deuxième commit. 

j'arrive un peu comme un chien dans un jeu de quilles avec cette PR après beaucoup de PR déjà écrite, j'ai essayé de me fondre dans le style et la façon de faire du code déjà, si il y a des trucs qui dénotent, les commentaire sont là pour ça :)

## 🔍 Implémentation

un peu de métier dans le formulaire,  des tests, une petite méthode de plus dans la vue

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
