### PR TITLE
MAJ de Django-Magicauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,4 @@ selenium==4.1.3
 sentry-sdk==1.5.8
 whitenoise==6.0.0
 
-django-magicauth @ git+https://github.com/betagouv/django-magicauth.git@0.10
+django-magicauth @ git+https://github.com/betagouv/django-magicauth.git@0.11


### PR DESCRIPTION
## 🌮 Objectif

Résoudre un bug de rendu introduit lors de la précédente MAJ de django-magicauth : 

<img width="641" alt="Capture d’écran 2022-04-08 à 09 14 36" src="https://user-images.githubusercontent.com/1035145/162383879-96c6fda2-50b0-4cbf-9aac-f6274a57a68e.png">


## 🔍 Implémentation

- MAJ de Django-Magicauth

