### PR TITLE
Suppression du modèle DPO et ses références dans le code

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -58,10 +58,7 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
         MessageInline,
     )
     inline_type = "stacked"
-    inline_reverse = (
-        "manager",
-        "data_privacy_officer",
-    )
+    inline_reverse = ("manager",)
 
 
 if settings.AC_HABILITATION_FORM_ENABLED:

--- a/aidants_connect_habilitation/migrations/0015_remove_dpo_model.py
+++ b/aidants_connect_habilitation/migrations/0015_remove_dpo_model.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aidants_connect_habilitation', '0014_auto_20220324_1713'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='organisationrequest',
+            name='data_privacy_officer_set',
+        ),
+        migrations.RemoveField(
+            model_name='organisationrequest',
+            name='data_privacy_officer',
+        ),
+        migrations.DeleteModel(
+            name='DataPrivacyOfficer',
+        ),
+    ]

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -24,7 +24,6 @@ __all__ = [
     "PersonWithResponsibilities",
     "Issuer",
     "IssuerEmailConfirmation",
-    "DataPrivacyOfficer",
     "Manager",
     "OrganisationRequest",
     "AidantRequest",
@@ -149,12 +148,6 @@ class IssuerEmailConfirmation(models.Model):
         email_confirmation_sent.send(self.__class__, request=request, confirmation=self)
 
 
-class DataPrivacyOfficer(PersonWithResponsibilities):
-    class Meta:
-        verbose_name = "DPO"
-        verbose_name_plural = "DPOs"
-
-
 class Manager(PersonWithResponsibilities):
     address = models.TextField("Adresse")
     zipcode = models.CharField("Code Postal", max_length=10)
@@ -180,15 +173,6 @@ class OrganisationRequest(models.Model):
         on_delete=models.CASCADE,
         related_name="organisation",
         verbose_name="Responsable",
-        default=None,
-        null=True,
-    )
-
-    data_privacy_officer = models.OneToOneField(
-        DataPrivacyOfficer,
-        on_delete=models.CASCADE,
-        related_name="organisation",
-        verbose_name="Délégué à la protection des données",
         default=None,
         null=True,
     )
@@ -353,14 +337,6 @@ class OrganisationRequest(models.Model):
                     & Q(manager__isnull=False)
                 ),
                 name="manager_set",
-            ),
-            models.CheckConstraint(
-                check=Q(status=RequestStatusConstants.NEW.name)
-                | (
-                    ~Q(status=RequestStatusConstants.NEW.name)
-                    & Q(data_privacy_officer__isnull=False)
-                ),
-                name="data_privacy_officer_set",
             ),
         ]
         verbose_name = "Demande d’habilitation"

--- a/aidants_connect_habilitation/static/js/personnel_form.js
+++ b/aidants_connect_habilitation/static/js/personnel_form.js
@@ -33,19 +33,11 @@
             this.mutateAddAidantButtonVisibility();
         },
 
-        "onItsMeBtnClicked": function onItsMeBtnClicked(target) {
+        "onManagerItsMeBtnClicked": function onManagerItsMeBtnClicked() {
             const self = this;
             Object.keys(this.issuerDataValue).forEach(function (key) {
-                target.querySelector("[name$='" + key + "']").value = self.issuerDataValue[key];
+                self.managerSubformTarget.querySelector("[name$='" + key + "']").value = self.issuerDataValue[key];
             });
-        },
-
-        "onManagerItsMeBtnClicked": function onManagerItsMeBtnClicked() {
-            this.onItsMeBtnClicked(this.managerSubformTarget);
-        },
-
-        "onDpoItsMeBtnClicked": function onDpoItsMeBtnClicked() {
-            this.onItsMeBtnClicked(this.dpoSubformTarget);
         },
 
         "mutateAddAidantButtonVisibility": function mutateAddAidantButtonVisibility() {
@@ -65,7 +57,6 @@
         "aidantFormTemplate",
         "aidantFormset",
         "managerSubform",
-        "dpoSubform",
     ];
 
     PersonnelForm.values = {

--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -99,32 +99,6 @@
             </fieldset>
           </section>
         </div>
-        <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-          <section class="shadowed">
-            <h4 class="h2">Délégué à la protection des données <span class="text-red">— Facultatif</span></h4>
-            <fieldset
-              id="dpo-subform"
-              data-personnel-form-target="dpoSubform"
-            >
-              <legend class="sr-only">Délégué à la protection des données - facultatif</legend>
-              <button
-                id="its-me-dpo"
-                class="primary"
-                type="button"
-                data-action="personnel-form#onDpoItsMeBtnClicked"
-              >
-                <span aria-hidden="true">👋 </span>C’est moi ! Remplir avec mes infos
-              </button>
-              <h5 class="h3">Identité</h5>
-              {% field_as_narrow_fr_grid_row form.data_privacy_officer_form.last_name %}
-              {% field_as_narrow_fr_grid_row form.data_privacy_officer_form.first_name %}
-              {% field_as_narrow_fr_grid_row form.data_privacy_officer_form.profession %}
-              <h5 class="h3">Contact</h5>
-              {% field_as_narrow_fr_grid_row form.data_privacy_officer_form.phone %}
-              {% field_as_narrow_fr_grid_row form.data_privacy_officer_form.email %}
-            </fieldset>
-          </section>
-        </div>
       </div>
 
 

--- a/aidants_connect_habilitation/templates/validation_form.html
+++ b/aidants_connect_habilitation/templates/validation_form.html
@@ -83,7 +83,7 @@
     {# Infos générales #}
     <h3>Personnes impliquées</h3>
     <div class="form-in-3-cols">
-      {# first row: responsable + dpo #}
+      {# first row: responsable #}
       <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
           <div class="shadowed with-button-box">
@@ -109,28 +109,6 @@
             </div>
           </div>
         </div>
-        {% if organisation.data_privacy_officer %}
-          <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-            <div class="shadowed with-button-box">
-              <h4 class="h2">Délégué à la protection des données</h4>
-              <div>
-                <p>
-                  <strong>{{ organisation.data_privacy_officer.get_full_name }}</strong><br>
-                  {{ organisation.data_privacy_officer.profession }}
-                </p>
-                <p>
-                  {{ organisation.data_privacy_officer.email }}<br>{{ organisation.data_privacy_officer.phone }}
-                </p>
-              </div>
-              <div class="button-box">
-                <a class="button primary"
-                   href="{% url 'habilitation_new_aidants' issuer_id=issuer.issuer_id uuid=organisation.uuid %}">
-                  Éditer
-                </a>
-              </div>
-            </div>
-          </div>
-        {% endif %}
       </div>
       {# 2nd row and more: aidants #}
       <div class="fr-grid-row fr-grid-row--gutters">

--- a/aidants_connect_habilitation/templates/view_organisation_request.html
+++ b/aidants_connect_habilitation/templates/view_organisation_request.html
@@ -71,7 +71,7 @@
     {# Infos générales #}
     <h3>Personnes impliquées</h3>
     <div class="form-in-3-cols">
-      {# first row: responsable + dpo #}
+      {# first row: responsable #}
       <div class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
           <div class="shadowed with-button-box">
@@ -93,22 +93,6 @@
             </div>
           </div>
         </div>
-        {% if organisation.data_privacy_officer %}
-          <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-            <div class="shadowed with-button-box">
-              <h4 class="h2">Délégué à la protection des données</h4>
-              <div>
-                <p>
-                  <strong>{{ organisation.data_privacy_officer.get_full_name }}</strong><br>
-                  {{ organisation.data_privacy_officer.profession }}
-                </p>
-                <p>
-                  {{ organisation.data_privacy_officer.email }}<br>{{ organisation.data_privacy_officer.phone }}
-                </p>
-              </div>
-            </div>
-          </div>
-        {% endif %}
       </div>
       {# 2nd row and more: aidants #}
       <div class="fr-grid-row fr-grid-row--gutters">

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -17,7 +17,6 @@ from aidants_connect.common.constants import (
 )
 from aidants_connect_habilitation.models import (
     AidantRequest,
-    DataPrivacyOfficer,
     Issuer,
     Manager,
     OrganisationRequest,
@@ -53,17 +52,6 @@ class IssuerFactory(DjangoModelFactory):
         model = Issuer
 
 
-class DataPrivacyOfficerFactory(DjangoModelFactory):
-    first_name = FactoryFaker("first_name")
-    last_name = FactoryFaker("last_name")
-    email = FactoryFaker("email")
-    profession = FactoryFaker("job")
-    phone = LazyFunction(_generate_valid_phone)
-
-    class Meta:
-        model = DataPrivacyOfficer
-
-
 class ManagerFactory(DjangoModelFactory):
     first_name = FactoryFaker("first_name")
     last_name = FactoryFaker("last_name")
@@ -84,7 +72,6 @@ class ManagerFactory(DjangoModelFactory):
 class OrganisationRequestFactory(DjangoModelFactory):
     issuer = SubFactory(IssuerFactory)
     manager = SubFactory(ManagerFactory)
-    data_privacy_officer = SubFactory(DataPrivacyOfficerFactory)
 
     uuid = LazyFunction(uuid4)
 
@@ -130,7 +117,6 @@ class OrganisationRequestFactory(DjangoModelFactory):
 
 class DraftOrganisationRequestFactory(OrganisationRequestFactory):
     manager = None
-    data_privacy_officer = None
 
     status = RequestStatusConstants.NEW.name
 

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -54,11 +54,6 @@ class OrganisationRequestTests(TestCase):
             OrganisationRequestFactory(manager=None)
         self.assertIn("manager_set", str(cm.exception))
 
-    def test_data_privacy_officer_set_constraint(self):
-        with self.assertRaises(IntegrityError) as cm:
-            OrganisationRequestFactory(data_privacy_officer=None)
-        self.assertIn("data_privacy_officer_set", str(cm.exception))
-
 
 class TestIssuerEmailConfirmation(TestCase):
     NOW = now()

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -20,7 +20,6 @@ from aidants_connect.common.constants import (
 )
 from aidants_connect_habilitation.forms import (
     AidantRequestFormSet,
-    DataPrivacyOfficerForm,
     IssuerForm,
     ManagerForm,
     OrganisationRequestForm,
@@ -693,14 +692,12 @@ class AidantsRequestFormViewTests(TestCase):
         organisation: OrganisationRequest = DraftOrganisationRequestFactory()
 
         manager_data = utils.get_form(ManagerForm).data
-        dpo_data = utils.get_form(DataPrivacyOfficerForm).data
         aidants_data = utils.get_form(AidantRequestFormSet).data
 
         # Logic to manually put prefix on form data
         # See https://docs.djangoproject.com/fr/4.0/ref/forms/api/#django.forms.Form.prefix # noqa:E501
         cleaned_data = {
             **{f"manager-{k}": v for k, v in manager_data.items()},
-            **{f"dpo-{k}": v for k, v in dpo_data.items()},
             **{k.replace("form-", "aidants-"): v for k, v in aidants_data.items()},
         }
 

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -312,7 +312,6 @@ class PersonnelRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, FormV
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
 
-        data_privacy_officer = self.organisation.data_privacy_officer
         manager = self.organisation.manager
         aidant_qs = self.organisation.aidant_requests
 
@@ -320,11 +319,6 @@ class PersonnelRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, FormV
             form_kwargs[
                 f"{PersonnelForm.AIDANTS_FORMSET_PREFIX}_queryset"
             ] = aidant_qs.all()
-
-        if data_privacy_officer:
-            form_kwargs[
-                f"{PersonnelForm.DPO_FORM_PREFIX}_instance"
-            ] = data_privacy_officer
 
         if manager:
             form_kwargs[f"{PersonnelForm.MANAGER_FORM_PREFIX}_instance"] = manager


### PR DESCRIPTION
## 🌮 Objectif

Après discussion avec les bizdev, on s'est rendus compte que le formulaire DPO aurait dû être prévu dès le départ pour être facultatif. Ça n'a pas été le cas et le code a été totalement été totalement écrit avec un DPO obligatoire en tête. Le rendre facultatif à ce stade du développement entraîne beaucoup de problème, d'autant que ces information ne sont pour le moment pas utilisées ni même stockées après l'habilitation. À ce stade, il est plus simple de tout simplement supprimer le formulaire pour le moment.

Si cet état venait à changer à l'avenir, il suffirait de revert cette modification.

## 🖼️ Images

![image](https://user-images.githubusercontent.com/22097904/161091913-6ea9a362-15be-401d-97e0-c7f2f9b83cbf.png)