### PR TITLE
Gérer le cas où le demandeur rempli deux aidants avec le même mail

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -176,6 +176,13 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
                 if organisation_request.accept_request_and_create_organisation():
                     orgs_created += 1
                     self.send_acceptance_email(organisation_request)
+                else:
+                    self.message_user(
+                        request,
+                        f"""L'organisation {organisation_request.name} n'a pas été créée.
+                        Vérifiez si la demande est bien en attente de validation.""",
+                        level=messages.ERROR,
+                    )
             except Organisation.AlreadyExists as e:
                 self.message_user(request, e, level=messages.ERROR)
         if orgs_created > 1:

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -371,21 +371,28 @@ class OrganisationRequest(models.Model):
             responsable.save()
 
         for aidant in self.aidant_requests.all():
-            HabilitationRequest.objects.create(
-                first_name=aidant.first_name,
-                last_name=aidant.last_name,
-                email=aidant.email,
-                profession=aidant.profession,
-                organisation=organisation,
-            )
+            if not HabilitationRequest.objects.filter(
+                email=self.manager.email, organisation=organisation
+            ).exists():
+                HabilitationRequest.objects.create(
+                    first_name=aidant.first_name,
+                    last_name=aidant.last_name,
+                    email=aidant.email,
+                    profession=aidant.profession,
+                    organisation=organisation,
+                )
+
         if self.manager.is_aidant:
-            HabilitationRequest.objects.create(
-                first_name=self.manager.first_name,
-                last_name=self.manager.last_name,
-                email=self.manager.email,
-                profession=self.manager.profession,
-                organisation=organisation,
-            )
+            if not HabilitationRequest.objects.filter(
+                email=self.manager.email, organisation=organisation
+            ).exists():
+                HabilitationRequest.objects.create(
+                    first_name=self.manager.first_name,
+                    last_name=self.manager.last_name,
+                    email=self.manager.email,
+                    profession=self.manager.profession,
+                    organisation=organisation,
+                )
 
         return True
 


### PR DESCRIPTION
## 🌮 Objectif

Gérer le cas où le demandeur rempli deux aidants avec le même mail. Par exemple il coche la case "c'est aussi un aidant" et s'ajoute en tant qu'aidant. Ou il ajoute deux aidants avec le même mail.

## 🔍 Implémentation

Vérifier si aidant à former existe déjà au moment de créer l'aidant à former. J'en ai profité pour ajouter un message d'erreur si un bizdev essaye d'accepter une demande dans un état autre que "en attente de validation".

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
