### PR TITLE
Éviter d'afficher "None" pour les organisations sans ville sauvegardée en base

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/statistics.html
@@ -7,16 +7,16 @@
       </h3>
       <p>
         {{ organisation.address }}<br>
-        {{ organisation.zipcode }} {{ organisation.city }}
+        {{ organisation.zipcode }} {{ organisation.city|default_if_none:"" }}
       </p>
     </div>
     {% if organisation.data_pass_id %}
-    <div class="tile background-color-grey">
-      <h3>Numéro d’habilitation</h3>
-      <p>
-        {{ organisation.data_pass_id }}
-      </p>
-    </div>
+      <div class="tile background-color-grey">
+        <h3>Numéro d’habilitation</h3>
+        <p>
+          {{ organisation.data_pass_id }}
+        </p>
+      </div>
     {% endif %}
     <div class="tile background-color-grey">
       <h3>Aidants actifs</h3>

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -136,6 +136,15 @@ class EspaceResponsableOrganisationPage(TestCase):
         self.assertContains(response, aidant_a.first_name)
         self.assertContains(response, aidant_b.first_name)
 
+    def test_display_organisation_properly(self):
+        self.client.force_login(self.responsable_tom)
+        organisation = OrganisationFactory(city=None)
+        self.responsable_tom.responsable_de.add(organisation)
+        response = self.client.get(
+            f"/espace-responsable/organisation/{organisation.id}/"
+        )
+        self.assertNotContains(response, "None")
+
     def test_display_data_pass_id(self):
         self.client.force_login(self.responsable_tom)
         self.responsable_tom.organisation.data_pass_id = 4242


### PR DESCRIPTION
## 🌮 Objectif

Éviter d'afficher un disgracieux "None" qui inquiète les utilisateurs aidants/responsables quand une organisation n'a pas de ville en base.

## 🔍 Implémentation

- utilisation de default_if_none dans le template pour n'afficher rien du tout
- test


## 🖼️ Images

Avec ville : 

![Capture d’écran 2022-03-24 à 16 30 01](https://user-images.githubusercontent.com/1035145/159952352-f4b12443-3da3-4eee-ba5f-c60409fca38b.png)


Sans ville : 

![Capture d’écran 2022-03-24 à 16 30 33](https://user-images.githubusercontent.com/1035145/159952296-2c1bce54-522c-4a5c-aa0d-778b68c3c057.png)

