### PR TITLE
Corriger position message erreur

### DIFF
--- a/aidants_connect_habilitation/templates/fields/fields_as_narrow_fr_grid_row.html
+++ b/aidants_connect_habilitation/templates/fields/fields_as_narrow_fr_grid_row.html
@@ -13,6 +13,6 @@
 
 {% if errors %}
   <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="errors fr-col-12 fr-col-md-7 fr-col-offset-md-5 fr-col-lg-12">{{ errors }}</div>
+    <div class="errors fr-col-12">{{ errors }}</div>
   </div>
 {% endif %}

--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -92,7 +92,7 @@
 
                 {% if errors %}
                   <div class="fr-grid-row fr-grid-row--gutters">
-                    <div class="errors fr-col-12 fr-col-md-7 fr-col-offset-md-5">{{ errors }}</div>
+                    <div class="errors fr-col-12">{{ errors }}</div>
                   </div>
                 {% endif %}
               {% endwith %}


### PR DESCRIPTION
## 🌮 Objectif

Corriger position message erreur sur formulaire responsable. Observation : le style a changé après la classe "errorlist". je ne sais pas s'il faut laisser comme ça.

## 🔍 Implémentation
Avant
<img width="548" alt="Screenshot 2022-04-28 at 16 15 18" src="https://user-images.githubusercontent.com/5683664/166962862-384d2579-840b-4069-a33b-6b3c0bc6a246.png">

Après
<img width="368" alt="Screenshot 2022-05-05 at 17 50 28" src="https://user-images.githubusercontent.com/5683664/166962903-5179c40f-a0b9-40dd-a5da-74eefd9fad00.png">

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
