### PR TITLE
Supprimer les flaky tests et résoudre des bugs dans l'habilitation

### DIFF
--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -300,9 +300,12 @@ class OrganisationRequest(models.Model):
             return False
 
         try:
+            organisation_type, _ = OrganisationType.objects.get_or_create(
+                name=(self.type_other if self.type_other else self.type)
+            )
             organisation = Organisation.objects.create(
                 name=self.name,
-                type=(self.type_other if self.type_other else self.type),
+                type=organisation_type,
                 siret=self.siret,
                 address=self.address,
                 zipcode=self.zipcode,
@@ -326,6 +329,7 @@ class OrganisationRequest(models.Model):
                 first_name=self.manager.first_name,
                 last_name=self.manager.last_name,
                 email=self.manager.email,
+                username=self.manager.email,
                 phone=self.manager.phone,
                 profession=self.manager.profession,
                 organisation=organisation,

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -7,7 +7,7 @@ from factory import Faker as FactoryFaker
 from factory import LazyFunction, SubFactory
 from factory import lazy_attribute as factory_lazy_attribute
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyChoice, FuzzyInteger, FuzzyText
+from factory.fuzzy import FuzzyInteger, FuzzyText
 from faker import Faker
 from phonenumber_field.phonenumber import to_python
 
@@ -63,7 +63,7 @@ class ManagerFactory(DjangoModelFactory):
     zipcode = FactoryFaker("postcode")
     city = FactoryFaker("city")
 
-    is_aidant = FuzzyChoice([True, False])
+    is_aidant = True
 
     class Meta:
         model = Manager
@@ -75,15 +75,9 @@ class OrganisationRequestFactory(DjangoModelFactory):
 
     uuid = LazyFunction(uuid4)
 
-    status = FuzzyChoice(
-        [
-            value
-            for value in RequestStatusConstants.values()
-            if value != RequestStatusConstants.NEW.name
-        ]
-    )
+    status = RequestStatusConstants.AC_VALIDATION_PROCESSING.name
 
-    type_id = FuzzyChoice(RequestOriginConstants.values)
+    type_id = RequestOriginConstants.SECRETARIATS_MAIRIE.value
     name = FactoryFaker("company")
     siret = FuzzyInteger(111_111_111, 999_999_999)
     address = FactoryFaker("street_address")

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -74,6 +74,7 @@ class OrganisationRequestFactory(DjangoModelFactory):
     manager = SubFactory(ManagerFactory)
 
     uuid = LazyFunction(uuid4)
+    data_pass_id = FuzzyInteger(10000000, 99999999)
 
     status = RequestStatusConstants.AC_VALIDATION_PROCESSING.name
 

--- a/aidants_connect_habilitation/tests/factories.py
+++ b/aidants_connect_habilitation/tests/factories.py
@@ -114,6 +114,7 @@ class DraftOrganisationRequestFactory(OrganisationRequestFactory):
     manager = None
 
     status = RequestStatusConstants.NEW.name
+    data_pass_id = None
 
 
 class AidantRequestFactory(DjangoModelFactory):

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -60,40 +60,41 @@ class OrganisationRequestTests(TestCase):
             OrganisationRequestFactory(manager=None)
         self.assertIn("manager_set", str(cm.exception))
 
-    def prepare_data_for_nominal_case(self):
-        organisation_request = OrganisationRequestFactory(
-            status=RequestStatusConstants.AC_VALIDATION_PROCESSING.name,
-            data_pass_id=67255555,
-        )
-        organisation_request.manager.is_aidant = True
-        organisation_request.manager.save()
-        for _ in range(3):
-            AidantRequestFactory(organisation=organisation_request)
-        organisation_request.save()
-        return organisation_request
-
-    def prepare_data_with_existing_responsable(self):
-        organisation_request = OrganisationRequestFactory(
-            status=RequestStatusConstants.AC_VALIDATION_PROCESSING.name,
-            data_pass_id=69366666,
-        )
-        organisation_request.manager.is_aidant = True
-        organisation_request.manager.save()
-        # existing manager
-        AidantFactory(
-            email=organisation_request.manager.email,
-            username=organisation_request.manager.email,
-            can_create_mandats=False,
-        )
-        for _ in range(3):
-            AidantRequestFactory(organisation=organisation_request)
-        organisation_request.save()
-        return organisation_request
-
     def test_accept_when_it_should_work_fine(self):
+        def prepare_data_for_nominal_case():
+            organisation_request = OrganisationRequestFactory()
+            for _ in range(3):
+                AidantRequestFactory(organisation=organisation_request)
+            organisation_request.save()
+            return organisation_request
+
+        def prepare_data_for_org_with_type_other():
+            organisation_request = OrganisationRequestFactory(
+                type_id=RequestOriginConstants.OTHER.value,
+                type_other="My other type value",
+            )
+            for _ in range(3):
+                AidantRequestFactory(organisation=organisation_request)
+            organisation_request.save()
+            return organisation_request
+
+        def prepare_data_with_existing_responsable():
+            organisation_request = OrganisationRequestFactory()
+            # existing manager
+            AidantFactory(
+                email=organisation_request.manager.email,
+                username=organisation_request.manager.email,
+                can_create_mandats=False,
+            )
+            for _ in range(3):
+                AidantRequestFactory(organisation=organisation_request)
+            organisation_request.save()
+            return organisation_request
+
         for organisation_request in (
-            self.prepare_data_for_nominal_case(),
-            self.prepare_data_with_existing_responsable(),
+            prepare_data_for_nominal_case(),
+            prepare_data_for_org_with_type_other(),
+            prepare_data_with_existing_responsable(),
         ):
             result = organisation_request.accept_request_and_create_organisation()
 


### PR DESCRIPTION
## 🌮 Objectif

J'ai commencéc par agir pour éviter les "flaky tests", càd les tests qui peuvent passer ou échouer aléatoirement sans changement dans le code.

Et en faisant ça j'ai trouvé des bugs embêtants… donc j'ai corrigé et j'ai ajouté des tests fiables.

## 🔍 Implémentation

- Suppression des fuzzychoices sur des éléments sensibles comme le type de l'orga ou le statut de la demande
- Correction de deux bugs non identifiés dans la création d'orga à partir d'une orga request
- Ajustement de la draftOrganisationRequestFactory (car un brouillon n'est pas censé porter de data_pass_id, contrairement aux autres statuts)

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
