### PR TITLE
Validation que le code postal est bien composé de chiffres

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -182,6 +182,13 @@ class OrganisationRequestForm(PatchedErrorListForm):
 
         return self.data["france_services_number"]
 
+    def clean_zipcode(self):
+        data: str = self.cleaned_data["zipcode"]
+        if not data.isnumeric():
+            raise ValidationError("Veuillez entrer un code postal valide")
+
+        return data
+
     class Meta:
         model = models.OrganisationRequest
         fields = [
@@ -233,6 +240,13 @@ class ManagerForm(PersonWithResponsibilitiesForm):
             "required": "Le champ « ville » est obligatoire.",
         },
     )
+
+    def clean_zipcode(self):
+        data: str = self.cleaned_data["zipcode"]
+        if not data.isnumeric():
+            raise ValidationError("Veuillez entrer un code postal valide")
+
+        return data
 
     class Meta(PersonWithResponsibilitiesForm.Meta):
         model = Manager

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -91,6 +91,30 @@ class TestOrganisationRequestForm(TestCase):
             ],
         )
 
+    def test_clean_type_zipcode_number_passes(self):
+        form = get_form(
+            OrganisationRequestForm,
+            ignore_errors=True,
+            type_id=RequestOriginConstants.OTHER.value,
+            zipcode="01700",
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.errors, {})
+
+    def test_clean_type_zipcode_not_number_raises_error(self):
+        form = get_form(
+            OrganisationRequestForm,
+            ignore_errors=True,
+            type_id=RequestOriginConstants.OTHER.value,
+            zipcode="La Commune",
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["zipcode"], ["Veuillez entrer un code postal valide"]
+        )
+
     def test_private_org_requires_partner_administration(self):
         form = get_form(
             OrganisationRequestForm,
@@ -207,7 +231,6 @@ class TestPersonnelForm(TestCase):
 
 
 class TestValidationFormForm(TestCase):
-
     names_attr = ["cgu", "dpo", "professionals_only", "without_elected"]
 
     def test_form_valid_only_with_four_enabled_choices(self):
@@ -247,3 +270,29 @@ class TestValidationFormForm(TestCase):
         ]
         self.assertEqual(orga.messages.all()[0].content, "Bonjour")
         self.assertEqual(orga.messages.all()[0].sender, MessageStakeholders.ISSUER.name)
+
+
+class TestManagerForm(TestCase):
+    def test_clean_type_zipcode_number_passes(self):
+        form = get_form(
+            OrganisationRequestForm,
+            ignore_errors=True,
+            type_id=RequestOriginConstants.OTHER.value,
+            zipcode="01700",
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.errors, {})
+
+    def test_clean_type_zipcode_not_number_raises_error(self):
+        form = get_form(
+            OrganisationRequestForm,
+            ignore_errors=True,
+            type_id=RequestOriginConstants.OTHER.value,
+            zipcode="La Commune",
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["zipcode"], ["Veuillez entrer un code postal valide"]
+        )


### PR DESCRIPTION
## 🌮 Objectif

Rajout d'une validation dans les formulaires qui permet d'éviter une erreur rencontrée en prod ce matin dans un cas où la personne remplit par erreur la ville dans le champ de code postal.

## 🔍 Implémentation

- Rajout d'une validation formulaire pour vérifier que le code postal est bien composé de chiffres