### PR TITLE
Supprime le lien vers l'incubateur des territoires

### DIFF
--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -14,6 +14,7 @@
       <li>
         <h2>aidantsconnect.beta.gouv.fr</h2>
       </li>
+      <li><a href="https://incubateur.anct.gouv.fr/">Une startup d’État de l'Incubateur des Territoires</a></li>
       <li><a href="https://agence-cohesion-territoires.gouv.fr/">Agence Nationale de la Cohésion des Territoires</a></li>
     </ul>
     <nav role="navigation" aria-label="Menu pied de page">

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -14,7 +14,6 @@
       <li>
         <h2>aidantsconnect.beta.gouv.fr</h2>
       </li>
-      <li><a href="https://incubateur.anct.gouv.fr/actions/startups-territoires/">Une startup d’État de l'Incubateur des Territoires</a></li>
       <li><a href="https://agence-cohesion-territoires.gouv.fr/">Agence Nationale de la Cohésion des Territoires</a></li>
     </ul>
     <nav role="navigation" aria-label="Menu pied de page">


### PR DESCRIPTION
Supprimer la mention : " Une Startup d'Etat de l'Incubateur des Territoires", car le lien est mort  (la page a visiblement été supprimée côté Incubateur) 