### PR TITLE
Habilitation en masse par e-mail : évolutions

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -803,6 +803,7 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
             status__in=(
                 HabilitationRequest.STATUS_PROCESSING,
                 HabilitationRequest.STATUS_NEW,
+                HabilitationRequest.STATUS_VALIDATED,
             )
         )
         treated_emails = set()

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -835,7 +835,7 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
                 "email", flat=True
             )
         )
-        non_existing_emails = ignored_emails - existing_emails
+        non_existing_emails = set(ignored_emails - existing_emails)
         already_refused_emails = set(
             HabilitationRequest.objects.filter(
                 email__in=existing_emails,
@@ -843,7 +843,7 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
                     HabilitationRequest.STATUS_REFUSED,
                     HabilitationRequest.STATUS_CANCELLED,
                 ),
-            )
+            ).values_list("email", flat=True)
         )
         undefined_error_emails = existing_emails - already_refused_emails
         return {

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -538,8 +538,10 @@ class HabilitationRequest(models.Model):
             return False
 
         if Aidant.objects.filter(username=self.email).count() > 0:
-            aidant = Aidant.objects.get(username=self.email)
+            aidant: Aidant = Aidant.objects.get(username=self.email)
             aidant.organisations.add(self.organisation)
+            aidant.is_active = True
+            aidant.save()
             self.status = self.STATUS_VALIDATED
             self.save()
             return True

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -533,6 +533,7 @@ class HabilitationRequest(models.Model):
     def __str__(self):
         return f"{self.email}"
 
+    @transaction.atomic
     def validate_and_create_aidant(self):
         if self.status not in (
             self.STATUS_PROCESSING,
@@ -550,7 +551,7 @@ class HabilitationRequest(models.Model):
             self.save()
             return True
 
-        aidant = Aidant(
+        aidant = Aidant.objects.create(
             last_name=self.last_name,
             first_name=self.first_name,
             profession=self.profession,
@@ -559,7 +560,6 @@ class HabilitationRequest(models.Model):
             username=self.email,
         )
         self.status = self.STATUS_VALIDATED
-        aidant.save()
         self.save()
         return True
 

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -534,7 +534,11 @@ class HabilitationRequest(models.Model):
         return f"{self.email}"
 
     def validate_and_create_aidant(self):
-        if self.status not in (self.STATUS_PROCESSING, self.STATUS_NEW):
+        if self.status not in (
+            self.STATUS_PROCESSING,
+            self.STATUS_NEW,
+            self.STATUS_VALIDATED,
+        ):
             return False
 
         if Aidant.objects.filter(username=self.email).count() > 0:

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -65,12 +65,12 @@
   {% if undefined_error_emails %}
     <div class="errornote">
       {% blocktranslate count counter=undefined_error_emails|length %}
-        Une erreur s'est produite pour l'adresse mail suivante, mais je ne sais pas
-        laquelle et j'espère que vous ne verrez jamais ce message. :s
+        Une erreur indéterminée s'est produite pour l'adresse mail suivante,
         {% plural %}
-        Une erreur s'est produite pour les adresses mails suivantes, mais je ne sais pas
-        laquelle et j'espère que vous ne verrez jamais ce message. :s
+        Une erreur indéterminée s'est produite pour les adresses mails suivantes,
       {% endblocktranslate %}
+      parlez-en à quelqu'un(e) de l'équipe technique pour voir ce qui aurait pu la causer.<br>
+      Aucun compte aidant n'a été créé.
       <ul>
         {% for email in undefined_error_emails %}
           <li>{{ email }}</li>

--- a/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/admin/habilitation_request/mass-habilitation.html
@@ -23,14 +23,56 @@
   {% if ignored_emails %}
     <div class="errornote">
       {% blocktranslate count counter=ignored_emails|length %}
-        Nous n'avons pas pu traiter l'adress e-mail suivante : aucune demande
-        ne correspond, ou alors elle a déjà été annulée ou validée.
+        Une adresse e-mail a été ignorée. Veuillez retrouver le détail ci-dessous.
         {% plural %}
-        Nous n'avons pas pu traiter les {{ counter }} e-mails suivants : aucune demande ne correspond,
-        ou alors elles ont déjà été validées/annulées.
+        {{ counter }} adresses e-mails ont été ignorées. Veuillez retrouver le détail
+        ci-dessous.
+      {% endblocktranslate %}
+    </div>
+  {% endif %}
+  {% if non_existing_emails %}
+    <div class="errornote">
+      {% blocktranslate count counter=non_existing_emails|length %}
+        Nous n'avons trouvé aucun aidant à former portant l'e-mail suivant : aucun compte
+        aidant n'a été créé.
+        {% plural %}
+        Nous n'avons trouvé aucun aidant à former pour les {{ counter }} e-mails suivants :
+        aucun compte aidant n'a été créé.
       {% endblocktranslate %}
       <ul>
-        {% for email in ignored_emails %}
+        {% for email in non_existing_emails %}
+          <li>{{ email }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  {% if already_refused_emails %}
+    <div class="errornote">
+      {% blocktranslate count counter=already_refused_emails|length %}
+        Il existe bien un aidant à former portant l'adresse e-mail suivante, mais
+        la demande était déjà annulée ou refusée : aucun compte aidant n'a été créé.
+        {% plural %}
+        Il existe bien des aidants à former portant les adresses e-mail suivantes, mais
+        les demandes étaient déjà annulée ou refusée : aucun compte aidant n'a été créé.
+      {% endblocktranslate %}
+      <ul>
+        {% for email in already_refused_emails %}
+          <li>{{ email }}</li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% endif %}
+  {% if undefined_error_emails %}
+    <div class="errornote">
+      {% blocktranslate count counter=undefined_error_emails|length %}
+        Une erreur s'est produite pour l'adresse mail suivante, mais je ne sais pas
+        laquelle et j'espère que vous ne verrez jamais ce message. :s
+        {% plural %}
+        Une erreur s'est produite pour les adresses mails suivantes, mais je ne sais pas
+        laquelle et j'espère que vous ne verrez jamais ce message. :s
+      {% endblocktranslate %}
+      <ul>
+        {% for email in undefined_error_emails %}
           <li>{{ email }}</li>
         {% endfor %}
       </ul>
@@ -38,7 +80,7 @@
   {% endif %}
   {% if treated_emails %}
     <div class="successnote">
-      <p>Les demandes suivantes ont été validées, les comptes aidant ont été créés :</p>
+      <p>Les demandes suivantes ont été validées, les comptes aidant ont été créés et/ou activés :</p>
       <ul>
         {% for email in treated_emails %}
           <li><span aria-hidden="true">✅ </span>{{ email }}</li>

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1627,7 +1627,6 @@ class HabilitationRequestMethodTests(TestCase):
 
     def test_do_not_validate_if_invalid_status(self):
         for status in (
-            HabilitationRequest.STATUS_VALIDATED,
             HabilitationRequest.STATUS_REFUSED,
             HabilitationRequest.STATUS_CANCELLED,
         ):

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1591,7 +1591,7 @@ class HabilitationRequestMethodTests(TestCase):
                 db_hab_request.status, HabilitationRequest.STATUS_VALIDATED
             )
 
-    def test_validate_if_aidant_already_exists(self):
+    def test_validate_if_active_aidant_already_exists(self):
         aidant = AidantFactory()
         habilitation_request = HabilitationRequestFactory(
             status=HabilitationRequest.STATUS_PROCESSING, email=aidant.email
@@ -1605,6 +1605,24 @@ class HabilitationRequestMethodTests(TestCase):
             habilitation_request.status, HabilitationRequest.STATUS_VALIDATED
         )
         aidant.refresh_from_db()
+        self.assertIn(habilitation_request.organisation, aidant.organisations.all())
+
+    def test_validate_if_inactive_aidant_already_exists(self):
+        aidant = AidantFactory(is_active=False)
+        self.assertFalse(aidant.is_active)
+        habilitation_request = HabilitationRequestFactory(
+            status=HabilitationRequest.STATUS_PROCESSING, email=aidant.email
+        )
+        self.assertTrue(habilitation_request.validate_and_create_aidant())
+        self.assertEqual(
+            1, Aidant.objects.filter(email=habilitation_request.email).count()
+        )
+        habilitation_request.refresh_from_db()
+        self.assertEqual(
+            habilitation_request.status, HabilitationRequest.STATUS_VALIDATED
+        )
+        aidant.refresh_from_db()
+        self.assertTrue(aidant.is_active)
         self.assertIn(habilitation_request.organisation, aidant.organisations.all())
 
     def test_do_not_validate_if_invalid_status(self):

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -592,4 +592,5 @@ class HabilitationRequestAdminPageTests(TestCase):
                 "ont été créés"
             ),
         )
-        self.assertContains(response, "Nous n'avons pas pu traiter les")
+        self.assertContains(response, "2 adresses e-mails ont été ignorées.")
+        self.assertContains(response, "Nous n'avons trouvé aucun")


### PR DESCRIPTION
## 🌮 Objectif

Réparer quelques manques dans cette fonctionnalité pour la rendre plus utile aux bizdev.

## 🔍 Implémentation

- Les demandes déjà validées peuvent être "revalidées". Ça permettra, avec le point suivant, d'activer facilement des comptes aidants désactivés si besoin. 
- Valider une demande correspondant à un compte aidant existant, mais inactif, va activer le compte aidant en question.
- Rendre les messages d'erreur plus précis : jusque là ils n'avaient pas moyen de savoir si les e-mails étaient carrément faux ou si les demandes avaient juste été refusées.

## 🏕 Amélioration continue

- Ajouter une transaction autour de la méthode qui crée/modifie l'aidant et met à jour l'aidant à former.

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

<img width="1371" alt="Capture d’écran 2022-04-06 à 15 55 43" src="https://user-images.githubusercontent.com/1035145/161993576-ace631e1-6817-403f-bc0f-bebd64aa0b3d.png">

