### PR TITLE
modifier le status des OrganisationRequests lorsque celui ci est invalide

### DIFF
--- a/aidants_connect_habilitation/migrations/0021_auto_20220627_0809.py
+++ b/aidants_connect_habilitation/migrations/0021_auto_20220627_0809.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+from aidants_connect_habilitation.utils import real_fix_orga_request_status
+
+
+def fix_orga_request_without_status(apps, schema_editor):
+    OrganisationRequest = apps.get_model('aidants_connect_habilitation',
+                                         'OrganisationRequest')
+    real_fix_orga_request_status(OrganisationRequest)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('aidants_connect_habilitation', '0020_auto_20220420_0935'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_orga_request_without_status)
+    ]

--- a/aidants_connect_habilitation/tests/test_migrations.py
+++ b/aidants_connect_habilitation/tests/test_migrations.py
@@ -1,0 +1,75 @@
+from django.test import TestCase, tag
+
+from aidants_connect.common.constants import RequestStatusConstants
+from aidants_connect_habilitation.models import OrganisationRequest
+from aidants_connect_habilitation.tests.factories import OrganisationRequestFactory
+from aidants_connect_habilitation.utils import real_fix_orga_request_status
+
+
+@tag("models")
+class OrganisationRequestMigrationTests(TestCase):
+    def test_real_fix_orga_request_status(self):
+        OrganisationRequestFactory(
+            status=RequestStatusConstants.AC_VALIDATION_PROCESSING
+        )
+        OrganisationRequestFactory(status="Modifications finalisées")
+        OrganisationRequestFactory(status=RequestStatusConstants.NEW)
+        OrganisationRequestFactory(status=RequestStatusConstants.CHANGES_REQUIRED)
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.AC_VALIDATION_PROCESSING
+            ).count(),
+        )  # noqa
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.NEW
+            ).count(),
+        )
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.CHANGES_REQUIRED
+            ).count(),
+        )
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status="Modifications finalisées"
+            ).count(),
+        )
+
+        real_fix_orga_request_status(OrganisationRequest)
+
+        self.assertEqual(
+            2,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.AC_VALIDATION_PROCESSING
+            ).count(),
+        )  # noqa
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.NEW
+            ).count(),
+        )
+
+        self.assertEqual(
+            1,
+            OrganisationRequest.objects.filter(
+                status=RequestStatusConstants.CHANGES_REQUIRED
+            ).count(),
+        )
+
+        self.assertEqual(
+            0,
+            OrganisationRequest.objects.filter(
+                status="Modifications finalisées"
+            ).count(),
+        )

--- a/aidants_connect_habilitation/utils.py
+++ b/aidants_connect_habilitation/utils.py
@@ -1,0 +1,8 @@
+from aidants_connect.common.constants import RequestStatusConstants
+
+
+def real_fix_orga_request_status(OrganisationRequest):
+    orga_requests = OrganisationRequest.objects.filter(
+        status="Modifications finalisées"
+    )
+    orga_requests.update(status=RequestStatusConstants.AC_VALIDATION_PROCESSING)


### PR DESCRIPTION
## 🌮 Objectif

On a supprimé un des statuts possible des OrganisationRequests, celles qui étaient dans ce statut là lors de la suppression se retrouvent à être invalide. Cette PR a pour but de corriger cela

## 🔍 Implémentation

Ajout d'une data migration qui s'occupe de mettre à jour les OrganisationRequests invalides.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
