### PR TITLE
Fix d'une régression sur PersonnelForm introduite par #638

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -284,8 +284,12 @@ class BaseAidantRequestFormSet(BaseModelFormSet):
         self._non_form_errors.append(error)
 
     def is_empty(self):
-        cleaned_data = [aidant for aidant in self.cleaned_data if len(aidant) != 0]
-        return len(cleaned_data) == 0
+        for form in self.forms:
+            # If the form is not valid, it has data to correct so it is not empty
+            if not form.is_valid() or form.is_valid() and len(form.cleaned_data) != 0:
+                return False
+
+        return True
 
 
 AidantRequestFormSet = modelformset_factory(
@@ -382,6 +386,7 @@ class PersonnelForm:
     def is_valid(self) -> bool:
         # self.errors must be last called so that subforms are
         # validated before performing a global validation
+
         return (
             self.manager_form.is_valid()
             and self.aidants_formset.is_valid()

--- a/aidants_connect_habilitation/tests/utils.py
+++ b/aidants_connect_habilitation/tests/utils.py
@@ -11,7 +11,7 @@ from aidants_connect_habilitation.tests import factories
 
 
 @singledispatch
-def get_form(form_cls, ignore_errors=False, **kwargs):
+def get_form(form_cls, ignore_errors=False, formset_extra=10, **kwargs):
     """
     Generates a form ModelForm or FormSet[ModelForm] populated with data.
 
@@ -75,7 +75,7 @@ T = TypeVar("T", bound=ModelForm)
 
 
 @get_form.register(type(ModelForm))
-def _(form_cls: Type[T], ignore_errors=False, **kwargs) -> T:
+def _(form_cls: Type[T], ignore_errors=False, formset_extra=10, **kwargs) -> T:
     form = form_cls(data=__get_form_data(form_cls, **kwargs))
 
     if not ignore_errors and not form.is_valid():
@@ -86,7 +86,7 @@ def _(form_cls: Type[T], ignore_errors=False, **kwargs) -> T:
 
 @get_form.register(type(BaseModelFormSet))
 def _(
-    form_cls: Type[BaseModelFormSet], ignore_errors=False, **kwargs
+    form_cls: Type[BaseModelFormSet], ignore_errors=False, formset_extra=10, **kwargs
 ) -> BaseModelFormSet:
     formset_cls = form_cls
     form_cls = form_cls.form
@@ -95,9 +95,9 @@ def _(
     # `extra` class property matches initial data length.
     # See https://docs.djangoproject.com/fr/4.0/topics/forms/modelforms/#s-id2 # noqa
     old_extra = formset_cls.extra
-    formset_cls.extra = 10
+    formset_cls.extra = formset_extra
     form: BaseModelFormSet = formset_cls(
-        initial=[__get_form_data(form_cls, **kwargs) for _ in range(10)]
+        initial=[__get_form_data(form_cls, **kwargs) for _ in range(formset_extra)]
     )
 
     data = {


### PR DESCRIPTION
Cette régression provoque une 500 sur la page de personnel lorsque qu'un formulaire aidant contient une erreur. Elle a été introduite parce que `AidantRequestFormSet.is_empty` teste les données des sous-formulaires pour chercher des formulaires vides, mais sans vérifier que ces formulaires sont bien valides, donc que les données sont bien présentes.