### PR TITLE
Demander à l'utilisateur de choisir parmis mes adresses alternatives uniquement lorsque la requête renvoie un ou plusieurs résultats.

### DIFF
--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -74,7 +74,7 @@
                 Toute saisie d’email de contact générique entrainera un blocage de la demande d’habilitation.
               </h4>
 
-              {% if not form.manager_form.pristine %}
+              {% if form.manager_form.should_display_addresses_select %}
                 <section class="choice-fields">
                   {% field_as_narrow_fr_grid_row form.manager_form.alternative_address %}
                 </section>


### PR DESCRIPTION
Un petit bug de programmation que j'ai spotté pendant le travail sur #667. Lorsque l'API d'adresse ne retourne aucun résultat (si elle est hors-ligne, si elle ne trouve aucun résultat correpondant à la recherche ou si elle a été tout simplement manuellement désactivée), alors le multi-select peut quand-même s'afficher avec la seule proposition de laisser l'addresse telle quel. Notamment si le formulaire personnel est retourné en erreur pour une autre raison.

Cette PR réduit les conditions dans lesquels ce champ est affiché pour qu'il ne soit plus affiché que si la recherche API retourne effectivement au moins une proposition.