### PR TITLE
Recap mail regroupé par région

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.html
+++ b/aidants_connect_web/templates/aidants_connect_web/managment/notify_new_habilitation_requests.html
@@ -18,8 +18,12 @@
                         dans {{ organisations.count }} structures différentes :
                       </p>
                       <ul>
-                        {% for org in organisations %}
-                          <li>{{ org.name }} : {{ org.num_requests }} aidants</li>
+                        {% for reg, orgs in organisations_per_region.items %}
+                          <p><b>{{ reg }}</b></p>
+                          {% for org in orgs %}
+                            <li>{{ org.name }} : {{ org.num_requests }} aidants</li>
+                          {% endfor %}
+                          <br>
                         {% endfor %}
                       </ul>
                       <p>{{ nb_new_test_pix }} aidants à former ont passé le test PIX.</p>


### PR DESCRIPTION
## 🌮 Objectif
Dans mail qui est envoyé une fois par semaine aux bizdev qui récapitule le nombre de nouvelles demandes d'habilitation, regrouper les demandes par RÉGION et par structure (parce que les bizdev n'arrivent pas à savoir immédiatement si la demande les concerne) 

## 🔍 Implémentation
<img width="543" alt="Screenshot 2022-08-12 at 09 58 38" src="https://user-images.githubusercontent.com/5683664/184311038-906a0b20-3dba-49c8-963d-ff439b63e7ac.png">


## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
