### PR TITLE
Support correct de l'erreur d'écriture en base sur violation de contrainte unique_together du couple (AidantRequest.organisation, AidantRequest.email)

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -157,7 +157,7 @@ MIDDLEWARE = [
 ]
 
 # Add debug toolbar
-if DEBUG:
+if DEBUG and "test" not in sys.argv:
     INSTALLED_APPS.append("debug_toolbar")
     MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
     INTERNAL_IPS = ["127.0.0.1"] + ALLOWED_HOSTS

--- a/aidants_connect/urls.py
+++ b/aidants_connect/urls.py
@@ -1,3 +1,5 @@
+import sys
+
 from django.conf import settings
 from django.urls import include, path
 
@@ -12,7 +14,7 @@ urlpatterns = [
     path("habilitation/", include("aidants_connect_habilitation.urls")),
 ]
 
-if settings.DEBUG:
+if settings.DEBUG and "test" not in sys.argv:
     import debug_toolbar
 
     urlpatterns.append(path("__debug__/", include(debug_toolbar.urls)))

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -188,7 +188,8 @@ class TestPersonnelForm(TestCase):
         mock_manager_form_is_valid: Mock,
         mock_aidants_form_is_valid: Mock,
     ):
-        form = PersonnelForm()
+        organisation = DraftOrganisationRequestFactory()
+        form = PersonnelForm(organisation=organisation)
 
         mock_manager_form_is_valid.return_value = True
         mock_aidants_form_is_valid.return_value = True
@@ -206,8 +207,12 @@ class TestPersonnelForm(TestCase):
         self.assertFalse(form.is_valid())
 
     def test_is_not_valid_if_no_aidant_was_declared(self):
+        organisation = DraftOrganisationRequestFactory()
         manager_data = get_form(ManagerForm, is_aidant=False).clean()
-        aidants_form = get_form(AidantRequestFormSet, formset_extra=0)
+        aidants_form = get_form(
+            AidantRequestFormSet,
+            form_init_kwargs={"initial": 0, "organisation": organisation},
+        )
         aidants_data = aidants_form.data
 
         cleaned_data = {
@@ -221,7 +226,7 @@ class TestPersonnelForm(TestCase):
             },
         }
 
-        form = PersonnelForm(data=cleaned_data)
+        form = PersonnelForm(data=cleaned_data, organisation=organisation)
 
         self.assertFalse(form.is_valid())
         self.assertEqual(
@@ -233,7 +238,10 @@ class TestPersonnelForm(TestCase):
         )
 
         manager_data = get_form(ManagerForm, is_aidant=True).clean()
-        aidants_form = get_form(AidantRequestFormSet, formset_extra=0)
+        aidants_form = get_form(
+            AidantRequestFormSet,
+            form_init_kwargs={"initial": 0, "organisation": organisation},
+        )
         aidants_data = aidants_form.data
 
         cleaned_data = {
@@ -247,13 +255,15 @@ class TestPersonnelForm(TestCase):
             },
         }
 
-        form = PersonnelForm(data=cleaned_data)
+        form = PersonnelForm(data=cleaned_data, organisation=organisation)
 
         self.assertTrue(form.is_valid())
         self.assertEqual(form.errors, [])
 
         manager_data = get_form(ManagerForm, is_aidant=True).clean()
-        aidants_form = get_form(AidantRequestFormSet)
+        aidants_form = get_form(
+            AidantRequestFormSet, form_init_kwargs={"organisation": organisation}
+        )
         aidants_data = aidants_form.data
 
         cleaned_data = {
@@ -267,7 +277,7 @@ class TestPersonnelForm(TestCase):
             },
         }
 
-        form = PersonnelForm(data=cleaned_data)
+        form = PersonnelForm(data=cleaned_data, organisation=organisation)
 
         self.assertTrue(form.is_valid())
         self.assertEqual(form.errors, [])
@@ -276,7 +286,9 @@ class TestPersonnelForm(TestCase):
         organisation: OrganisationRequest = DraftOrganisationRequestFactory()
 
         manager_data = get_form(ManagerForm).clean()
-        aidants_form = get_form(AidantRequestFormSet)
+        aidants_form = get_form(
+            AidantRequestFormSet, form_init_kwargs={"organisation": organisation}
+        )
         aidants_data = aidants_form.data
 
         cleaned_data = {
@@ -290,7 +302,7 @@ class TestPersonnelForm(TestCase):
             },
         }
 
-        form = PersonnelForm(data=cleaned_data)
+        form = PersonnelForm(data=cleaned_data, organisation=organisation)
         self.assertTrue(form.is_valid())
 
         self.assertIs(organisation.manager, None)
@@ -373,16 +385,25 @@ class TestManagerForm(TestCase):
 
 class TestBaseAidantRequestFormSet(TestCase):
     def test_is_empty(self):
-        form: AidantRequestFormSet = get_form(AidantRequestFormSet, formset_extra=0)
+        organisation = DraftOrganisationRequestFactory()
+        form: AidantRequestFormSet = get_form(
+            AidantRequestFormSet,
+            form_init_kwargs={"initial": 0, "organisation": organisation},
+        )
         self.assertEqual(form.is_empty(), True)
 
-        form: AidantRequestFormSet = get_form(AidantRequestFormSet)
+        form: AidantRequestFormSet = get_form(
+            AidantRequestFormSet, form_init_kwargs={"organisation": organisation}
+        )
         self.assertEqual(form.is_empty(), False)
 
         # Correctly handle erroneous subform case
-        data = get_form(AidantRequestFormSet, formset_extra=1).data
+        data = get_form(
+            AidantRequestFormSet,
+            form_init_kwargs={"initial": 1, "organisation": organisation},
+        ).data
         data["form-0-email"] = "   "
-        form = AidantRequestFormSet(data=data)
+        form = AidantRequestFormSet(data=data, organisation=organisation)
         self.assertFalse(form.is_valid())
         self.assertEqual(form.is_empty(), False)
 

--- a/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
@@ -71,7 +71,9 @@ class AddAidantsRequestViewTests(FunctionalTestCase):
         self.__open_form_url(organisation)
 
         for i in range(2):
-            aidant_form: AidantRequestForm = get_form(AidantRequestForm)
+            aidant_form: AidantRequestForm = get_form(
+                AidantRequestForm, form_init_kwargs={"organisation": organisation}
+            )
             aidant_data = aidant_form.cleaned_data
             for field_name in aidant_form.fields:
                 element = self.selenium.find_element(

--- a/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
@@ -118,7 +118,7 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
 
         self.assertEqual(len(form_elts), 4)
 
-        form = AidantRequestForm()
+        form = AidantRequestForm(organisation=organisation)
 
         for i, _ in enumerate(form_elts):
             for field_name, field in form.fields.items():
@@ -277,7 +277,9 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
         self.__open_form_url(issuer, organisation)
 
         for i in range(2, 6):
-            aidant_form: AidantRequestForm = get_form(AidantRequestForm)
+            aidant_form: AidantRequestForm = get_form(
+                AidantRequestForm, form_init_kwargs={"organisation": organisation}
+            )
             aidant_data = aidant_form.cleaned_data
             for field_name in aidant_form.fields:
                 element: WebElement = self.selenium.find_element(
@@ -323,7 +325,9 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
             f"#id_{PersonnelForm.AIDANTS_FORMSET_PREFIX}-{modified_aidant_idx}-email",
         ).get_attribute("value")
 
-        new_aidant_form: AidantRequestForm = get_form(AidantRequestForm)
+        new_aidant_form: AidantRequestForm = get_form(
+            AidantRequestForm, form_init_kwargs={"organisation": organisation}
+        )
         aidant_data = new_aidant_form.cleaned_data
         for field_name in new_aidant_form.fields:
             element: WebElement = self.selenium.find_element(

--- a/aidants_connect_habilitation/tests/test_utils.py
+++ b/aidants_connect_habilitation/tests/test_utils.py
@@ -1,15 +1,19 @@
 from django.test import TestCase
 
 from aidants_connect_habilitation.forms import AidantRequestFormSet
+from aidants_connect_habilitation.tests.factories import DraftOrganisationRequestFactory
 from aidants_connect_habilitation.tests.utils import get_form
 
 
 class Test(TestCase):
     def test_get_base_model_form_set(self):
-        formset: AidantRequestFormSet = get_form(AidantRequestFormSet)
+        organisation = DraftOrganisationRequestFactory()
+        formset: AidantRequestFormSet = get_form(
+            AidantRequestFormSet, form_init_kwargs={"organisation": organisation}
+        )
         self.assertEqual(len(formset), 10)
         self.assertTrue(formset.is_valid())
 
-        formset = AidantRequestFormSet(data=formset.data)
+        formset = AidantRequestFormSet(data=formset.data, organisation=organisation)
         self.assertEqual(len(formset), 10)
         self.assertTrue(formset.is_valid())

--- a/aidants_connect_habilitation/tests/utils.py
+++ b/aidants_connect_habilitation/tests/utils.py
@@ -3,18 +3,35 @@ from importlib import import_module
 from inspect import getmembers, isclass
 from json import loads
 from os.path import join as path_join
-from typing import Type, TypeVar
+from typing import Type, TypeVar, Union
 
-from django.forms import BaseModelFormSet, ModelForm
+from django.forms import BaseModelFormSet, ModelForm, model_to_dict
+from django.forms.formsets import (
+    INITIAL_FORM_COUNT,
+    MAX_NUM_FORM_COUNT,
+    MIN_NUM_FORM_COUNT,
+    TOTAL_FORM_COUNT,
+    ManagementForm,
+)
+from django.forms.models import fields_for_model
 
 from factory.django import DjangoModelFactory
 
 from aidants_connect_habilitation import tests
 from aidants_connect_habilitation.tests import factories
 
+MF = TypeVar("MF", bound=ModelForm)
+BMFS = TypeVar("BMFS", bound=BaseModelFormSet)
+T = TypeVar("T", bound=Union[ModelForm, BaseModelFormSet])
+
 
 @singledispatch
-def get_form(form_cls, ignore_errors=False, formset_extra=10, **kwargs):
+def get_form(
+    form_cls: Type[T],
+    ignore_errors: bool = False,
+    form_init_kwargs: dict = None,
+    **kwargs,
+) -> T:
     """
     Generates a form ModelForm or FormSet[ModelForm] populated with data.
 
@@ -61,11 +78,17 @@ def get_form(form_cls, ignore_errors=False, formset_extra=10, **kwargs):
     to generate forms with invalid data, you can skip error checking by
     setting the ignore_errors parameter to True.
 
-    You can also directly pass data to the factory using **kwargs.
+    When using this function on a BaseModelFormSet, by default, 10 subforms
+    will be generated. You can use the parameter ``form_init_kwargs`` to
+    change this behaviour by passing ``{"initial": 5}``.
 
+    You can also directly pass data to the factory using **kwargs.
     :param form_cls: The form class to instanciate
     :param ignore_errors: If set to True get_form() won't perform an is_valid()
                           call on the generated form.
+    :param form_init_kwargs: supplementary keyword argument to pass to the form
+                             constructor. You can pass ``{"initial": 5}`` to get
+                             5 subforms when instanciating a BaseModelFormSet.
     :param kwargs: Supplementary arguments to pass to the factory.
     :return: The form to generate. Will be an instance of class form_cls.
     """
@@ -74,12 +97,14 @@ def get_form(form_cls, ignore_errors=False, formset_extra=10, **kwargs):
     )
 
 
-T = TypeVar("T", bound=ModelForm)
-
-
 @get_form.register(type(ModelForm))
-def _(form_cls: Type[T], ignore_errors=False, formset_extra=10, **kwargs) -> T:
-    form = form_cls(data=__get_form_data(form_cls, **kwargs))
+def _(
+    form_cls: Type[MF], ignore_errors=False, form_init_kwargs: dict = None, **kwargs
+) -> MF:
+    form_init_kwargs = form_init_kwargs or {}
+    form = form_cls(
+        data=__get_form_data(form_cls, form_init_kwargs, **kwargs), **form_init_kwargs
+    )
 
     if not ignore_errors and not form.is_valid():
         raise ValueError(str(form.errors))
@@ -89,44 +114,51 @@ def _(form_cls: Type[T], ignore_errors=False, formset_extra=10, **kwargs) -> T:
 
 @get_form.register(type(BaseModelFormSet))
 def _(
-    form_cls: Type[BaseModelFormSet], ignore_errors=False, formset_extra=10, **kwargs
-) -> BaseModelFormSet:
+    form_cls: Type[BMFS],
+    ignore_errors=False,
+    form_init_kwargs: dict = None,
+    **kwargs,
+) -> BMFS:
     formset_cls = form_cls
     form_cls = form_cls.form
 
-    # BaseModelFormSet won't take `initial` in account unless
-    # `extra` class property matches initial data length.
-    # See https://docs.djangoproject.com/fr/4.0/topics/forms/modelforms/#s-id2 # noqa
+    form_init_kwargs = form_init_kwargs or {}
+    formset_extra = form_init_kwargs.pop("initial", 10)
+
     old_extra = formset_cls.extra
     formset_cls.extra = formset_extra
-    form: BaseModelFormSet = formset_cls(
-        initial=[__get_form_data(form_cls, **kwargs) for _ in range(formset_extra)]
-    )
+
+    form: BaseModelFormSet = formset_cls(**form_init_kwargs)
+    management_form = ManagementForm(auto_id=form.auto_id, prefix=form.prefix)
 
     data = {
-        "form-TOTAL_FORMS": f"{len(form)}",
-        "form-INITIAL_FORMS": "0",
-        "form-MIN_NUM_FORMS": "",
-        "form-MAX_NUM_FORMS": "",
+        f"{management_form.add_prefix(k)}": v
+        for k, v in {
+            TOTAL_FORM_COUNT: formset_extra,
+            INITIAL_FORM_COUNT: min(0, form.min_num),
+            MIN_NUM_FORM_COUNT: form.min_num,
+            MAX_NUM_FORM_COUNT: form.max_num,
+        }.items()
     }
 
-    for i, subform in enumerate(form.forms):
-        subform = form_cls(data=subform.initial)
-        subform.is_valid()
-        subdata = {f"form-{i}-{k}": v for (k, v) in subform.clean().items()}
-        data.update(subdata)
+    for i in range(0, formset_extra):
+        subform_data = __get_form_data(
+            form_cls, {**form_init_kwargs, "prefix": form.add_prefix(i)}, **kwargs
+        )
+        data.update(**subform_data)
 
-    form = formset_cls(data=data)
+    formset_cls.extra = old_extra
+
+    form = formset_cls(**form_init_kwargs, data=data)
 
     if not ignore_errors and not form.is_valid():
         raise ValueError(str(form.errors))
 
-    formset_cls.extra = old_extra
-
     return form
 
 
-def __get_form_data(form_cls: Type[T], **kwargs) -> T:
+def __get_form_data(form_cls: Type[MF], form_init_kwargs: dict, **kwargs) -> dict:
+    # Find factory from model class
     for name, cls in getmembers(import_module(factories.__name__), isclass):
         if (
             issubclass(cls, DjangoModelFactory)
@@ -140,7 +172,31 @@ def __get_form_data(form_cls: Type[T], **kwargs) -> T:
             f"{form_cls}"
         )
 
-    return form_cls(instance=factory_cls.build(**kwargs)).initial
+    # Obtain the fields to serialize from form
+    # This code was extracted from django.form.models
+    form: MF = form_cls(**form_init_kwargs)
+    fields = fields_for_model(
+        form._meta.model,
+        form._meta.fields,
+        form._meta.exclude,
+        form._meta.widgets,
+        getattr(form, "formfield_callback", None),
+        form._meta.localized_fields,
+        form._meta.labels,
+        form._meta.help_texts,
+        form._meta.error_messages,
+        form._meta.field_classes,
+        apply_limit_choices_to=False,
+    )
+
+    # Serialize generated model to dict
+    data = model_to_dict(factory_cls.build(**kwargs), fields=fields)
+
+    return (
+        {form.add_prefix(k): v for k, v in data.items()}
+        if form_init_kwargs.get("prefix")
+        else data
+    )
 
 
 def load_json_fixture(name: str) -> dict:

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -307,14 +307,13 @@ class ModifyOrganisationRequestFormView(
 
 class PersonnelRequestFormView(OnlyNewRequestsView, FormView):
     template_name = "personnel_form.html"
-    form_class = PersonnelForm
 
     @property
     def step(self) -> HabilitationFormStep:
         return HabilitationFormStep.PERSONNEL
 
     def form_valid(self, form):
-        form.save(self.organisation)
+        form.save()
         return super().form_valid(form)
 
     def get_context_data(self, **kwargs):
@@ -329,6 +328,9 @@ class PersonnelRequestFormView(OnlyNewRequestsView, FormView):
             "issuer_data": issuer_data,
             "organisation": self.organisation,
         }
+
+    def get_form(self, form_class=None):
+        return PersonnelForm(organisation=self.organisation, **self.get_form_kwargs())
 
     def get_form_kwargs(self):
         form_kwargs = super().get_form_kwargs()
@@ -449,7 +451,6 @@ class ReadonlyRequestView(LateStageRequestView, FormView):
 
 class AddAidantsRequestView(LateStageRequestView, FormView):
     template_name = "add_aidants_request.html"
-    form_class = AidantRequestFormSet
 
     def dispatch(self, request, *args, **kwargs):
         if self.organisation.status not in [
@@ -471,6 +472,11 @@ class AddAidantsRequestView(LateStageRequestView, FormView):
                 )
             )
         return super().dispatch(request, *args, **kwargs)
+
+    def get_form(self, form_class=None):
+        return AidantRequestFormSet(
+            organisation=self.organisation, **self.get_form_kwargs()
+        )
 
     def get_context_data(self, **kwargs):
         return {


### PR DESCRIPTION
## 🌮 Objectif

Cette erreur est apparue plusieurs fois en prod. Jusqu'ici, elle avait toujours été observée déclanchée par des bots. Mains il y a quelques jours, c'est une requête légitime qui a déclanchée cette erreur, renvoyant une réponse 500 à la personne, ce qui n'est pas top.

Pour le contexte, les formulaires qui gèrent les nouvelles requête aidant (`AidantRequestForm` et `BaseAidantRequestFormSet`) n'ont pas connaissance de l'organisation de destination au moment du traitement. Cette information était passée uniquement à l'appel de `PersonnelForm.save()`, donc beaucoup trop tard pour effectuer cette vérification.

Cette PR change ce comportement pour pouvoir vérifier qu'un aidant avec le même email n'existe pas déjà en base de données au moment de la requête (dans `AidantRequestForm.clean_email()`) ou que plusieurs aidants avec le même email n'ont pas été soumis (dans `BaseAidantRequestFormSet.clean()`).

## 🔍 Implémentation

- Modification des constructeurs de `AidantRequestForm`, `BaseAidantRequestFormSet` et `PersonnelForm` pour renseigner l'organisation de destination.
- Modification de la méthode `PersonnelForm.save()` qui n'a plus besoin de renseigner cette info.
- Tests.
- Modification de la fonction `aidants_connect_habilitation.tests.utils.get_form()` pour pouvoir passer des arguments au constructeur du formulaire afin de prendre en charge les nouveau constructeurs de `AidantRequestForm`, `BaseAidantRequestFormSet` et `PersonnelForm`.
- Modification de tous les tests qui dépendent de `aidants_connect_habilitation.tests.utils.get_form()` pour s'adater à la nouvelle signature.

## 🏕 Amélioration continue

- Désactivation de la debug toolbar lors des tests. Cela permet d'activer le mode debug dans les tests Selenium pour mieux diagnostiquer quand un test Selenium renvoie une 500.