### PR TITLE
Ajout de colonnes et de champs de recherche dans l'admin django

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -53,6 +53,13 @@ class IssuerAdmin(VisibleToAdminMetier, ModelAdmin):
         "phone",
         "email_verified",
     )
+    search_fields = (
+        "email",
+        "last_name",
+        "first_name",
+    )
+
+    list_filter = ("email_verified",)
     readonly_fields = ("issuer_id",)
     inlines = (OrganisationRequestInline,)
     actions = ["resend_confirmation_emails"]
@@ -111,6 +118,13 @@ class ManagerAdmin(VisibleToAdminMetier, ModelAdmin):
         "organisation",
         "zipcode",
     )
+    search_fields = (
+        "email",
+        "last_name",
+        "first_name",
+    )
+
+    list_filter = ("is_aidant",)
 
 
 class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -63,12 +63,25 @@ from aidants_connect_web.models import (
 logger = logging.getLogger()
 
 
+def get_email_user_for_device(obj):
+    try:
+        return obj.user.email
+    except Exception:
+        pass
+    try:
+        return obj.aidant.email
+    except Exception:
+        pass
+    return None
+
+
 class StaticDeviceStaffAdmin(VisibleToAdminMetier, StaticDeviceAdmin):
-    pass
+    list_display = ("name", "user", get_email_user_for_device)
+    search_fields = ("name", "user__username", "user__email")
 
 
 class TOTPDeviceStaffAdmin(VisibleToAdminMetier, TOTPDeviceAdmin):
-    pass
+    search_fields = ("name", "user__username", "user__email")
 
 
 class SpecificDeleteActionsMixin:
@@ -1360,8 +1373,8 @@ class CarteTOTPAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
 
     totp_devices_diagnostic.short_description = "Diagnostic Carte/TOTP Device"
 
-    list_display = ("serial_number", "aidant")
-    search_fields = ("serial_number",)
+    list_display = ("serial_number", "aidant", get_email_user_for_device)
+    search_fields = ("serial_number", "aidant__email")
     raw_id_fields = ("aidant",)
     readonly_fields = ("totp_devices_diagnostic",)
     ordering = ("-created_at",)


### PR DESCRIPTION
## 🌮 Objectif

Simplifier certaines tâches de recherche en ajoutant des colonnes et des champs de recherche dans l'admin

## 🔍 Implémentation

Modification des admins

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
