### PR TITLE
Correction du hash du script en ligne dans `main.html` et autorisation des images en base64 dans le CSP

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -408,12 +408,13 @@ CSP_DEFAULT_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'", "https://stats.data.gouv.fr/matomo.php")
 CSP_IMG_SRC = (
     "'self'",
+    "data:",
     "https://www.service-public.fr/resources/v-5cf79a7acf/web/css/img/png/",
 )
 CSP_SCRIPT_SRC = (
     "'self'",
     STIMULUS_JS_URL,
-    "'sha256-p0nVvBQQOY8PrKj8/JWPCKOJU8Iso8I6LIVer817o64='",  # main.html
+    "'sha256-+iP5od5k5h6dnQJ5XGJGipIf2K6VdSrIwATxnixVR8s='",  # main.html
     "'sha256-ARvyo8AJ91wUvPfVqP2FfHuIHZJN3xaLI7Vgj2tQx18='",  # wait.html
     "'sha256-mXH/smf1qtriC8hr62Qt2dvp/StB/Ixr4xmBRvkCz0U='",  # main-habilitation.html
     "https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js",


### PR DESCRIPTION
## 🌮 Objectif

#715 a modifié le script qui permet d'ajouter les polyfills pour IE11. Rien de grave à part des erreurs dans la console pour les autres navigateurs mais c'est laid. Cette PR corrige ce problème. Il modifie aussi `aidants_connect.settings.CSP_IMG_SRC` pour autorisation des images déclarées en ligne en base64 dans le CSP.