### PR TITLE
Résolution de soucis mineurs d'héritage de classes

### DIFF
--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -87,6 +87,10 @@ class LateStageRequestView(VerifiedEmailIssuerView, View):
 
 
 class OnlyNewRequestsView(HabilitationStepMixin, LateStageRequestView):
+    @property
+    def step(self) -> HabilitationFormStep:
+        raise NotImplementedError()
+
     def dispatch(self, request, *args, **kwargs):
         if not self.issuer.email_verified:
             # Duplicate logic of VerifiedEmailIssuerView

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -79,10 +79,6 @@ class VerifiedEmailIssuerView(CheckIssuerMixin, View):
 
 
 class LateStageRequestView(VerifiedEmailIssuerView, View):
-    @property
-    def step(self) -> HabilitationFormStep:
-        raise NotImplementedError()
-
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.organisation = get_object_or_404(
@@ -90,11 +86,7 @@ class LateStageRequestView(VerifiedEmailIssuerView, View):
         )
 
 
-class OnlyNewRequestsView(LateStageRequestView):
-    @property
-    def step(self) -> HabilitationFormStep:
-        raise NotImplementedError()
-
+class OnlyNewRequestsView(HabilitationStepMixin, LateStageRequestView):
     def dispatch(self, request, *args, **kwargs):
         if not self.issuer.email_verified:
             # Duplicate logic of VerifiedEmailIssuerView
@@ -287,7 +279,7 @@ class ModifyOrganisationRequestFormView(
         return {**super().get_form_kwargs(), "instance": self.organisation}
 
 
-class PersonnelRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, FormView):
+class PersonnelRequestFormView(OnlyNewRequestsView, FormView):
     template_name = "personnel_form.html"
     form_class = PersonnelForm
 
@@ -338,7 +330,7 @@ class PersonnelRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, FormV
         )
 
 
-class ValidationRequestFormView(OnlyNewRequestsView, HabilitationStepMixin, FormView):
+class ValidationRequestFormView(OnlyNewRequestsView, FormView):
     template_name = "validation_form.html"
     form_class = ValidationForm
 


### PR DESCRIPTION
## 🌮 Objectif

Éviter des avertissements dans les IDE

## 🔍 Implémentation

- Seules les vues qui doivent afficher un fil d'Ariane devraient demander un `step`
