### PR TITLE
Préservation des filtres dans l'admin sur la parcours d'acceptation ou de refus des requêtes

### DIFF
--- a/aidants_connect/common/tests/testcases.py
+++ b/aidants_connect/common/tests/testcases.py
@@ -1,9 +1,13 @@
 from django.conf import settings
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
+from django.urls import reverse
 
 from selenium.common.exceptions import WebDriverException
+from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options as FirefoxOptions
 from selenium.webdriver.firefox.webdriver import WebDriver
+from selenium.webdriver.support.expected_conditions import url_matches
+from selenium.webdriver.support.wait import WebDriverWait
 
 
 class FunctionalTestCase(StaticLiveServerTestCase):
@@ -36,3 +40,24 @@ class FunctionalTestCase(StaticLiveServerTestCase):
         """Helper method to trigger a GET request on the Django live server."""
 
         self.selenium.get(f"{self.live_server_url}{url}")
+
+    def admin_login(self, user: str, password: str, otp: str):
+        selenium_wait = WebDriverWait(self.selenium, 10)
+
+        path = reverse("otpadmin:login")
+        self.open_live_url(path)
+        selenium_wait.until(url_matches(f"^.+{path}$"))
+
+        self.selenium.find_element(By.CSS_SELECTOR, 'input[name="username"]').send_keys(
+            user
+        )
+        self.selenium.find_element(By.CSS_SELECTOR, 'input[name="password"]').send_keys(
+            password
+        )
+        self.selenium.find_element(
+            By.CSS_SELECTOR, 'input[name="otp_token"]'
+        ).send_keys(otp)
+
+        self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+
+        selenium_wait.until(url_matches(f"^.+{reverse('otpadmin:index')}$"))

--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.admin import ModelAdmin, StackedInline, TabularInline
+from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
 from django.core.mail import send_mail
 from django.db.models import QuerySet
 from django.http import HttpRequest, HttpResponseNotAllowed, HttpResponseRedirect
@@ -299,11 +300,15 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
             ),
         )
 
-        return HttpResponseRedirect(
-            reverse(
-                "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
-            )
+        redirect_path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
         )
+        preserved_filters = self.get_preserved_filters(request)
+        opts = self.model._meta
+        redirect_path = add_preserved_filters(
+            {"preserved_filters": preserved_filters, "opts": opts}, redirect_path
+        )
+        return HttpResponseRedirect(redirect_path)
 
     def send_acceptance_email(self, object, body_text=None, subject=None):
         if body_text:
@@ -380,11 +385,15 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
             ),
         )
 
-        return HttpResponseRedirect(
-            reverse(
-                "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
-            )
+        redirect_path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
         )
+        preserved_filters = self.get_preserved_filters(request)
+        opts = self.model._meta
+        redirect_path = add_preserved_filters(
+            {"preserved_filters": preserved_filters, "opts": opts}, redirect_path
+        )
+        return HttpResponseRedirect(redirect_path)
 
     def send_refusal_email(self, object, body_text=None, subject=None):
         if body_text:
@@ -454,11 +463,15 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
             ),
         )
 
-        return HttpResponseRedirect(
-            reverse(
-                "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
-            )
+        redirect_path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
         )
+        preserved_filters = self.get_preserved_filters(request)
+        opts = self.model._meta
+        redirect_path = add_preserved_filters(
+            {"preserved_filters": preserved_filters, "opts": opts}, redirect_path
+        )
+        return HttpResponseRedirect(redirect_path)
 
     def send_changes_required_message(self, object, content=None):
         message = RequestMessage(organisation=object, sender="AC", content=content)

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/accept_form.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/accept_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load static ac_extras i18n %}
+{% load static admin_extras ac_extras i18n %}
 
 {% block extrastyle %}
   {{ block.super }}
@@ -16,7 +16,7 @@
 {% block content %}
   <h1>Accepter la demande d'habilitation n° {{ object.data_pass_id }}</h1>
   <h2>Organisation {{ object.name }}</h2>
-  <form action="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_accept' object_id=object_id %}"
+  <form action="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_accept' object_id=object_id %}"
         method="POST">
     <fieldset class="module aligned">
       {{ form.as_p }}

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/change_form.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/change_form.html
@@ -1,17 +1,17 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_urls %}
+{% load i18n admin_urls admin_extras %}
 
 {% block object-tools-items %}
   {% with status=adminform.form.instance.status %}
     {% if status in "AC_VALIDATION_PROCESSING,CHANGES_REQUESTED" %}
       <li>
-        <a href="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_accept' object_id=object_id %}">
+        <a href="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_accept' object_id=object_id %}">
           <span aria-hidden="true">✅️ </span>
           Accepter
         </a>
       </li>
       <li>
-        <a href="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_refuse' object_id=object_id %}">
+        <a href="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_refuse' object_id=object_id %}">
           <span aria-hidden="true">❌ </span>
           Refuser
         </a>
@@ -25,7 +25,7 @@
         </a>
       </li>-->
       <li>
-        <a href="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_requirechanges' object_id=object_id %}">
+        <a href="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_requirechanges' object_id=object_id %}">
           <span aria-hidden="true">✨ </span>
           Demander des modifications
         </a>

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/refusal_form.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/refusal_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load static ac_extras i18n %}
+{% load static admin_extras ac_extras i18n %}
 
 {% block extrastyle %}
   {{ block.super }}
@@ -16,7 +16,7 @@
 {% block content %}
   <h1>Refuser la demande d'habilitation n° {{ object.data_pass_id }}</h1>
   <h2>Organisation {{ object.name }}</h2>
-  <form action="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_refuse' object_id=object_id %}"
+  <form action="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_refuse' object_id=object_id %}"
         method="POST">
     <fieldset class="module aligned">
       {{ form.as_p }}

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/require_changes.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/require_changes.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load static ac_extras i18n %}
+{% load static admin_extras ac_extras i18n %}
 
 {% block extrastyle %}
   {{ block.super }}
@@ -16,7 +16,7 @@
 {% block content %}
   <h1>Demander de modifications pour la demande d'habilitation n° {{ object.data_pass_id }}</h1>
   <h2>Organisation {{ object.name }}</h2>
-  <form action="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_requirechanges' object_id=object_id %}"
+  <form action="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_requirechanges' object_id=object_id %}"
         method="POST">
     <fieldset class="module aligned">
       {{ form.as_p }}

--- a/aidants_connect_habilitation/templatetags/admin_extras.py
+++ b/aidants_connect_habilitation/templatetags/admin_extras.py
@@ -1,0 +1,34 @@
+from urllib.parse import urlparse
+
+from django import template
+from django.http import HttpRequest
+from django.template.base import Node, Parser, Token
+from django.template.defaulttags import url
+from django.utils.safestring import SafeString, mark_safe
+
+register = template.Library()
+
+
+def query_url(request: HttpRequest, path: str) -> SafeString:
+    query = urlparse(request.get_full_path()).query
+    full_path = f"{path}?{query}" if len(query) else path
+    return mark_safe(full_path)
+
+
+@register.tag
+def qurl(parser: Parser, token: Token):
+    """
+    Similar to {% url %} but passes any query parameters from
+    request down to the generated url
+    """
+    return QUrlNode(parser, token)
+
+
+class QUrlNode(Node):
+    def __init__(self, parser: Parser, token: Token):
+        self.parser = parser
+        self.token = token
+
+    def render(self, context):
+        path = url(self.parser, self.token).render(context)
+        return query_url(context["request"], path)

--- a/aidants_connect_habilitation/tests/test_functionnal/test_admin.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_admin.py
@@ -1,0 +1,278 @@
+from urllib.parse import urlparse
+
+from django.test import tag
+from django.urls import reverse
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import url_matches
+from selenium.webdriver.support.wait import WebDriverWait
+
+from aidants_connect.common.constants import RequestStatusConstants
+from aidants_connect.common.tests.testcases import FunctionalTestCase
+from aidants_connect_habilitation.models import OrganisationRequest
+from aidants_connect_habilitation.tests.factories import OrganisationRequestFactory
+from aidants_connect_web.models import Aidant
+from aidants_connect_web.tests.factories import AdminFactory
+
+
+@tag("functional")
+class OrganisationRequestAdminTests(FunctionalTestCase):
+    def setUp(self):
+        super().setUp()
+        self.password = "123456789"
+        self.otp = "123456"
+        self.aidant: Aidant = AdminFactory(
+            password=self.password, post__with_otp_device=self.otp
+        )
+
+    def test_filters_are_presereved_throughout_acceptance_process(self):
+        self.admin_login(self.aidant.email, self.password, self.otp)
+
+        organisation_status = RequestStatusConstants.AC_VALIDATION_PROCESSING
+
+        organisation: OrganisationRequest = OrganisationRequestFactory(
+            status=organisation_status.name
+        )
+
+        # Open the list of organisation requests
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+        self.open_live_url(path)
+
+        # Filter by status
+        self.selenium.find_element(
+            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+        ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )
+
+        # Navigate to the organisation detail
+        self.selenium.find_element(
+            By.XPATH, f"//a[normalize-space(text())='{organisation.name}']"
+        ).click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_change",
+            kwargs={"object_id": organisation.id},
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        href = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_accept",
+            kwargs={"object_id": organisation.id},
+        )
+
+        # Move to second step
+        self.selenium.find_element(By.XPATH, f'//a[contains(@href, "{href}")]').click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{href}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        # Definitely accept request
+        self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )
+
+    def test_filters_are_presereved_throughout_refusal_process(self):
+        self.admin_login(self.aidant.email, self.password, self.otp)
+
+        organisation_status = RequestStatusConstants.AC_VALIDATION_PROCESSING
+
+        organisation: OrganisationRequest = OrganisationRequestFactory(
+            status=organisation_status.name
+        )
+
+        # Open the list of organisation requests
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+        self.open_live_url(path)
+
+        # Filter by status
+        self.selenium.find_element(
+            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+        ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )
+
+        # Navigate to the organisation detail
+        self.selenium.find_element(
+            By.XPATH, f"//a[normalize-space(text())='{organisation.name}']"
+        ).click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_change",
+            kwargs={"object_id": organisation.id},
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        href = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_refuse",
+            kwargs={"object_id": organisation.id},
+        )
+
+        # Move to second step
+        self.selenium.find_element(By.XPATH, f'//a[contains(@href, "{href}")]').click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{href}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        # Definitely deny request
+        self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )
+
+    def test_filters_are_presereved_throughout_requiring_modification_process(self):
+        self.admin_login(self.aidant.email, self.password, self.otp)
+
+        organisation_status = RequestStatusConstants.AC_VALIDATION_PROCESSING
+
+        organisation: OrganisationRequest = OrganisationRequestFactory(
+            status=organisation_status.name
+        )
+
+        # Open the list of organisation requests
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+        self.open_live_url(path)
+
+        # Filter by status
+        self.selenium.find_element(
+            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+        ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )
+
+        # Navigate to the organisation detail
+        self.selenium.find_element(
+            By.XPATH, f"//a[normalize-space(text())='{organisation.name}']"
+        ).click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_change",
+            kwargs={"object_id": organisation.id},
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        href = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_requirechanges",
+            kwargs={"object_id": organisation.id},
+        )
+
+        # Move to second step
+        self.selenium.find_element(By.XPATH, f'//a[contains(@href, "{href}")]').click()
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{href}\\?([^=]+=[^=]+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"_changelist_filters=status__exact%3D{organisation_status.name}",
+        )
+
+        # Definitely require changes
+        self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
+
+        path = reverse(
+            "otpadmin:aidants_connect_habilitation_organisationrequest_changelist"
+        )
+
+        WebDriverWait(self.selenium, 10).until(
+            url_matches(f"^.+{path}\\?(\\w+=\\w+)+$")
+        )
+
+        # Check filters were preserved
+        self.assertEqual(
+            urlparse(self.selenium.current_url).query,
+            f"status__exact={organisation_status.name}",
+        )


### PR DESCRIPTION
## 🌮 Objectif

 Préservation des filtres dans l'admin sur la parcours d'acceptation ou de refus des requêtes

## 🔍 Implémentation

J'ai utilisé les fonctions `self.get_preserved_filters()` et `add_preserved_filters()` — qui sont, normalement, des API publiques — pour récupérer les filtres +  un filtre custom pour répercuter les query params le long du parcours.
