### PR TITLE
Accepter les numéros de téléphone d'Outremer

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -217,7 +217,7 @@ class PersonWithResponsibilitiesForm(PatchedErrorListForm):
         exclude = ["id"]
 
 
-class ManagerForm(PatchedErrorListForm):
+class ManagerForm(PersonWithResponsibilitiesForm):
     zipcode = CharField(
         label="Code Postal",
         max_length=10,

--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -1,7 +1,6 @@
 from typing import List, Tuple
 
 from django.conf import settings
-from django.core import validators
 from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.forms import (
     BaseModelFormSet,
@@ -15,12 +14,11 @@ from django.forms.formsets import MAX_NUM_FORM_COUNT, TOTAL_FORM_COUNT
 from django.urls import reverse
 from django.utils.html import format_html
 
-from phonenumber_field.formfields import PhoneNumberField
-from phonenumber_field.phonenumber import to_python
 from phonenumber_field.widgets import PhoneNumberInternationalFallbackWidget
 
 from aidants_connect.common.constants import MessageStakeholders, RequestOriginConstants
 from aidants_connect.common.forms import (
+    AcPhoneNumberField,
     PatchedErrorList,
     PatchedErrorListForm,
     PatchedForm,
@@ -34,22 +32,6 @@ from aidants_connect_habilitation.models import (
     RequestMessage,
 )
 from aidants_connect_web.models import OrganisationType
-
-
-class AcPhoneNumberField(PhoneNumberField):
-    regions = ("FR", "GP", "GF", "MQ", "RE", "KM", "PM")
-
-    def to_python(self, value):
-        for region in self.regions:
-            phone_number = to_python(value, region=region)
-
-            if phone_number in validators.EMPTY_VALUES:
-                return self.empty_value
-
-            if phone_number and phone_number.is_valid():
-                return phone_number
-
-        raise ValidationError(self.error_messages["invalid"])
 
 
 class IssuerForm(PatchedErrorListForm):
@@ -221,7 +203,7 @@ class OrganisationRequestForm(PatchedErrorListForm):
 
 
 class PersonWithResponsibilitiesForm(PatchedErrorListForm):
-    phone = PhoneNumberField(
+    phone = AcPhoneNumberField(
         initial="",
         region=settings.PHONENUMBER_DEFAULT_REGION,
         widget=PhoneNumberInternationalFallbackWidget(

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -9,6 +9,7 @@ from aidants_connect.common.constants import (
 )
 from aidants_connect_habilitation.forms import (
     AidantRequestFormSet,
+    IssuerForm,
     ManagerForm,
     OrganisationRequestForm,
     PersonnelForm,
@@ -21,6 +22,21 @@ from aidants_connect_habilitation.tests.factories import (
 )
 from aidants_connect_habilitation.tests.utils import get_form
 from aidants_connect_web.models import OrganisationType
+
+
+class TestIssuerForm(TestCase):
+    def test_form_is_valid_with_dom_tom_phonenumber(self):
+        form = IssuerForm(
+            data={
+                "phone": "06 90 11 12 13",
+                "first_name": "Mary",
+                "last_name": "Read",
+                "profession": "Pirate",
+                "email": "mary_read@example.com",
+            }
+        )
+
+        self.assertTrue(form.is_valid())
 
 
 class TestOrganisationRequestForm(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Comme l'indique le titre de la PR, il s'agit de permettre à nos aidants et demandeurs ultramarins de nous donner leur numéro de téléphone dans le formulaire d'habilitation…

## 🔍 Implémentation

- Création d'un AcPhoneNumberField qui essaie la France métropolitaine puis tous les territoires et départements d'outremer, au lieu de juste la région par défaut
- Utilisation de ce champ aux deux endroits du front où on demande un numéro de téléphone