### PR TITLE
Ne plus vider le champ 'type_other' quand l'utilisateur choisi un type d'organisation connu dans le formulaire

### DIFF
--- a/aidants_connect_habilitation/static/js/organisation_form.js
+++ b/aidants_connect_habilitation/static/js/organisation_form.js
@@ -22,7 +22,6 @@
 
         "hideTypeOtherInputContainer": function hideTypeOtherInputContainer() {
             this.typeOtherInputContainerTarget.setAttribute("hidden", "hidden");
-            this.typeOtherInputContainerTarget.value = "";
         },
 
         "showTypeOtherInputContainer": function showTypeOtherInputContainer() {


### PR DESCRIPTION
## 🌮 Objectif

Je me suis rendu compte que le morceau de JS ne fonctionnait de toutes façons pas et que le champ `type_other` n'était pas vidé lorsque qu'un type connu était choisi dans la liste déroulante dans le formulaire d'organisation, comme je le souhaitais initialement.

En vérifiant le code, je me suis rendu compte que, de toutes façons, [je nettoyais déjà le champ dans le `Form`](https://github.com/betagouv/Aidants_Connect/blob/main/aidants_connect_habilitation/forms.py#L133-L134) et [qu'il y a un check dans le modèle](https://github.com/betagouv/Aidants_Connect/blob/main/aidants_connect_habilitation/models.py#L272-L284). Donc on est safe. Autant laisser le champ tranquille dans le front, ce qui évite d'embêter l'utilisatrice ou l'utilisateur en cas de misclick.