### PR TITLE
Clôturer demandes d'habilitation

### DIFF
--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -368,6 +368,9 @@ class OrganisationRequest(models.Model):
         else:
             responsable = responsable_query[0]
             responsable.responsable_de.add(organisation)
+            if responsable.has_a_totp_device:
+                self.status = RequestStatusConstants.CLOSED.name
+                self.save()
             responsable.save()
 
         for aidant in self.aidant_requests.all():


### PR DESCRIPTION
## 🌮 Objectif

- Clôturer les demandes valides quand le responsable active la carte 
- Clôturer les demandes au moment de la validation quand elles ont un responsable existant et avec carte TOTP validée

## 🔍 Implémentation

Clôture les demandes quand le responsable a une carte totp ici : accept_request_and_create_organisation(self)
Clôture les demandes au moment de la validation de la carte totp ici : validate_aidant_carte_totp
+ 2 tests

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
