### PR TITLE
Permettre la recherche par UUID dans les organisation des requêtes d'habilitations

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -79,7 +79,7 @@ class MessageInline(VisibleToAdminMetier, StackedInline):
 class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
     list_filter = ("status", RegionFilter, DepartmentFilter)
     list_display = ("name", "issuer", "status", "data_pass_id", "created_at")
-    search_fields = ("data_pass_id", "name")
+    search_fields = ("data_pass_id", "name", "uuid")
     raw_id_fields = ("issuer", "organisation")
     fields = (
         "issuer",


### PR DESCRIPTION
## 🌮 Objectif

L'orsqu'on récupère une erreur Sentry, la seule infor qu'on a concernant la demande, c'est son UUID. Il faut qu'on puisse rechercher un objet par UUID.