### PR TITLE
Consentement par SMS partie 2.1 : un petit oubli

### DIFF
--- a/aidants_connect_common/forms.py
+++ b/aidants_connect_common/forms.py
@@ -32,10 +32,6 @@ class PatchedModelForm(ModelForm, WidgetAttrMixin):
 
         super().__init__(*sig.args, **sig.kwargs)
 
-    def widget_attrs(self, widget_name: str, attrs: dict):
-        for attr_name, attr_value in attrs.items():
-            self.fields[widget_name].widget.attrs[attr_name] = attr_value
-
 
 class PatchedForm(Form, WidgetAttrMixin):
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## 🌮 Objectif

La méthode `widget_attrs` fait maintenant partie de `WidgetAttrMixin` il n'y a pas besoin de la garder dans `PatchedModelForm`.
