### PR TITLE
Corriger les infractions du script Matomo aux règles CSP

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -405,7 +405,7 @@ STIMULUS_JS_URL = "https://unpkg.com/stimulus@2.0.0/dist/stimulus.umd.js"
 
 # Content security policy
 CSP_DEFAULT_SRC = ("'self'",)
-CSP_CONNECT_SRC = ("'self'",)
+CSP_CONNECT_SRC = ("'self'", "https://stats.data.gouv.fr/matomo.php")
 CSP_IMG_SRC = (
     "'self'",
     "https://www.service-public.fr/resources/v-5cf79a7acf/web/css/img/png/",
@@ -420,6 +420,7 @@ CSP_SCRIPT_SRC = (
     "'sha256-oOHki3o/lOkQD0J+jC75068TFqQoV40dYK6wrkIXI1c='",  # statistiques.html
     "https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.0.0/chartjs-plugin-datalabels.min.js",
     "'sha256-CO4GFu3p1QNoCvjdyc+zNsVh77XOc5H2OcZYFb8YUPA='",  # home_page.html
+    "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js",
 )
 
 CSP_STYLE_SRC = ("'self'",)

--- a/aidants_connect_common/static/js/matomo-init.js
+++ b/aidants_connect_common/static/js/matomo-init.js
@@ -1,0 +1,16 @@
+(function () {
+    const matomoUrl = document.querySelector("#matomo-script").dataset.matomoUrl;
+    const matomoSiteId = document.querySelector("#matomo-script").dataset.matomoSiteId;
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["trackPageView"]);
+    _paq.push(["enableLinkTracking"]);
+    (function () {
+        _paq.push(["setTrackerUrl", matomoUrl + "matomo.php"]);
+        _paq.push(["setSiteId", matomoSiteId]);
+        var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0];
+        g.async = true;
+        g.src = "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js";
+        s.parentNode.insertBefore(g, s);
+    })();
+})();

--- a/aidants_connect_common/templates/layouts/matomo_script.html
+++ b/aidants_connect_common/templates/layouts/matomo_script.html
@@ -1,17 +1,10 @@
+{% load static %}
 {% if MATOMO_INSTANCE_URL and MATOMO_INSTANCE_SITE_ID %}
-  <script>
-      var _paq = window._paq = window._paq || [];
-      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-      _paq.push(["trackPageView"]);
-      _paq.push(["enableLinkTracking"]);
-      (function () {
-          var u = "{{ MATOMO_INSTANCE_URL }}";
-          _paq.push(["setTrackerUrl", u + "matomo.php"]);
-          _paq.push(["setSiteId", "{{ MATOMO_INSTANCE_SITE_ID }}"]);
-          var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0];
-          g.async = true;
-          g.src = "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js";
-          s.parentNode.insertBefore(g, s);
-      })();
-  </script>
+  <script
+    id="matomo-script"
+    defer
+    src="{% static 'js/matomo-init.js' %}"
+    data-matomo-url="{{ MATOMO_INSTANCE_URL }}"
+    data-matomo-site-id="{{ MATOMO_INSTANCE_SITE_ID }}"
+  ></script>
 {% endif %}


### PR DESCRIPTION
## 🌮 Objectif

En allant sur la prod, je me suit rendu compte que la console de Firefox affichait des erreurs de CSP liées à Matomo, ce qui explique les faibles statistiques qu'on a depuis cet été et la prééminence d'IE11 dans celles-ci. Cette PR corrige les infractions du script Matomo aux règles CSP.