### PR TITLE
Utilisons `pytz` correctement

### DIFF
--- a/aidants_connect_habilitation/tasks.py
+++ b/aidants_connect_habilitation/tasks.py
@@ -26,8 +26,8 @@ def import_pix_results(*, logger=None):
     json_result = cli.cards.download(card_id=card_id, format="json")
 
     for person in json_result:
-        date_test_pix = datetime.strptime(person["date d'envoi"], "%Y-%m-%d").replace(
-            tzinfo=pytz_timezone("Europe/Paris")
+        date_test_pix = pytz_timezone("Europe/Paris").localize(
+            datetime.strptime(person["date d'envoi"], "%Y-%m-%d")
         )
         aidants = HabilitationRequest.objects.filter(email=person["email saisi"])
         if aidants.exists():
@@ -35,4 +35,5 @@ def import_pix_results(*, logger=None):
             aidant_a_former.test_pix_passed = True
             aidant_a_former.date_test_pix = date_test_pix
             aidant_a_former.save()
+
     logger.info("Sucessfully updated PIX results")

--- a/aidants_connect_web/migrations/0011_fix_pytz_timezones.py
+++ b/aidants_connect_web/migrations/0011_fix_pytz_timezones.py
@@ -1,0 +1,34 @@
+from datetime import timedelta
+
+from django.db import migrations
+
+from pytz import timezone as pytz_timezone
+
+
+def fix_pytz_timzeones(apps, schema_editor):
+    hrqs = apps.get_model(
+        "aidants_connect_web", "HabilitationRequest"
+    ).objects.filter(date_test_pix__isnull=False).all()
+
+    paris_tz = pytz_timezone("Europe/Paris")
+    lmt_offset = timedelta()
+
+    for offset, _, name in paris_tz._tzinfos.keys():
+        if name == "LMT":
+            lmt_offset = offset
+            break
+
+    for item in hrqs:
+        # Dates use UTC TZ in DB, only with improper offset
+        item.date_test_pix = item.date_test_pix + lmt_offset
+        item.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("aidants_connect_web", "0010_auto_20220825_1121"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_pytz_timzeones)
+    ]

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -552,7 +552,7 @@ class AutorisationModelTests(TestCase):
         self.assertEqual(first_autorisation.demarche, "Carte grise")
         self.assertEqual(second_autorisation.mandat.usager.family_name, "Flanders")
 
-    fake_date = datetime(2019, 1, 14, tzinfo=pytz_timezone("Europe/Paris"))
+    fake_date = pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 14))
 
     @freeze_time(fake_date)
     def test_autorisation_expiration_date_setting(self):
@@ -567,11 +567,11 @@ class AutorisationModelTests(TestCase):
         )
         self.assertEqual(
             autorisation.creation_date,
-            datetime(2019, 1, 14, tzinfo=pytz_timezone("Europe/Paris")),
+            pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 14)),
         )
         self.assertEqual(
             autorisation.mandat.expiration_date,
-            datetime(2019, 1, 17, tzinfo=pytz_timezone("Europe/Paris")),
+            pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 17)),
         )
 
     def test_was_separately_revoked_auth_not_revoked(self):

--- a/aidants_connect_web/tests/test_views/test_FC_as_FS.py
+++ b/aidants_connect_web/tests/test_views/test_FC_as_FS.py
@@ -37,7 +37,7 @@ class FCAuthorize(TestCase):
         self.assertNotEqual(connection.state, "")
 
 
-DATE = datetime(2019, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
+DATE = pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 14, 3, 20, 34, 0))
 TEST_FC_CONNECTION_AGE = 300
 
 
@@ -182,12 +182,13 @@ class FCCallback(TestCase):
 
         self.assertEqual(connection.access_token, "test_access_token")
         url = (
-            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=e"
-            "yJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRi"
-            "NDQ4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjox"
-            "NTQ3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29u"
-            "bmVjdC5nb3V2LmZyIiwic3ViIjoiMTIzIiwibm9uY2UiOiJ0ZXN0X25vbmNlIn0.QGb2uhgG"
-            "wXvKaVT8FXwOzSObtuLrBRKigd7DVJwUG5s&state=test_state"
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?"
+            "id_token_hint=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhd"
+            "WQiOiIyMTEyODY0MzNlMzljY2UwMWRiNDQ4ZDgwMTgxYmRmZDAwNTU1NGI"
+            "xOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ3NDMzMDM0L"
+            "jAsImlhdCI6MTU0NzQzMTgzNC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29u"
+            "bmVjdC5nb3V2LmZyIiwic3ViIjoiMTIzIiwibm9uY2UiOiJ0ZXN0X25vbmNl"
+            "In0.xKAPSsCaTVN29-PeC11j6XMSJnzrT44-OLZ7Nlt7jtE&state=test_state"
             "&post_logout_redirect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)
@@ -256,14 +257,15 @@ class FCCallback(TestCase):
         self.assertEqual(connection.usager.given_name, "Joséphine")
 
         url = (
-            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?id_token_hint=ey"
-            "J0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMTEyODY0MzNlMzljY2UwMWRiND"
-            "Q4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ"
-            "3NDM2MDk0LjAsImlhdCI6MTU0NzQzNDg5NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmVj"
-            "dC5nb3V2LmZyIiwic3ViIjoiOWI3NTQ3ODI3MDVjNTVlYmZlMTAzNzFjOTA5ZjYyZTczYTNlM"
-            "DlmYjU2NmZjNWQyMzA0MGEyOWZhZTRlMGViYiIsIm5vbmNlIjoidGVzdF9ub25jZSJ9.J8048"
-            "J_B5MgwQkLzX28yXTDFPB4mTeoyUGW9RSW5YZ4&state=test_state&post_logout_redi"
-            "rect_uri=http://localhost:3000/logout-callback"
+            "https://fcp.integ01.dev-franceconnect.fr/api/v1/logout?"
+            "id_token_hint=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiIyMT"
+            "EyODY0MzNlMzljY2UwMWRiNDQ4ZDgwMTgxYmRmZDAwNTU1NGIxOWNkNTFiM2ZlNzk"
+            "0M2Y2YjNiODZhYjZlIiwiZXhwIjoxNTQ3NDMzMDM0LjAsImlhdCI6MTU0NzQzMTgz"
+            "NC4wLCJpc3MiOiJodHRwOi8vZnJhbmNlY29ubmVjdC5nb3V2LmZyIiwic3ViIjoiO"
+            "WI3NTQ3ODI3MDVjNTVlYmZlMTAzNzFjOTA5ZjYyZTczYTNlMDlmYjU2NmZjNWQyMz"
+            "A0MGEyOWZhZTRlMGViYiIsIm5vbmNlIjoidGVzdF9ub25jZSJ9.HjK5vaK2zrzmSN"
+            "zB103TN7ft0t_RX-C5vdupICFccc0&state=test_state"
+            "&post_logout_redirect_uri=http://localhost:3000/logout-callback"
         )
         self.assertRedirects(response, url, fetch_redirect_response=False)
 

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_revoke.py
@@ -1,12 +1,11 @@
-import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve
 from django.utils import timezone
 
-import pytz
+from pytz import timezone as pytz_timezone
 
 from aidants_connect import settings
 from aidants_connect_web.models import Autorisation, Mandat
@@ -293,8 +292,8 @@ class MandatCancellationAttestationTests(TestCase):
         cls.valid_mandat = MandatFactory(
             organisation=cls.our_organisation,
             usager=cls.our_usager,
-            creation_date=datetime.datetime(
-                2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
+            creation_date=pytz_timezone("Europe/Paris").localize(
+                datetime(2021, 2, 1, 13, 12)
             ),
         )
         cls.valid_autorisation = AutorisationFactory(
@@ -304,8 +303,8 @@ class MandatCancellationAttestationTests(TestCase):
         cls.cancelled_mandat = MandatFactory(
             organisation=cls.our_organisation,
             usager=cls.our_usager,
-            creation_date=datetime.datetime(
-                2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
+            creation_date=pytz_timezone("Europe/Paris").localize(
+                datetime(2021, 2, 1, 13, 12)
             ),
         )
         AutorisationFactory(
@@ -317,8 +316,8 @@ class MandatCancellationAttestationTests(TestCase):
         cls.expired_mandat = MandatFactory(
             organisation=cls.our_organisation,
             usager=cls.our_usager,
-            creation_date=datetime.datetime(
-                2021, 2, 1, 13, 12, tzinfo=pytz.timezone("Europe/Paris")
+            creation_date=pytz_timezone("Europe/Paris").localize(
+                datetime(2021, 2, 1, 13, 12)
             ),
             expiration_date=timezone.now() - timedelta(minutes=5),
         )

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -68,8 +68,8 @@ class AuthorizeTests(TestCase):
             mandat=mandat_3,
             demarche="Logement",
         )
-        date_further_away_minus_one_hour = datetime(
-            2019, 1, 9, 8, tzinfo=pytz_timezone("Europe/Paris")
+        date_further_away_minus_one_hour = pytz_timezone("Europe/Paris").localize(
+            datetime(2019, 1, 9, 8)
         )
         cls.connection = Connection.objects.create(
             state="test_expiration_date_triggered",
@@ -217,7 +217,7 @@ class AuthorizeTests(TestCase):
         url = reverse("fi_select_demarche") + "?connection_id=" + str(connection.id)
         self.assertRedirects(response, url, fetch_redirect_response=False)
 
-    date_further_away = datetime(2019, 1, 9, 9, tzinfo=pytz_timezone("Europe/Paris"))
+    date_further_away = pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 9, 9))
 
     @freeze_time(date_further_away)
     def test_post_to_authorize_with_expired_connection_triggers_connection_timeout(
@@ -254,8 +254,8 @@ class FISelectDemarcheTests(TestCase):
             nonce="avalidnonce456",
             usager=cls.usager,
         )
-        date_further_away_minus_one_hour = datetime(
-            2019, 1, 9, 8, tzinfo=pytz_timezone("Europe/Paris")
+        date_further_away_minus_one_hour = pytz_timezone("Europe/Paris").localize(
+            datetime(2019, 1, 9, 8)
         )
         cls.connection_2 = Connection.objects.create(
             state="test_expiration_date_triggered",
@@ -263,8 +263,8 @@ class FISelectDemarcheTests(TestCase):
             usager=cls.usager,
             expires_on=date_further_away_minus_one_hour,
         )
-        mandat_creation_date = datetime(
-            2019, 1, 5, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
+        mandat_creation_date = pytz_timezone("Europe/Paris").localize(
+            datetime(2019, 1, 5, 3, 20, 34, 0)
         )
 
         cls.mandat_thierry_usager_1 = MandatFactory(
@@ -307,7 +307,7 @@ class FISelectDemarcheTests(TestCase):
             response, "aidants_connect_web/id_provider/fi_select_demarche.html"
         )
 
-    date_close = datetime(2019, 1, 6, 9, tzinfo=pytz_timezone("Europe/Paris"))
+    date_close = pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 6, 9))
 
     @freeze_time(date_close)
     def test_get_demarches_for_one_usager_and_two_autorisations(self):
@@ -340,7 +340,7 @@ class FISelectDemarcheTests(TestCase):
         )
         self.assertEqual(response.status_code, 302)
 
-    date_further_away = datetime(2019, 1, 9, 9, tzinfo=pytz_timezone("Europe/Paris"))
+    date_further_away = pytz_timezone("Europe/Paris").localize(datetime(2019, 1, 9, 9))
 
     @freeze_time(date_further_away)
     def test_expired_autorisation_does_not_appear(self):
@@ -411,8 +411,8 @@ class TokenTests(TestCase):
         cls.connection.code = cls.code_hash
         cls.connection.nonce = "avalidnonce456"
         cls.connection.usager = cls.usager
-        cls.connection.expires_on = datetime(
-            2012, 1, 14, 3, 21, 34, tzinfo=pytz_timezone("Europe/Paris")
+        cls.connection.expires_on = pytz_timezone("Europe/Paris").localize(
+            datetime(2012, 1, 14, 3, 21, 34)
         )
         cls.connection.save()
         cls.fc_request = {
@@ -427,7 +427,7 @@ class TokenTests(TestCase):
         found = resolve("/token/")
         self.assertEqual(found.func, id_provider.token)
 
-    date = datetime(2012, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
+    date = pytz_timezone("Europe/Paris").localize(datetime(2012, 1, 14, 3, 20, 34, 0))
 
     @freeze_time(date)
     @mock.patch(
@@ -435,7 +435,7 @@ class TokenTests(TestCase):
         return_value="5ieq7Bg173y99tT6MA",
     )
     def test_correct_info_triggers_200(self, _):
-
+        self.maxDiff = None
         response = self.client.post("/token/", self.fc_request)
 
         response_content = response.content.decode("utf-8")
@@ -449,14 +449,14 @@ class TokenTests(TestCase):
             "access_token": connection.access_token,
             "expires_in": 3600,
             "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJ0ZXN0X2NsaWVu"
-            "dF9pZCIsImV4cCI6MTMyNjUxMDk5NCwiaWF0IjoxMzI2NTEwNjk0LCJpc3MiOiJsb2NhbGhvc"
-            "3QiLCJzdWIiOiJhdmFsaWRzdWI3ODkiLCJub25jZSI6ImF2YWxpZG5vbmNlNDU2In0.a7nbGA"
-            "-Ib9I1HaMb5iC9s4fDP1ZbIXUJpU-YbdYFcWA",
+            "dF9pZCIsImV4cCI6MTMyNjUwNzkzNCwiaWF0IjoxMzI2NTA3NjM0LCJpc3MiOiJsb2NhbGhvc"
+            "3QiLCJzdWIiOiJhdmFsaWRzdWI3ODkiLCJub25jZSI6ImF2YWxpZG5vbmNlNDU2In0.HnXqpp"
+            "IwykH_7GJgmFCT8Lt119qQyygiKk6W-WSXVCU",
             "refresh_token": "5ieq7bg173y99tt6ma",
             "token_type": "Bearer",
         }
 
-        self.assertEqual(response_json, awaited_response)
+        self.assertEqual(awaited_response, response_json)
 
     def test_wrong_grant_type_triggers_403(self):
         fc_request = dict(self.fc_request)
@@ -548,8 +548,8 @@ class UserInfoTests(TestCase):
             nonce="avalidnonde456",
             usager=cls.usager,
             access_token=cls.access_token_hash,
-            expires_on=datetime(
-                2012, 1, 14, 3, 21, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
+            expires_on=pytz_timezone("Europe/Paris").localize(
+                datetime(2012, 1, 14, 3, 21, 34, 0)
             ),
             aidant=cls.aidant_thierry,
             organisation=cls.aidant_thierry.organisation,
@@ -560,11 +560,10 @@ class UserInfoTests(TestCase):
         found = resolve("/userinfo/")
         self.assertEqual(found.func, id_provider.user_info)
 
-    date = datetime(2012, 1, 14, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
+    date = pytz_timezone("Europe/Paris").localize(datetime(2012, 1, 14, 3, 20, 34, 0))
 
     @freeze_time(date)
     def test_well_formatted_access_token_returns_200(self):
-
         response = self.client.get(
             "/userinfo/", **{"HTTP_AUTHORIZATION": f"Bearer {self.access_token}"}
         )
@@ -588,7 +587,6 @@ class UserInfoTests(TestCase):
 
     @freeze_time(date)
     def test_autorisation_use_triggers_journal_entry(self):
-
         self.client.get(
             "/userinfo/", **{"HTTP_AUTHORIZATION": f"Bearer {self.access_token}"}
         )
@@ -664,8 +662,8 @@ class EndSessionEndpointTests(TestCase):
             nonce="avalidnonde456",
             usager=cls.usager,
             access_token=cls.access_token_hash,
-            expires_on=datetime(
-                2012, 1, 14, 3, 21, 34, 0, tzinfo=pytz_timezone("Europe/Paris")
+            expires_on=pytz_timezone("Europe/Paris").localize(
+                datetime(2012, 1, 14, 3, 21, 34, 0)
             ),
             aidant=cls.aidant_thierry,
             organisation=cls.aidant_thierry.organisation,

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -613,7 +613,7 @@ class GenerateAttestationTests(TestCase):
         self.assertTemplateUsed(response, "aidants_connect_web/attestation.html")
 
     @freeze_time(
-        datetime(2020, 7, 18, 3, 20, 34, 0, tzinfo=pytz_timezone("Europe/Paris"))
+        pytz_timezone("Europe/Paris").localize(datetime(2020, 7, 18, 3, 20, 34, 0))
     )
     def test_attestation_contains_text(self):
         self.client.force_login(self.aidant_thierry)


### PR DESCRIPTION
## 🌮 Objectif

En tentant de passer de  à [`zoneinfo`](https://docs.python.org/3/library/zoneinfo.html) qui remplace `pytz` dans Python 3.9, je me suis rendu compte que nous n'utilisions pas `pytz` correctement. En effet, [la documentation spécifie](https://pythonhosted.org/pytz/#localized-times-and-date-arithmetic) :

> Unfortunately using the tzinfo argument of the standard datetime constructors [c'est-à-dire l'argument `tzinfo`] does not work with pytz for many timezones.

Dans notre cas — et pour une raison très étrange — `datetime(…, tzinfo=pytz.timezone("Europe/Paris"))` ou `datetime(…).replace(tzinfo=pytz.timezone("Europe/Paris"))` produisent l'utilisation d'[une timezone qui n'a plus cours en France depuis 1911 (la Saint-Pierre & Miquelon Standard Time pou PMT](https://www.timeanddate.com/time/change/france/paris?year=1911)). Lors de ce changement, toutes les horloges ont reculé de 9 minutes.

Pour la plupart des utilisations, ça ne pose pas de problème parce qu'on utilise `pytz` presque uniquement pour fixer le temps avec `freezegun` dans les tests.  À part [pour une tâche Celery qui met à jour les enregistrements `HabilitationRequest`](https://github.com/betagouv/Aidants_Connect/compare/fix-pytz-usage#diff-6c74126987324ba35aa14989a2774527e0e31ca87c55dd2a4aca1cb79c5eee61R28-R30). Du coup, tous les champs `HabilitationRequest.date_test_pix` sont retardés de 9 minutes.
