### PR TITLE
Utilisation du logger Celery pour les tâches Celery

### DIFF
--- a/aidants_connect_habilitation/management/commands/import_pix_results.py
+++ b/aidants_connect_habilitation/management/commands/import_pix_results.py
@@ -1,10 +1,14 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from aidants_connect_habilitation.tasks import import_pix_results
+
+logger = logging.getLogger()
 
 
 class Command(BaseCommand):
     help = "Gets test PIX results and update database"
 
     def handle(self, *args, **options):
-        import_pix_results()
+        import_pix_results(logger=logger)

--- a/aidants_connect_habilitation/tasks.py
+++ b/aidants_connect_habilitation/tasks.py
@@ -1,19 +1,20 @@
-import logging
 from datetime import datetime
+from logging import Logger
 
 from django.conf import settings
 
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from metabasepy import Client
 from pytz import timezone as pytz_timezone
 
 from aidants_connect_web.models import HabilitationRequest
 
-logger = logging.getLogger()
-
 
 @shared_task
-def import_pix_results():
+def import_pix_results(*, logger=None):
+    logger: Logger = logger or get_task_logger(__name__)
+
     username = settings.PIX_METABASE_USER
     password = settings.PIX_METABASE_PASSWORD
     card_id = settings.PIX_METABASE_CARD_ID

--- a/aidants_connect_web/management/commands/delete_duplicated_static_tokens.py
+++ b/aidants_connect_web/management/commands/delete_duplicated_static_tokens.py
@@ -1,6 +1,10 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from aidants_connect_web.tasks import delete_duplicated_static_tokens
+
+logger = logging.getLogger()
 
 
 class Command(BaseCommand):
@@ -10,4 +14,4 @@ class Command(BaseCommand):
     )
 
     def handle(self, *args, **options):
-        delete_duplicated_static_tokens()
+        delete_duplicated_static_tokens(logger=logger)

--- a/aidants_connect_web/management/commands/delete_expired_connections.py
+++ b/aidants_connect_web/management/commands/delete_expired_connections.py
@@ -1,10 +1,14 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from aidants_connect_web.tasks import delete_expired_connections
+
+logger = logging.getLogger()
 
 
 class Command(BaseCommand):
     help = "Deletes the expired `Connection` objects from the database"
 
     def handle(self, *args, **options):
-        delete_expired_connections()
+        delete_expired_connections(logger=logger)

--- a/aidants_connect_web/management/commands/notify_new_habilitation_requests.py
+++ b/aidants_connect_web/management/commands/notify_new_habilitation_requests.py
@@ -1,10 +1,14 @@
+import logging
+
 from django.core.management.base import BaseCommand
 
 from aidants_connect_web.tasks import notify_new_habilitation_requests
+
+logger = logging.getLogger()
 
 
 class Command(BaseCommand):
     help = "Notifies staff administrators that new habilitation requests are to be seen"
 
     def handle(self, *args, **options):
-        notify_new_habilitation_requests()
+        notify_new_habilitation_requests(logger=logger)

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -1,5 +1,5 @@
-import logging
 from datetime import timedelta
+from logging import Logger
 from typing import List
 
 from django.core.mail import send_mail
@@ -10,6 +10,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django_otp.plugins.otp_static.models import StaticDevice, StaticToken
 
 from aidants_connect import settings
@@ -21,11 +22,10 @@ from aidants_connect_web.models import (
     Organisation,
 )
 
-logger = logging.getLogger()
-
 
 @shared_task
-def delete_expired_connections():
+def delete_expired_connections(*, logger=None):
+    logger: Logger = logger or get_task_logger(__name__)
 
     logger.info("Deleting expired connections...")
 
@@ -44,7 +44,9 @@ def delete_expired_connections():
 
 
 @shared_task
-def delete_duplicated_static_tokens():
+def delete_duplicated_static_tokens(*, logger=None):
+    logger: Logger = logger or get_task_logger(__name__)
+
     logger.info("Deleting static devices for confirmed aidants...")
     obsolete_devices = (
         StaticDevice.objects.filter(user__is_staff=False)
@@ -74,6 +76,7 @@ def delete_duplicated_static_tokens():
 
 @shared_task
 def notify_soon_expired_mandates():
+
     mandates_qset = Mandat.find_soon_expired(settings.MANDAT_EXPIRED_SOON)
     organisations: List[Organisation] = list(
         Organisation.objects.filter(
@@ -109,7 +112,9 @@ def notify_soon_expired_mandates():
 
 
 @shared_task
-def notify_new_habilitation_requests():
+def notify_new_habilitation_requests(*, logger=None):
+    logger: Logger = logger or get_task_logger(__name__)
+
     logger.info("Checking new habilitation requests...")
     recipient_list = list(
         Aidant.objects.filter(is_staff=True, is_active=True).values_list(


### PR DESCRIPTION
## 🌮 Objectif

Le logger standard Python ne produit aucune trace dans les logs. [Il faut utiliser le logger fourni par Celery](https://docs.celeryq.dev/en/latest/userguide/tasks.html#logging), ce que fait cette PR.