### PR TITLE
Résout un bug d'affichage du bouton "renouveler le mandat"

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
@@ -26,7 +26,7 @@
       </ul>
     </td>
   {% endif %}
-  {% if usager.has_all_mandats_revoked_or_expired_over_a_year %}
+  {% if has_no_autorisations %}
   <td></td>
   {% else %}
   <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usagers.html
@@ -63,8 +63,8 @@
             </tr>
             </thead>
             <tbody>
-            {% for usager in usagers_dict.without_valid_mandate %}
-              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False %}
+            {% for usager, has_no_autorisations in usagers_dict.without_valid_mandate.items %}
+              {% include "aidants_connect_web/usagers/usager_row.html" with usager=usager with_valid_mandate=False has_no_autorisations=has_no_autorisations %}
             {% endfor %}
             </tbody>
           </table>

--- a/aidants_connect_web/tests/test_views/test_usagers.py
+++ b/aidants_connect_web/tests/test_views/test_usagers.py
@@ -142,8 +142,6 @@ class ViewAutorisationsTests(TestCase):
                 self.mandat_aidant_josephine_1,
                 self.mandat_aidant_josephine_6,
                 self.mandat_aidant_alice_no_autorisation,
-                self.mandat_aidant_pierre_expired_over_a_year,
-                self.mandat_aidant_pierre_revoked_over_a_year,
                 self.mandat_aidant_phillomene,
             ],
         )
@@ -173,8 +171,9 @@ class ViewAutorisationsTests(TestCase):
             ],
         )
 
+        usagers_without_valid_mandate = set(usagers["without_valid_mandate"].keys())
         self.assertSetEqual(
-            usagers["without_valid_mandate"], {self.usager_alice, self.usager_philomene}
+            usagers_without_valid_mandate, {self.usager_alice, self.usager_philomene}
         )
 
 


### PR DESCRIPTION
## 🌮 Objectif

Corriger bug bouton renouveler le mandat qui est parfois visible quand tous les mandats révoqués. Exemple : si l'usager a un mandat actif avec une autre organisation, le bouton reste visible 
-> fonction has_all_mandats_revoked_or_expired_over_a_year ne filtre pas par organisation.

## 🔍 Implémentation

Changement de la fonction _get_usagers_dict_from_mandats pour savoir si l'usager n'a pas d'autorisation valide (mandats révoquées ou pas d'autorisations). Changement de la fonction _get_mandats_for_usagers_index pour filtrer les mandats expirés ou révoqués depuis plus d'un an (pour simplifier la fonction _get_usagers_dict_from_mandats).

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
