### PR TITLE
Consentement par SMS partie 3 : custom `ChoiceEnum`

### DIFF
--- a/aidants_connect_common/tests/test_constants.py
+++ b/aidants_connect_common/tests/test_constants.py
@@ -1,0 +1,91 @@
+from django.test import TestCase
+
+from aidants_connect_common.utils.constants import DictChoices, TextChoicesEnum
+
+
+class TestChoicesMeta(TestCase):
+    def test_DictChoices_with_simple_declaration(self):
+        class TestDictChoices(DictChoices):
+            TEST_1 = {
+                "label": "Test 1",
+                "description": "This is a test",
+            }
+            TEST_2 = {
+                "label": "Test 2",
+                "description": "This is also a test",
+            }
+
+            @staticmethod
+            def _human_readable_name(enum_item):
+                return enum_item.label["description"]
+
+        values, labels = zip(*TestDictChoices.choices)
+        self.assertSequenceEqual(["TEST_1", "TEST_2"], values)
+        self.assertSequenceEqual(
+            [
+                {"label": "Test 1", "description": "This is a test"},
+                {"label": "Test 2", "description": "This is also a test"},
+            ],
+            labels,
+        )
+        values, labels = zip(*TestDictChoices.model_choices)
+        self.assertSequenceEqual(["TEST_1", "TEST_2"], values)
+        self.assertSequenceEqual(["This is a test", "This is also a test"], labels)
+
+    def test_DictChoices_with_labels_declaration(self):
+        class TestDictChoices(DictChoices):
+            TEST_1 = (
+                "TEST_VALUE_1",
+                {
+                    "label": "Test 1",
+                    "description": "This is a test",
+                },
+            )
+            TEST_2 = (
+                "TEST_VALUE_2",
+                {
+                    "label": "Test 2",
+                    "description": "This is also a test",
+                },
+            )
+
+            @staticmethod
+            def _human_readable_name(enum_item):
+                return enum_item.label["description"]
+
+        values, labels = zip(*TestDictChoices.choices)
+        self.assertSequenceEqual(["TEST_VALUE_1", "TEST_VALUE_2"], values)
+        self.assertSequenceEqual(
+            [
+                {"label": "Test 1", "description": "This is a test"},
+                {"label": "Test 2", "description": "This is also a test"},
+            ],
+            labels,
+        )
+        values, labels = zip(*TestDictChoices.model_choices)
+        self.assertSequenceEqual(["TEST_1", "TEST_2"], values)
+        self.assertSequenceEqual(["This is a test", "This is also a test"], labels)
+
+    def test_TextChoicesEnum_with_simple_declaration(self):
+        class TestTextChoicesEnum(TextChoicesEnum):
+            TEST_1 = "Test 1"
+            TEST_2 = "Test 2"
+
+        values, labels = zip(*TestTextChoicesEnum.choices)
+        self.assertSequenceEqual(["TEST_1", "TEST_2"], values)
+        self.assertSequenceEqual(
+            ["Test 1", "Test 2"],
+            labels,
+        )
+
+    def test_TextChoicesEnum_with_labels_declaration(self):
+        class TestTextChoicesEnum(TextChoicesEnum):
+            TEST_1 = ("TEST_VALUE_1", "Test 1")
+            TEST_2 = ("TEST_VALUE_2", "Test 2")
+
+        values, labels = zip(*TestTextChoicesEnum.choices)
+        self.assertSequenceEqual(["TEST_VALUE_1", "TEST_VALUE_2"], values)
+        self.assertSequenceEqual(
+            ["Test 1", "Test 2"],
+            labels,
+        )

--- a/aidants_connect_common/utils/constants.py
+++ b/aidants_connect_common/utils/constants.py
@@ -1,12 +1,15 @@
+import enum
 from datetime import date, timedelta
-from enum import Enum, unique
-from typing import Any, Iterable, Tuple
+from typing import List, Tuple
 
 from django.conf import settings
-from django.db.models import IntegerChoices, TextChoices
+from django.db.models import Choices, IntegerChoices, TextChoices
+from django.db.models.enums import ChoicesMeta as DjangoChoicesMeta
+from django.utils.functional import Promise
 from django.utils.timezone import now
 
 __all__ = [
+    "DictChoices",
     "JournalActionKeywords",
     "JOURNAL_ACTIONS",
     "AuthorizationDurations",
@@ -15,6 +18,67 @@ __all__ = [
     "RequestStatusConstants",
     "MessageStakeholders",
 ]
+
+
+class ChoicesMeta(DjangoChoicesMeta):
+    def __new__(metacls, classname, bases, classdict, **kwds):
+        """This is a 1:1 copy of Django's models.enums.ChoicesMeta
+        but allowing dict as enum value and using enum labels rather
+        that weird computation on enum names"""
+        labels = []
+        for key in classdict._member_names:
+            value = classdict[key]
+            if not (
+                isinstance(value, (list, tuple))
+                and len(value) > 1
+                and isinstance(value[-1], (Promise, str, dict))
+            ):
+                value = (key, value)
+            *value, label = value
+            value = tuple(value)
+
+            labels.append(label)
+            # Use dict.__setitem__() to suppress defenses against double
+            # assignment in enum's classdict.
+            dict.__setitem__(classdict, key, value)
+        cls = super(DjangoChoicesMeta, metacls).__new__(
+            metacls, classname, bases, classdict, **kwds
+        )
+        for member, label in zip(cls.__members__.values(), labels):
+            member._label_ = label
+            # Unpack enum.value if Enum kept it a tuple during creation
+            if isinstance(member._value_, tuple):
+                member._value_, *_ = member._value_
+        return enum.unique(cls)
+
+
+class DictChoicesMeta(ChoicesMeta):
+    @property
+    def model_choices(cls) -> List[Tuple]:
+        empty = [(None, "__empty__")] if hasattr(cls, "__empty__") else []
+        return empty + [(item.name, item._human_readable_name(item)) for item in cls]
+
+
+class ChoicesEnum(Choices, metaclass=ChoicesMeta):
+    pass
+
+
+class TextChoicesEnum(str, ChoicesEnum):
+    pass
+
+
+class DictChoices(Choices, metaclass=DictChoicesMeta):
+    """Use for Enums that have dictionnaries as values
+
+    Provide a .model_choices property to use in models.Model
+    classes fields
+    """
+
+    @staticmethod
+    def _human_readable_name(enum_item):
+        """Implement this to return a human readable string from
+        an enum value for the models.Model field"""
+        raise NotImplementedError()
 
 
 class JournalActionKeywords:
@@ -135,21 +199,6 @@ class AuthorizationDurationChoices(TextChoices):
     )
 
 
-class ChoiceEnum(Enum):
-    @classmethod
-    def choices(cls) -> Iterable[Tuple[Any, Any]]:
-        return ((item.name, item.value) for item in cls)
-
-    @classmethod
-    def labels(cls):
-        return [label for _, label in cls.choices()]
-
-    @classmethod
-    def values(cls):
-        return [value for value, _ in cls.choices()]
-
-
-@unique
 class RequestOriginConstants(IntegerChoices):
     FRANCE_SERVICE = (1, "France Services/MSAP")
     CCAS = (2, "CCAS")
@@ -171,8 +220,7 @@ class RequestOriginConstants(IntegerChoices):
     OTHER = (12, "Autre")
 
 
-@unique
-class RequestStatusConstants(ChoiceEnum):
+class RequestStatusConstants(TextChoicesEnum):
     NEW = "Brouillon"
     AC_VALIDATION_PROCESSING = "En attente de validation par Aidants Connect"
     VALIDATED = "Validée"
@@ -182,7 +230,6 @@ class RequestStatusConstants(ChoiceEnum):
     CHANGES_PROPOSED = "Modifications proposées par Aidants Connect"
 
 
-@unique
-class MessageStakeholders(ChoiceEnum):
+class MessageStakeholders(TextChoicesEnum):
     AC = "Aidants Connect"
     ISSUER = "Demandeur"

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -229,7 +229,7 @@ class OrganisationRequest(models.Model):
         "État",
         max_length=150,
         default=RequestStatusConstants.NEW.name,
-        choices=RequestStatusConstants.choices(),
+        choices=RequestStatusConstants.choices,
     )
 
     type = models.ForeignKey(OrganisationType, null=True, on_delete=SET_NULL)
@@ -573,7 +573,7 @@ class RequestMessage(models.Model):
     )
 
     sender = models.CharField(
-        "Expéditeur", max_length=20, choices=MessageStakeholders.choices()
+        "Expéditeur", max_length=20, choices=MessageStakeholders.choices
     )
     content = models.TextField("Message")
 

--- a/aidants_connect_habilitation/tests/test_functionnal/test_admin.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_admin.py
@@ -42,7 +42,7 @@ class OrganisationRequestAdminTests(FunctionalTestCase):
 
         # Filter by status
         self.selenium.find_element(
-            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+            By.CSS_SELECTOR, f'[title="{organisation_status.label}"]'
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
@@ -126,7 +126,7 @@ class OrganisationRequestAdminTests(FunctionalTestCase):
 
         # Filter by status
         self.selenium.find_element(
-            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+            By.CSS_SELECTOR, f'[title="{organisation_status.label}"]'
         ).click()
 
         WebDriverWait(self.selenium, 10).until(
@@ -210,7 +210,7 @@ class OrganisationRequestAdminTests(FunctionalTestCase):
 
         # Filter by status
         self.selenium.find_element(
-            By.CSS_SELECTOR, f'[title="{organisation_status.value}"'
+            By.CSS_SELECTOR, f'[title="{organisation_status.label}"]'
         ).click()
 
         WebDriverWait(self.selenium, 10).until(

--- a/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
@@ -23,9 +23,7 @@ class AddAidantsRequestViewTests(FunctionalTestCase):
             RequestStatusConstants.VALIDATED.name,
         }
 
-        unauthorized_statuses = (
-            set(RequestStatusConstants.values()) - authorized_statuses
-        )
+        unauthorized_statuses = set(RequestStatusConstants.values) - authorized_statuses
 
         for status in unauthorized_statuses:
             organisation: OrganisationRequest = OrganisationRequestFactory(

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -1192,7 +1192,7 @@ class AddAidantsRequestViewTests(TestCase):
         cls.pattern_name = "habilitation_organisation_add_aidants"
 
     def test_redirects_on_unauthorized_request_status(self):
-        unauthorized_statuses = set(RequestStatusConstants.values()) - {
+        unauthorized_statuses = set(RequestStatusConstants.values) - {
             RequestStatusConstants.NEW.name,
             RequestStatusConstants.AC_VALIDATION_PROCESSING.name,
             RequestStatusConstants.VALIDATED.name,


### PR DESCRIPTION
## 🌮 Objectif

Cette PR pourrait être un peu controversée, en particulier à cause du code de métaprogrammation Python qui pourrait être difficile à comprendre et à maintenir pour des futurs devs Python un peu junior. Elle introduit concrètement une réécriture de la classe `ChoicesMeta`  de Django pour permettre l'utilisation de dictionnaires comme valeurs dans les énumérations. L'enjeu est de permettre de créer des widgets plus complexes comme [le bouton de démarches qui présente une icône, in titre et une description](https://github.com/betagouv/Aidants_Connect/blob/main/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html#L90-L114) et regrouper toutes ces informations dans l'enum.

Cette nouvelle implémentation corrige aussi un choix de design de la classe `Choices` que j'ai troujours trouvé discutable qui est que le label (le texte pour les humains) est optionnel. S'il n'est pas renseigné (si la valeur de l'enum n'est pas un tuple) il est auto-calculé à partir du nom de la variable de l'enum ce qui ne fonctionne qu'avec l'anglais. Ça ne correspond pas du tout à la manière dont nous utilisons habituellement les enums qui est de mettre le texte pour les humains comme valeur et ça oblige à toujours utiliser la notation tuple.