### PR TITLE
Sécurisation de la vue 'renew_mandat'

### DIFF
--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -78,7 +78,9 @@ urlpatterns = [
     ),
     # renew mandat
     path(
-        "renew_mandat/<int:usager_id>", renew_mandat.renew_mandat, name="renew_mandat"
+        "renew_mandat/<int:usager_id>",
+        renew_mandat.RenewMandat.as_view(),
+        name="renew_mandat",
     ),
     # new mandat
     path("creation_mandat/", mandat.new_mandat, name="new_mandat"),

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -12,7 +12,7 @@ from django.views.generic import FormView
 from aidants_connect.common.constants import AuthorizationDurations
 from aidants_connect_web.decorators import activity_required, user_is_aidant
 from aidants_connect_web.forms import MandatForm
-from aidants_connect_web.models import Aidant, Connection, Journal, Usager
+from aidants_connect_web.models import Aidant, Connection, Journal, Mandat, Usager
 
 
 class RenewMandat(FormView):
@@ -23,6 +23,10 @@ class RenewMandat(FormView):
     def dispatch(self, request, *args, **kwargs):
         self.aidant: Aidant = request.user
         self.usager: Usager = self.aidant.get_usager(kwargs.get("usager_id"))
+
+        if not Mandat.objects.for_usager(self.usager).renewable().exists():
+            django_messages.error(request, "Cet usager n'a aucun mandat renouvelable.")
+            return redirect("espace_aidant_home")
 
         if not self.usager:
             django_messages.error(

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -4,7 +4,10 @@ from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.hashers import make_password
-from django.shortcuts import redirect, render
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.views.generic import FormView
 
 from aidants_connect.common.constants import AuthorizationDurations
 from aidants_connect_web.decorators import activity_required, user_is_aidant
@@ -12,57 +15,55 @@ from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.models import Aidant, Connection, Journal, Usager
 
 
-@login_required
-@user_is_aidant
-@activity_required
-def renew_mandat(request, usager_id):
-    aidant: Aidant = request.user
-    usager: Usager = aidant.get_usager(usager_id)
+class RenewMandat(FormView):
+    form_class = MandatForm
+    template_name = "aidants_connect_web/new_mandat/renew_mandat.html"
 
-    if not usager:
-        django_messages.error(request, "Cet usager est introuvable ou inaccessible.")
-        return redirect("espace_aidant_home")
+    @method_decorator([login_required, user_is_aidant, activity_required])
+    def dispatch(self, request, *args, **kwargs):
+        self.aidant: Aidant = request.user
+        self.usager: Usager = self.aidant.get_usager(kwargs.get("usager_id"))
 
-    form = MandatForm()
+        if not self.usager:
+            django_messages.error(
+                request, "Cet usager est introuvable ou inaccessible."
+            )
+            return redirect("espace_aidant_home")
 
-    if request.method == "GET":
-        return render(
-            request,
-            "aidants_connect_web/new_mandat/renew_mandat.html",
-            {"aidant": aidant, "form": form},
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_valid(self, form):
+        data = form.cleaned_data
+        access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
+        connection = Connection.objects.create(
+            aidant=self.aidant,
+            organisation=self.aidant.organisation,
+            connection_type="FS",
+            access_token=access_token,
+            usager=self.usager,
+            demarches=data["demarche"],
+            duree_keyword=data["duree"],
+            mandat_is_remote=data["is_remote"],
+        )
+        duree = AuthorizationDurations.duration(connection.duree_keyword)
+        Journal.log_init_renew_mandat(
+            aidant=self.aidant,
+            usager=self.usager,
+            demarches=connection.demarches,
+            duree=duree,
+            is_remote_mandat=connection.mandat_is_remote,
+            access_token=connection.access_token,
         )
 
-    else:
-        form = MandatForm(request.POST)
+        self.request.session["connection"] = connection.pk
 
-        if form.is_valid():
-            data = form.cleaned_data
-            access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
-            connection = Connection.objects.create(
-                aidant=aidant,
-                organisation=aidant.organisation,
-                connection_type="FS",
-                access_token=access_token,
-                usager=usager,
-                demarches=data["demarche"],
-                duree_keyword=data["duree"],
-                mandat_is_remote=data["is_remote"],
-            )
-            duree = AuthorizationDurations.duration(connection.duree_keyword)
-            Journal.log_init_renew_mandat(
-                aidant=aidant,
-                usager=usager,
-                demarches=connection.demarches,
-                duree=duree,
-                is_remote_mandat=connection.mandat_is_remote,
-                access_token=connection.access_token,
-            )
+        return super().form_valid(form)
 
-            request.session["connection"] = connection.pk
-            return redirect("new_mandat_recap")
-        else:
-            return render(
-                request,
-                "aidants_connect_web/new_mandat/renew_mandat.html",
-                {"aidant": aidant, "form": form},
-            )
+    def get_context_data(self, **kwargs):
+        return {
+            **super().get_context_data(**kwargs),
+            "aidant": self.aidant,
+        }
+
+    def get_success_url(self):
+        return reverse("new_mandat_recap")


### PR DESCRIPTION
## 🌮 Objectif

Lors de l'affichage de la liste des usagers accompagné, le bouton *renouveler le mandat* n'est pas affiché si les comditions ne sont pas remplies (le mandat est expiré depuis plus d'un an ou a été manuellement révoqué).

Mais la vue n'est pas sécurisé et il est quand-même possible de renouveler un mandat qui ne remplit pas les conditions en entrant manuellement l'URL dans la barre d'adresse parce que la vue ne fait aucune vérification.
## 🔍 Implémentation

- Vérification que l'usager ou l'usagère accompagnée a bien au moins un mandat qui peut être renouvelé

## 🏕 Amélioration continue

- Réécritude de la vue en CBV comme décidé en équipe au démarrage de l'application d'habilitation.
