### PR TITLE
Envoyer message depuis la page de validation de demande

### DIFF
--- a/aidants_connect_habilitation/templates/validation_form.html
+++ b/aidants_connect_habilitation/templates/validation_form.html
@@ -15,32 +15,29 @@
       Il est possible de les modifier si besoin.
     </p>
     {% include "_display_org_request.html" with organisation=organisation show_all_buttons=True %}
-    <!--
     <h3>Information complémentaire</h3>
+    <form method="post">
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-12 fr-col-md-8">
         <div class="shadowed">
           <h4 class="h3">Une question ? Une précision ?</h4>
           <p class="more-info-messages">Si vous souhaitez ajouter une précision ou nous poser une question, c’est ici que ça se passe ! Saisissez votre message ci-dessous, il nous sera envoyé avec votre demande.</p>
           <div class="fr-grid-row">
-            <div class="fr-col-4">
-              Votre message
-            </div>
+            <label class="fr-col-4" for="{{ form.content.id_for_label }}">Votre message</label>
             <div class="fr-col-8">
-              Message box
+              {% csrf_token %}
+              {{ form.message_content }}
             </div>
           </div>
         </div>
       </div>
     </div>
-    -->
     <h3>Validation de la demande</h3>
     <div class="fr-grid-row fr-grid-row--gutters">
       <div class="fr-col-12 fr-col-md-8">
         <div class="shadowed">
           <h4 class="h2">Modalités d'utilisation</h4>
-          <form method="post">
-            {% csrf_token %}
+
             {{ form.non_field_errors }}
             {% checkbox_fr_grid_row form.cgu %}
             {% checkbox_fr_grid_row form.dpo %}
@@ -53,10 +50,10 @@
               </a>
               <button class="primary" type="submit">Soumettre la demande</button>
             </div>
-          </form>
         </div>
       </div>
     </div>
+    </form>
     {% include "_more-info.html" %}
   </div>{# fr-container #}
 {% endblock %}

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from django.test import TestCase
 
 from aidants_connect.common.constants import (
+    MessageStakeholders,
     RequestOriginConstants,
     RequestStatusConstants,
 )
@@ -217,6 +218,7 @@ class TestValidationFormForm(TestCase):
         form = ValidationForm(
             data={name: True for name in TestValidationFormForm.names_attr}
         )
+        form.data["message_content"] = "Bonjour"
         form.is_valid()
 
         orga = form.save(organisation=orga_request)
@@ -227,3 +229,5 @@ class TestValidationFormForm(TestCase):
             self.assertTrue(getattr(orga, name))
             for name in TestValidationFormForm.names_attr
         ]
+        self.assertEqual(orga.messages.all()[0].content, "Bonjour")
+        self.assertEqual(orga.messages.all()[0].sender, MessageStakeholders.ISSUER.name)

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -384,7 +384,7 @@ class ReadonlyRequestView(LateStageRequestView, FormView):
 
     def form_valid(self, form):
         message: RequestMessage = form.save(commit=False)
-        message.sender = MessageStakeholders.ISSUER.value
+        message.sender = MessageStakeholders.ISSUER.name
         message.organisation = self.organisation
         message.save()
 


### PR DESCRIPTION
## 🌮 Objectif
Pouvoir envoyer un message au moment de la validation de demande d'habilitation.

## 🔍 Implémentation
Ajout du champ content dans ValidationForm et création de message dans la méthode save(). Mise à jour de validation_form.html. Mise à jour du test pour vérifier la création du message.

<img width="660" alt="Screenshot 2022-04-13 at 18 51 55" src="https://user-images.githubusercontent.com/5683664/163231029-9b2a4648-020b-422b-96d1-80aacd174968.png">


## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
