### PR TITLE
Pouvoir filtrer les aidant par ID dans l'admin

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -487,6 +487,7 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
     # that references specific fields on `auth.User`.
     list_display = (
         "__str__",
+        "id",
         "email",
         "organisation",
         "carte_totp",
@@ -502,7 +503,7 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         "is_staff",
         "is_superuser",
     )
-    search_fields = ("first_name", "last_name", "email", "organisation__name")
+    search_fields = ("id", "first_name", "last_name", "email", "organisation__name")
     ordering = ("email",)
 
     filter_horizontal = (


### PR DESCRIPTION
## 🌮 Objectif

Metabase est très pratique pour faire des requêtes complexes sans trop se prendre la tête mais, pour des raisons de sécurité, on n'y affiche pas les données personnelles. Uniquement les ID des enregistrement. Cette PR rajoute la possibilité de filtrer les aidants par ID pour pouvoir les retrouver après une requête Metabase.