### PR TITLE
Eviter une IntegrityError sur un signal  post_migrate 

### DIFF
--- a/aidants_connect_web/signals.py
+++ b/aidants_connect_web/signals.py
@@ -59,5 +59,5 @@ def populate_db_for_tests(app_config: AppConfig, **_):
         OrganisationType = app_config.get_model("OrganisationType")
         for org_type in RequestOriginConstants:
             OrganisationType.objects.get_or_create(
-                id=org_type.value, name=org_type.label
+                id=org_type.value, defaults={"name": org_type.label}
             )


### PR DESCRIPTION
## 🌮 Objectif

Dans le cas où les données "name" dans la base ne sont pas exactement celles fournies par RequestOriginConstants .. on prend une IntegrityError à chaque lancement de migrate (c'est mon cas en local). 

Du coup petit refactor pour éviter ça.

## 🔍 Implémentation

le name du get_or_create des OrganisationType passent en paramètre defaults.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
