### PR TITLE
Ne pas permettre de soumettre une demande sans responsable

### DIFF
--- a/aidants_connect_habilitation/templates/_display_org_request.html
+++ b/aidants_connect_habilitation/templates/_display_org_request.html
@@ -97,6 +97,7 @@
     <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
       <div class="shadowed with-button-box">
         <h4 class="h2">Responsable de structure</h4>
+        {% if organisation.manager %}
         <div>
           <p>
             <strong>{{ organisation.manager.get_full_name }}</strong>
@@ -112,6 +113,10 @@
           </p>
           <p>Ce responsable est aussi aidant : {{ organisation.manager.is_aidant|yesno:"Oui,Non" }}</p>
         </div>
+        {% else %}
+        <a href="{% url "habilitation_new_aidants" issuer_id=issuer.issuer_id uuid=organisation.uuid %}">
+          Ajouter un responsable</a>
+        {% endif %}
         {% if show_all_buttons %}
           <div class="button-box">
             <a class="button primary"

--- a/aidants_connect_habilitation/templates/validation_form.html
+++ b/aidants_connect_habilitation/templates/validation_form.html
@@ -14,6 +14,8 @@
       Vous retrouverez ici les informations principales saisies dans le formulaire.
       Il est possible de les modifier si besoin.
     </p>
+
+    {{ form.non_field_errors }}
     {% include "_display_org_request.html" with organisation=organisation show_all_buttons=True %}
     <h3>Information complémentaire</h3>
     <form method="post">
@@ -37,8 +39,6 @@
       <div class="fr-col-12 fr-col-md-8">
         <div class="shadowed">
           <h4 class="h2">Modalités d'utilisation</h4>
-
-            {{ form.non_field_errors }}
             {% checkbox_fr_grid_row form.cgu %}
             {% checkbox_fr_grid_row form.dpo %}
             {% checkbox_fr_grid_row form.professionals_only %}

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -750,7 +750,7 @@ class ValidationRequestFormViewTests(TestCase):
         )
         AidantRequestFactory(organisation=cls.organisation)
         cls.organisation_no_manager: OrganisationRequest = (
-            DraftOrganisationRequestFactory()
+            DraftOrganisationRequestFactory(manager=None)
         )
 
     def get_url(self, issuer_id, uuid):

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -365,6 +365,18 @@ class ValidationRequestFormView(OnlyNewRequestsView, FormView):
         form.save(self.organisation)
         return super().form_valid(form)
 
+    def post(self, request, *args, **kwargs):
+        form: ValidationForm = self.get_form()
+        if self.organisation.manager is None:
+            form.add_error(
+                None,
+                "Veuillez ajouter le responsable de la structure avant validation.",
+            )
+        if form.is_valid():
+            return self.form_valid(form)
+        else:
+            return self.form_invalid(form)
+
 
 class ReadonlyRequestView(LateStageRequestView, FormView):
     template_name = "view_organisation_request.html"


### PR DESCRIPTION
## 🌮 Objectif

Quand un demandeur ouvre son space "issuer" si, par exemple, il a commencé à remplir la demande (déjà rempli la structure) et il est revenue plus tard. Il est donc envoyé au space "issuer" où il peut appuyer soumettre une demande et il sera envoyé à la page de validation de la demande. Dans cette page il peut appuyer valider et on aurait une erreur 500 car le responsable n'a pas été rempli.

## 🔍 Implémentation
Ajout de lien pour ajouter un responsable
<img width="465" alt="Screenshot 2022-04-28 at 18 08 24" src="https://user-images.githubusercontent.com/5683664/165799570-0fd5df7c-52e4-4d51-8456-ac2138aca4fd.png">

Message d'erreur si responsable pas rempli

<img width="1261" alt="Screenshot 2022-05-05 at 14 50 05" src="https://user-images.githubusercontent.com/5683664/166929915-85f3b5c6-4571-45e6-bc1c-b807b29e0a34.png">


## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
