### PR TITLE
Réparation du script Matomo en prod

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -595,5 +595,13 @@ PIX_METABASE_CARD_ID = os.getenv("PIX_METABASE_CARD_ID")
 GOUV_ADDRESS_SEARCH_API_BASE_URL = "https://api-adresse.data.gouv.fr/search/"
 GOUV_ADDRESS_SEARCH_API_DISABLED = getenv_bool("GOUV_ADDRESS_SEARCH_API_DISABLED", True)
 
+# Matomo
 MATOMO_INSTANCE_URL = os.getenv("MATOMO_INSTANCE_URL")
 MATOMO_INSTANCE_SITE_ID = os.getenv("MATOMO_INSTANCE_SITE_ID")
+
+if MATOMO_INSTANCE_SITE_ID and MATOMO_INSTANCE_URL:
+    CSP_SCRIPT_SRC = (
+        *CSP_SCRIPT_SRC,
+        "'sha256-kKsklEZ3MJfIKwxmvIbVAVSQM/J1k9axzIS0kOiYdzw='",
+        "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js",
+    )

--- a/aidants_connect/templates/layouts/matomo_script.html
+++ b/aidants_connect/templates/layouts/matomo_script.html
@@ -1,0 +1,17 @@
+{% if MATOMO_INSTANCE_URL and MATOMO_INSTANCE_SITE_ID %}
+  <script>
+      var _paq = window._paq = window._paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(["trackPageView"]);
+      _paq.push(["enableLinkTracking"]);
+      (function () {
+          var u = "{{ MATOMO_INSTANCE_URL }}";
+          _paq.push(["setTrackerUrl", u + "matomo.php"]);
+          _paq.push(["setSiteId", "{{ MATOMO_INSTANCE_SITE_ID }}"]);
+          var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0];
+          g.async = true;
+          g.src = "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js";
+          s.parentNode.insertBefore(g, s);
+      })();
+  </script>
+{% endif %}

--- a/aidants_connect_habilitation/templates/layouts/main-habilitation.html
+++ b/aidants_connect_habilitation/templates/layouts/main-habilitation.html
@@ -61,23 +61,7 @@
   <link rel="mask-icon" href="{% static 'images/favicons/safari-pinned-tab.svg' %}" color="#5bbad5">
 
   <!-- Matomo -->
-  {% if MATOMO_INSTANCE_URL and MATOMO_INSTANCE_SITE_ID %}
-    <script>
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function () {
-            var u = "{{ MATOMO_INSTANCE_URL }}";
-            _paq.push(['setTrackerUrl', u + 'matomo.php']);
-            _paq.push(['setSiteId', '{{ MATOMO_INSTANCE_SITE_ID }}']);
-            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-            g.async = true;
-            g.src = '//cdn.matomo.cloud/gouv.matomo.cloud/matomo.js';
-            s.parentNode.insertBefore(g, s);
-        })();
-    </script>
-  {% endif %}
+  {% include "layouts/matomo_script.html" %}
 </head>
 
 <body>

--- a/aidants_connect_web/templates/layouts/main.html
+++ b/aidants_connect_web/templates/layouts/main.html
@@ -61,23 +61,7 @@
   <link rel="mask-icon" href="{% static 'images/favicons/safari-pinned-tab.svg' %}" color="#5bbad5">
 
   <!-- Matomo -->
-  {% if MATOMO_INSTANCE_URL and MATOMO_INSTANCE_SITE_ID %}
-    <script>
-        var _paq = window._paq = window._paq || [];
-        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-        (function () {
-            var u = "{{ MATOMO_INSTANCE_URL }}";
-            _paq.push(['setTrackerUrl', u + 'matomo.php']);
-            _paq.push(['setSiteId', '{{ MATOMO_INSTANCE_SITE_ID }}']);
-            var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
-            g.async = true;
-            g.src = '//cdn.matomo.cloud/gouv.matomo.cloud/matomo.js';
-            s.parentNode.insertBefore(g, s);
-        })();
-    </script>
-  {% endif %}
+  {% include "layouts/matomo_script.html" %}
 </head>
 
 <body>


### PR DESCRIPTION
## 🌮 Objectif

Réparation du script Matomo en prod

## 🔍 Implémentation

- Ajout du SHA dans la liste CSP pour le script inline
- Ajout de l'URL du script Matomo dans la liste CSP,
- Refacto du script inline dans un template à part.