### PR TITLE
Amélioration de Aidant.__str__

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -264,7 +264,8 @@ class Aidant(AbstractUser):
         verbose_name = "aidant"
 
     def __str__(self):
-        return f"{self.first_name} {self.last_name}"
+        full_name = f"{self.first_name} {self.last_name}".strip()
+        return full_name if full_name else self.username
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)


### PR DESCRIPTION
## 🌮 Objectif

Lorsque les champs `first_name` et `last_name` du modèle `Aidant` sont vides, la méthode `__str__` renvoie une chaine blanche ce qui empêche de cliquer sur le champ dans l'admin. Ça n'arrive pas en prod parce qu'on a des validateurs, mais en dev, si, en particulier en créant l'enregistrement avec la commande `./manage.py createsuperuser`.