### PR TITLE
Parallélisation des tests Django

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           name: run unit tests
           command: |
             . venv/bin/activate
-            coverage run manage.py test
+            coverage run manage.py test --parallel
       - run:
           name: coverage report
           command: |


### PR DESCRIPTION
## 🌮 Objectif

Il est possible de lancer les tests Django en parallèle et ça améliore de beaucoup le temps d'exécution (du moins en local…) : https://docs.djangoproject.com/fr/3.2/topics/testing/overview/#speeding-up-the-tests

Bien sûr, il faut que les tests soient isolés.