### PR TITLE
Activation de la validation d'adresse sur le formulaire OrganisationRequestForm

### DIFF
--- a/aidants_connect_habilitation/templates/_address_validatable_mixin.html
+++ b/aidants_connect_habilitation/templates/_address_validatable_mixin.html
@@ -1,0 +1,7 @@
+{% load form_extras %}
+
+{% if form.should_display_addresses_select %}
+  <section class="choice-fields">
+    {% field_as_narrow_fr_grid_row form.alternative_address %}
+  </section>
+{% endif %}

--- a/aidants_connect_habilitation/templates/organisation_form.html
+++ b/aidants_connect_habilitation/templates/organisation_form.html
@@ -30,6 +30,8 @@
             {% field_as_fr_grid_row form.name %}
             <h3>Informations administratives</h3>
 
+            {% include "_address_validatable_mixin.html" with form=form %}
+
             {% field_as_fr_grid_row form.address %}
 
             {% with errors=form.zipcode.errors|add:form.city.errors %}
@@ -93,4 +95,8 @@
   {% stimulusjs %}
   <script src="{% static 'js/utils.js' %}"></script>
   <script src="{% static 'js/organisation_form.js' %}"></script>
+{% endblock %}
+
+{% block extracss %}
+  <link href="{% static 'css/personnel_form.css' %}" rel="stylesheet">
 {% endblock %}

--- a/aidants_connect_habilitation/templates/personnel_form.html
+++ b/aidants_connect_habilitation/templates/personnel_form.html
@@ -76,11 +76,7 @@
                     Toute saisie d’email de contact générique entrainera un blocage de la demande d’habilitation.
                   </h4>
 
-                  {% if form.manager_form.should_display_addresses_select %}
-                    <section class="choice-fields">
-                      {% field_as_narrow_fr_grid_row form.manager_form.alternative_address %}
-                    </section>
-                  {% endif %}
+                  {% include "_address_validatable_mixin.html" with form=form.manager_form %}
 
                   {% field_as_narrow_fr_grid_row form.manager_form.address %}
 


### PR DESCRIPTION
## 🌮 Objectif

Activation de la validation d'adresse sur le formulaire OrganisationRequestForm. La plus grosse partie du code était déjà correctement découplée donc c'était facile. Y'a un tout petit peu de refacto en plus.

## 🖼️ Images

![image](https://user-images.githubusercontent.com/22097904/177742967-44bb16df-96c1-4fc1-bf1a-0da18af26801.png)

