### PR TITLE
Corrige le nombre de mandats actifs affiché dans l'espace aidant/responsable

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -114,9 +114,15 @@ class Organisation(models.Model):
 
     @cached_property
     def num_active_mandats(self):
-        return Mandat.objects.filter(
-            expiration_date__gte=timezone.now(), organisation=self
-        ).count()
+        return (
+            Mandat.objects.filter(
+                expiration_date__gte=timezone.now(),
+                organisation=self,
+                autorisations__revocation_date__isnull=True,
+            )
+            .distinct()
+            .count()
+        )
 
     @cached_property
     def aidants_not_responsables(self):

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -31,6 +31,7 @@ from aidants_connect_web.tests.factories import (
     MandatFactory,
     OrganisationFactory,
     OrganisationTypeFactory,
+    RevokedMandatFactory,
     UsagerFactory,
 )
 from aidants_connect_web.utilities import (
@@ -785,6 +786,14 @@ class OrganisationModelTests(TestCase):
                     expiration_date=timezone.now() - timedelta(days=6),
                 )
 
+        def create_revoked_mandats(count, organisation):
+            for _ in range(count):
+                RevokedMandatFactory(
+                    organisation=organisation,
+                    expiration_date=timezone.now() + timedelta(days=5),
+                    post__create_authorisations=["argent", "famille", "logement"],
+                )
+
         org_without_mandats = OrganisationFactory(name="Licornes")
         self.assertEqual(0, org_without_mandats.num_mandats)
         self.assertEqual(0, org_without_mandats.num_active_mandats)
@@ -797,7 +806,8 @@ class OrganisationModelTests(TestCase):
         org_with_active_and_inactive_mandats = OrganisationFactory(name="Libellules")
         create_active_mandats(3, org_with_active_and_inactive_mandats)
         create_expired_mandats(4, org_with_active_and_inactive_mandats)
-        self.assertEqual(7, org_with_active_and_inactive_mandats.num_mandats)
+        create_revoked_mandats(2, org_with_active_and_inactive_mandats)
+        self.assertEqual(9, org_with_active_and_inactive_mandats.num_mandats)
         self.assertEqual(3, org_with_active_and_inactive_mandats.num_active_mandats)
 
     def test_count_usagers(self):


### PR DESCRIPTION
## 🌮 Objectif

Corriger bug nombre de mandats actifs dans l'espace responsable.

## 🔍 Implémentation

Ajout de filtre sur les mandats révoqués.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
