### PR TITLE
Gestion des erreurs sur le formulaire de recherche utilisateur

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -424,7 +424,6 @@ CSP_SCRIPT_SRC = (
     "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js",
     "https://code.jquery.com/jquery-3.6.1.js",
     "https://code.jquery.com/ui/1.13.1/jquery-ui.js",
-    "'sha256-cFyvsDuA3AcV8Zc3M5E7whbtucLdPz2NtUjdlLeuz+c='",  # authorize.html
 )
 
 CSP_STYLE_SRC = ("'self'",)

--- a/aidants_connect_web/static/js/hidden_users_search.js
+++ b/aidants_connect_web/static/js/hidden_users_search.js
@@ -1,0 +1,25 @@
+"use strict";
+
+$(function () {
+    const users = JSON.parse(document.querySelector("#usagers_list").textContent);
+    $("#filter-input").autocomplete({
+        source: users,
+        minLength: 3,
+        focus: function (event, ui) {
+            $("#filter-input").val(ui.item.label);
+            return false;
+        },
+        select: function (event, ui) {
+            $("#filter-input").val(ui.item.label);
+            $("#filter-input-id").val(ui.item.value);
+            return false;
+        },
+        appendTo: $("#autocomplete"),
+    })
+        .data("ui-autocomplete")._renderItem = function (ul, item) {
+        return $("<li class=ui-menu-item-wrapper>")
+            .attr("data-value", item.value)
+            .append(item.label)
+            .appendTo(ul);
+    };
+});

--- a/aidants_connect_web/static/js/hidden_users_search.js
+++ b/aidants_connect_web/static/js/hidden_users_search.js
@@ -1,9 +1,35 @@
 "use strict";
 
 $(function () {
+    const collator = new Intl.Collator(navigator.language, {
+        usage: "search",
+        sensitivity: "base",
+    })
+
+    // Inspired by https://github.com/idmadj/locale-includes/blob/master/src/index.js
+    function localeIncludes(haystack, needle) {
+        const haystackLength = haystack.length
+        const needleLength = needle.length
+        const lengthDiff = haystackLength - needleLength
+
+        for (var i = 0; i <= lengthDiff; i++) {
+            const subHaystack = haystack.substring(i, i + needleLength)
+            if (collator.compare(subHaystack, needle) === 0) {
+                return true
+            }
+        }
+        return false
+    }
+
     const users = JSON.parse(document.querySelector("#usagers_list").textContent);
     $("#filter-input").autocomplete({
-        source: users,
+        source: function (request, response) {
+            const results = users.filter(function(item) {
+                return localeIncludes(item.label, request.term);
+            });
+
+            response(results);
+        },
         minLength: 3,
         focus: function (event, ui) {
             $("#filter-input").val(ui.item.label);

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -5,85 +5,62 @@
 {% block title %}Aidants Connect - Sélectionnez l'usager{% endblock %}
 
 {% block extracss %}
-  <link href="{% static 'css/id_provider.css' %}" rel="stylesheet" />
-  <link href="{% static 'css/autocomplete.css' %}" rel="stylesheet" />
+  <link href="{% static 'css/id_provider.css' %}" rel="stylesheet"/>
+  <link href="{% static 'css/autocomplete.css' %}" rel="stylesheet"/>
 {% endblock extracss %}
 
 {% block content %}
-
-<div class="fr-container">
-  <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="fr-col-12 fr-col-md-8">
-      <h1 id="welcome_aidant">Bienvenue sur votre Espace Aidants Connect, {{ aidant.first_name }}</h1>
-      <div class="container shadowed">
-
+  <div class="fr-container">
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <div class="fr-col-12 fr-col-md-8">
+        <h1 id="welcome_aidant">Bienvenue sur votre Espace Aidants Connect, {{ aidant.first_name }}</h1>
+        <div class="container shadowed">
           <h1>Sélectionnez l'usager que vous souhaitez FranceConnecter</h1>
-            <p id="instructions" class="subtitle">Seuls les usagers avec un mandat en cours sont affichés ici.</p>
-            {% if usagers %}
+          <p id="instructions" class="subtitle">Seuls les usagers avec un mandat en cours sont affichés ici.</p>
+          {% if usagers %}
             <form method="post">
-            <div class="form-grid-row fr-grid-row fr-grid-row--gutters">
-              <div class="fr-col-12">
-                <label id="filter-input-label" for="filter-input">
-                  Rechercher un usager :
-                </label>
-              </div>
-              <div class="fr-col-12">
-                <input type="text" id="filter-input" required />
-                <input id="filter-input-id" name="chosen_usager" hidden />
-                <div id="autocomplete" class="autocomplete-input_wrapper input-spinner-wrapper"></div>
-              </div>
+              <div class="form-grid-row fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12">
+                  <label id="filter-input-label" for="filter-input">
+                    Rechercher un usager :
+                  </label>
+                </div>
+                <div class="fr-col-12">
+                  {% if errors %}{{ errors }}{% endif %}
+                </div>
+                <div class="fr-col-12">
+                  <input type="text" id="filter-input" required/>
+                  <input id="filter-input-id" name="chosen_usager" hidden/>
+                  <div id="autocomplete" class="autocomplete-input_wrapper input-spinner-wrapper"></div>
+                </div>
                 {% csrf_token %}
-                <input type="hidden" name="connection_id" value="{{ connection_id }}" />
+                <input type="hidden" name="connection_id" value="{{ connection_id }}"/>
 
-            </div>
-            <div class="button-box">
-              <button id="submit-button" class="primary" type="submit">Séléctionner</button>
-            </div>
-          </form>
+              </div>
+              <div class="button-box">
+                <button id="submit-button" class="primary" type="submit">Séléctionner</button>
+              </div>
+            </form>
           {% else %}
             <div class="notification" role="alert">
               Vous n’avez pas d'usagers avec au moins un mandat en cours.<br>
-              Pour créer un nouveau mandat, rendez-vous sur votre <a href="{% url 'espace_aidant_home' %}">Espace Aidant</a>.
+              Pour créer un nouveau mandat, rendez-vous sur votre <a href="{% url 'espace_aidant_home' %}">Espace
+              Aidant</a>.
             </div>
           {% endif %}
+        </div>
       </div>
     </div>
   </div>
-</div>
-<br><br>
+  <br><br>
 {% endblock content %}
 
 {% block extrajs %}
+  {{ data|json_script:"usagers_list" }}
   <script src="https://code.jquery.com/jquery-3.6.1.js"></script>
   <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
-
- {{ data|json_script:"usagers_list" }}
-
+  <script src="{% static 'js/hidden_users_search.js' %}"></script>
   <script>
-    $(function () {
 
-      const users = JSON.parse(document.querySelector("#usagers_list").textContent);
-
-      const autoWidget = $("#filter-input").autocomplete({
-        source: users,
-        minLength: 3,
-        focus : function(event, ui) {
-          $("#filter-input").val(ui.item.label);
-          return false;
-        },
-        select: function(event, ui) {
-          $("#filter-input").val(ui.item.label);
-          $("#filter-input-id").val(ui.item.value);
-          return false;
-        },
-        appendTo: $("#autocomplete"),
-      })
-      .data( "ui-autocomplete" )._renderItem = function( ul, item ) {
-        return $("<li class=ui-menu-item-wrapper>" )
-          .attr("data-value", item.value )
-          .append(item.label)
-          .appendTo( ul );
-      };
-    });
   </script>
 {% endblock %}

--- a/aidants_connect_web/tests/test_functional/test_id_provider.py
+++ b/aidants_connect_web/tests/test_functional/test_id_provider.py
@@ -69,9 +69,9 @@ class IdProviderTest(FunctionalTestCase):
         login_aidant(self)
 
         autocomplete = self.selenium.find_element(By.ID, "filter-input")
-        autocomplete.send_keys("Anne")
+        autocomplete.send_keys("Jose")
         usager = self.selenium.find_element(
-            By.XPATH, f"//li[@data-value='{self.usager_anne.id}']"
+            By.XPATH, f"//li[@data-value='{self.usager_josephine.id}']"
         )
         usager.click()
 

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -238,6 +238,26 @@ class AuthorizeTests(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_post_to_authorize_with_with_empty_usager_selection(self):
+        self.maxDiff = None
+        self.client.force_login(self.aidant_thierry)
+        connection = Connection.objects.create(
+            state="avalidstate123", nonce="avalidnonce456", usager=self.usager
+        )
+        response = self.client.post(
+            "/authorize/",
+            data={"connection_id": connection.id, "chosen_usager": ""},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            response.context["errors"]["chosen_usager"],
+            [
+                "Aucun profil n'a été trouvé.Veuillez taper le nom d'une personne et "
+                "la barre de recherche et sélectionner parmis les propositions dans "
+                "la liste déroulante"
+            ],
+        )
+
 
 @tag("id_provider")
 class FISelectDemarcheTests(TestCase):


### PR DESCRIPTION
Dépendance : #766.

## 🌮 Objectif

La prod nous a remonté quelques erreurs après le déploiement de la nouvelle recherche utilisateur. Cette PR tente de clarifier l'utilisation de la recherche et prévenir les exceptions qu'on a vu passer en prod en obligeant l'utilisateur ou l'utilisatrice à cliquer sur un nom dans la liste déroulante.

Il y faudrait améliorer encode ce code en le convertissant en CBV mais ça me paraît trop gros et sensible pour cette PR.