### PR TITLE
Envoyer e-mail quand une demande d'habilitation est sauvegardé en brouillon

### DIFF
--- a/aidants_connect_habilitation/signals.py
+++ b/aidants_connect_habilitation/signals.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.core.mail import send_mail
+from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import HttpRequest
 from django.template import loader
@@ -7,6 +8,7 @@ from django.urls import reverse
 
 from aidants_connect_habilitation.models import (
     IssuerEmailConfirmation,
+    OrganisationRequest,
     email_confirmation_sent,
 )
 
@@ -29,6 +31,38 @@ def send_email_confirmation(
         from_email=settings.EMAIL_CONFIRMATION_EXPIRE_DAYS_EMAIL_FROM,
         recipient_list=[confirmation.issuer.email],
         subject=settings.EMAIL_CONFIRMATION_EXPIRE_DAYS_EMAIL_SUBJECT,
+        message=text_message,
+        html_message=html_message,
+    )
+
+
+@receiver(post_save, sender=OrganisationRequest)
+def notify_issuer_draft_request_saved(
+    instance: OrganisationRequest, created: bool, **_
+):
+    if not created:
+        return
+
+    path = reverse(
+        "habilitation_issuer_page",
+        kwargs={"issuer_id": str(instance.issuer.issuer_id)},
+    )
+
+    context = {
+        "url": f"https://{settings.HOST}{path}",
+        "organisation": instance,
+    }
+    text_message = loader.render_to_string(
+        "email/draft_organisation_request_saved.txt", context
+    )
+    html_message = loader.render_to_string(
+        "email/draft_organisation_request_saved.html", context
+    )
+
+    send_mail(
+        from_email=settings.EMAIL_ORGANISATION_REQUEST_CREATION_FROM,
+        recipient_list=[instance.issuer.email],
+        subject=settings.EMAIL_ORGANISATION_REQUEST_CREATION_SUBJECT,
         message=text_message,
         html_message=html_message,
     )

--- a/aidants_connect_habilitation/templates/email/draft_organisation_request_saved.html
+++ b/aidants_connect_habilitation/templates/email/draft_organisation_request_saved.html
@@ -1,0 +1,36 @@
+{% extends "layouts/email_base.html" %}
+{% block email_body %}
+  <table border="0" cellpadding="0" cellspacing="0" class="body">
+    <tr>
+      <td>&nbsp;</td>
+      <td class="container">
+        <div class="content">
+          <table class="main">
+            <tr>
+              <td class="wrapper">
+                <table border="0" cellpadding="6" cellspacing="0">
+                  <tr>
+                    <td>
+                      <p>Bonjour,</p>
+                      <p>
+                        Vous venez de créer une nouvelle demande d’habilitation à Aidants Connect pour
+                        l’organisation {{ organisation.name }}
+                      </p>
+                      <p>
+                        Vous pouvez <a href="{{ url }}">suivre le lien pour retrouver toutes vos demandes en cours</a> ou, si cela ne fonctionne pas, en copier l’URL suivante
+                        dans votre navigateur :
+                      </p>
+                      <p>{{ url }}</p>
+
+                      <p>À bientôt sur Aidants Connect</p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </td>
+    </tr>
+  </table>
+{% endblock %}

--- a/aidants_connect_habilitation/templates/email/draft_organisation_request_saved.txt
+++ b/aidants_connect_habilitation/templates/email/draft_organisation_request_saved.txt
@@ -1,0 +1,11 @@
+{% load ac_common %}
+
+Bonjour,
+
+Vous venez de créer une nouvelle demande d’habilitation à Aidants Connect pour l’organisation {{ organisation.name }}.
+{% linebreakless %}
+Vous pouvez suivre le lien pour retrouver toutes vos demandes en cours</a> en copiant l’URL suivante dans votre navigateur :
+{% endlinebreakless %}
+ {{ url }}
+
+À bientôt sur Aidants Connect

--- a/aidants_connect_habilitation/tests/test_admin.py
+++ b/aidants_connect_habilitation/tests/test_admin.py
@@ -41,6 +41,7 @@ class OrganisationRequestAdminTests(TestCase):
     def test_send_default_email(self):
         self.assertEqual(len(mail.outbox), 0)
 
+        # this is supposed to one email:
         org_request = OrganisationRequestFactory(
             status=RequestStatusConstants.VALIDATED.name,
             data_pass_id=67245456,
@@ -48,12 +49,13 @@ class OrganisationRequestAdminTests(TestCase):
         for _ in range(3):
             AidantRequestFactory(organisation=org_request)
 
-        # this is supposed to send one email:
+        # this is supposed to send another email:
         self.org_request_admin.send_acceptance_email(org_request)
 
-        # so here we expect 1 email here in outbox:
-        self.assertEqual(len(mail.outbox), 1)
-        acceptance_message = mail.outbox[0]
+        # so here we expect 2 emails here in outbox:
+        self.assertEqual(len(mail.outbox), 2)
+
+        acceptance_message = mail.outbox[1]
 
         # check subject and email contents
         self.assertIn(str(org_request.data_pass_id), acceptance_message.subject)
@@ -79,6 +81,7 @@ class OrganisationRequestAdminTests(TestCase):
     def test_send_email_with_custom_body_and_subject(self):
         self.assertEqual(len(mail.outbox), 0)
 
+        # this is supposed to one email:
         org_request = OrganisationRequestFactory(
             status=RequestStatusConstants.VALIDATED.name,
             data_pass_id=67245456,
@@ -86,16 +89,16 @@ class OrganisationRequestAdminTests(TestCase):
         for _ in range(3):
             AidantRequestFactory(organisation=org_request)
 
-        # this is supposed to send one email:
+        # this is supposed to send another email:
         email_body = "Corps du mail iaculis, scelerisque felis non, rutrum purus."
         email_subject = "Objet du mail consequat nisl sed viverra laoreet."
         self.org_request_admin.send_acceptance_email(
             org_request, email_body, email_subject
         )
 
-        # so here we expect 1 email here in outbox:
-        self.assertEqual(len(mail.outbox), 1)
-        acceptance_message = mail.outbox[0]
+        # so here we expect 2 emails here in outbox:
+        self.assertEqual(len(mail.outbox), 2)
+        acceptance_message = mail.outbox[1]
 
         # check subject and email contents
         self.assertEqual(email_subject, acceptance_message.subject)


### PR DESCRIPTION
## 🌮 Objectif

Envoyer e-mail quand une demande d'habilitation est sauvegardé en brouillon. Le mail envoie à l'espace demandeur (même lien que le mail "on se connaît"

## 🔍 Implémentation

J'ai remis le signal qui avait avant au moment de la création d'une organisation, cette fois-ci avec le bon lien.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
