### PR TITLE
Forçage des emails en minuscule

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -148,7 +148,12 @@ class AddressValidatableMixin(Form):
         raise NotImplementedError()
 
 
-class IssuerForm(PatchedErrorListForm):
+class CleanEmailMixin:
+    def clean_email(self):
+        return self.cleaned_data["email"].lower()
+
+
+class IssuerForm(PatchedErrorListForm, CleanEmailMixin):
     phone = AcPhoneNumberField(
         initial="",
         label="Téléphone",
@@ -351,7 +356,7 @@ class OrganisationRequestForm(PatchedErrorListForm, AddressValidatableMixin):
         widgets = {"address": TextInput}
 
 
-class PersonWithResponsibilitiesForm(PatchedErrorListForm):
+class PersonWithResponsibilitiesForm(PatchedErrorListForm, CleanEmailMixin):
     phone = AcPhoneNumberField(
         initial="",
         region=settings.PHONENUMBER_DEFAULT_REGION,
@@ -439,13 +444,13 @@ class EmailOrganisationValidationError(ValidationError):
         )
 
 
-class AidantRequestForm(PatchedErrorListForm):
+class AidantRequestForm(PatchedErrorListForm, CleanEmailMixin):
     def __init__(self, organisation: OrganisationRequest, **kwargs):
         self.organisation = organisation
         super().__init__(**kwargs)
 
     def clean_email(self):
-        email = self.cleaned_data["email"]
+        email = super().clean_email()
         # If self.instance is defined, se are modfiying an existing instance
         # not creating a new one
         if (not self.instance or not self.instance.pk) and AidantRequest.objects.filter(

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -61,6 +61,13 @@ class Person(models.Model):
     def __str__(self):
         return f"{self.first_name} {self.last_name}"
 
+    def save(
+        self, force_insert=False, force_update=False, using=None, update_fields=None
+    ):
+        if self.email:
+            self.email = self.email.lower()
+        super().save(force_insert, force_update, using, update_fields)
+
     def get_full_name(self):
         return str(self)
 

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -42,6 +42,15 @@ class TestIssuerForm(TestCase):
 
         self.assertTrue(form.is_valid())
 
+    def test_email_lower(self):
+        form = get_form(
+            IssuerForm,
+            email="TEST@TEST.TEST",
+        )
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual("test@test.test", form.cleaned_data["email"])
+
 
 class TestOrganisationRequestForm(TestCase):
     def test_clean_type_passes(self):
@@ -360,9 +369,8 @@ class TestValidationFormForm(TestCase):
 class TestManagerForm(TestCase):
     def test_clean_type_zipcode_number_passes(self):
         form = get_form(
-            OrganisationRequestForm,
+            ManagerForm,
             ignore_errors=True,
-            type_id=RequestOriginConstants.OTHER.value,
             zipcode="01700",
         )
 
@@ -371,9 +379,8 @@ class TestManagerForm(TestCase):
 
     def test_clean_type_zipcode_not_number_raises_error(self):
         form = get_form(
-            OrganisationRequestForm,
+            ManagerForm,
             ignore_errors=True,
-            type_id=RequestOriginConstants.OTHER.value,
             zipcode="La Commune",
         )
 
@@ -381,6 +388,12 @@ class TestManagerForm(TestCase):
         self.assertEqual(
             form.errors["zipcode"], ["Veuillez entrer un code postal valide"]
         )
+
+    def test_email_lower(self):
+        form = get_form(ManagerForm, email="TEST@TEST.TEST")
+
+        self.assertTrue(form.is_valid())
+        self.assertEqual("test@test.test", form.cleaned_data["email"])
 
 
 class TestBaseAidantRequestFormSet(TestCase):

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY, Mock, patch
 
 from django.core import mail
 from django.db import IntegrityError
+from django.forms import model_to_dict
 from django.http import HttpRequest
 from django.test import TestCase, override_settings, tag
 from django.utils.timezone import now
@@ -15,8 +16,10 @@ from aidants_connect.common.constants import (
     RequestStatusConstants,
 )
 from aidants_connect_habilitation.models import (
+    AidantRequest,
     Issuer,
     IssuerEmailConfirmation,
+    Manager,
     OrganisationRequest,
 )
 from aidants_connect_habilitation.tests.factories import (
@@ -436,3 +439,25 @@ class TestIssuerEmailConfirmation(TestCase):
             message=ANY,
             html_message=ANY,
         )
+
+
+class TestIssuer(TestCase):
+    def test_email_lower(self):
+        data = model_to_dict(IssuerFactory.build(email="TEST@TEST.TEST"))
+        issuer = Issuer.objects.create(**data)
+        self.assertEqual("test@test.test", issuer.email)
+
+
+class TestManager(TestCase):
+    def test_email_lower(self):
+        data = model_to_dict(ManagerFactory.build(email="TEST@TEST.TEST"))
+        issuer = Manager.objects.create(**data)
+        self.assertEqual("test@test.test", issuer.email)
+
+
+class TestAidantRequest(TestCase):
+    def test_email_lower(self):
+        orga = OrganisationRequestFactory()
+        data = model_to_dict(AidantRequestFactory.build(email="TEST@TEST.TEST"))
+        issuer = AidantRequest.objects.create(**{**data, "organisation": orga})
+        self.assertEqual("test@test.test", issuer.email)


### PR DESCRIPTION
## 🌮 Objectif

Forçage des emails en minuscule

## 🔍 Implémentation

- surcharge de la méthode `save()` des modèles qui contiennent des champ email pour passer les emails en minuscule
- ajout d'une méthode `clean_email()` sur les formulaires pour passer les emails en minuscule
