### PR TITLE
Fix d'une erreur de programmation dans PersonnelForm.is_valid

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -490,13 +490,13 @@ class PersonnelForm:
                 "Vous devez déclarer au moins 1 aidant si le ou la responsable de "
                 "l'organisation n'est pas elle-même déclarée comme aidante"
             )
-            self.aidants_formset.add_non_form_error(
-                "Vous devez déclarer au moins 1 aidant si le ou la responsable de "
-                "l'organisation n'est pas elle-même déclarée comme aidante"
-            )
             self.manager_form.add_error(
                 "is_aidant",
                 "Veuillez cocher cette case ou déclarer au moins un aidant ci-dessous",
+            )
+            self.aidants_formset.add_non_form_error(
+                "Vous devez déclarer au moins 1 aidant si le ou la responsable de "
+                "l'organisation n'est pas elle-même déclarée comme aidante"
             )
 
     def add_error(self, error: Union[ValidationError, str]):
@@ -505,14 +505,18 @@ class PersonnelForm:
         self._errors.append(error)
 
     def is_valid(self) -> bool:
-        # self.errors must be last called so that subforms are
-        # validated before performing a global validation
+        # Eagerly compute the result of `is_valid` calls
+        # to prevent early return of the boolean computation.
 
-        return (
-            self.manager_form.is_valid()
-            and self.aidants_formset.is_valid()
-            and not self.errors
-        )
+        # 'self.errors' must be last called so that subforms are
+        # validated before performing a global validation
+        is_valid = [
+            self.manager_form.is_valid(),
+            self.aidants_formset.is_valid(),
+            not self.errors,
+        ]
+
+        return all(is_valid)
 
     def save(
         self, organisation: OrganisationRequest, commit=True


### PR DESCRIPTION
Je n'arrive pas à reproduire l'`AttributeError` qui arrive en prod mais cette PR est ma meilleure théorie (la seule, en fait).

Concrètement, si `self.manager_form.is_valid()` est faux, alors Python, par optimisation, va éviter de calculer le reste de l'expression booléenne et retourner directement le résultat. Ainsi, `self.aidants_formset.is_valid()` et `self.errors` pouraient ne jamais être appelés. Mais `self.errors` le sera par le rendu template. Il tentera alors de toucher à des propriétés dans `self._clean()`) de `self.aidants_formset` qui n'existent que si  `self.aidants_formset.is_valid()` a été appelé, ce qui n'a pas été le cas.

Il est tout-à-fait possible que ce ne soit pas l'origine des crash en prod mais comme ce risque existe, il doit être écarté, de toutes façon. 

Cette PR invers aussi `self.aidants_formset.add_non_form_error` pour — si l'exception continue d'arriver en prod — les 2 sous-formulaires sont affectés sous seul le formset (ce qui serait vraiment étrange…)