### PR TITLE
Revert temporaire de la nouvelle recherche usager

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -408,13 +408,12 @@ CSP_DEFAULT_SRC = ("'self'",)
 CSP_CONNECT_SRC = ("'self'", "https://stats.data.gouv.fr/matomo.php")
 CSP_IMG_SRC = (
     "'self'",
-    "data:",
     "https://www.service-public.fr/resources/v-5cf79a7acf/web/css/img/png/",
 )
 CSP_SCRIPT_SRC = (
     "'self'",
     STIMULUS_JS_URL,
-    "'sha256-+iP5od5k5h6dnQJ5XGJGipIf2K6VdSrIwATxnixVR8s='",  # main.html
+    "'sha256-p0nVvBQQOY8PrKj8/JWPCKOJU8Iso8I6LIVer817o64='",  # main.html
     "'sha256-ARvyo8AJ91wUvPfVqP2FfHuIHZJN3xaLI7Vgj2tQx18='",  # wait.html
     "'sha256-mXH/smf1qtriC8hr62Qt2dvp/StB/Ixr4xmBRvkCz0U='",  # main-habilitation.html
     "https://cdn.jsdelivr.net/npm/chart.js@3.7.1/dist/chart.min.js",
@@ -424,10 +423,12 @@ CSP_SCRIPT_SRC = (
     "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js",
     "https://code.jquery.com/jquery-3.6.1.js",
     "https://code.jquery.com/ui/1.13.1/jquery-ui.js",
-    "'sha256-cFyvsDuA3AcV8Zc3M5E7whbtucLdPz2NtUjdlLeuz+c='",  # authorize.html
 )
 
-CSP_STYLE_SRC = ("'self'",)
+CSP_STYLE_SRC = (
+    "'self'",
+    "https://code.jquery.com/ui/1.13.2/themes/base/jquery-ui.css",
+)
 
 CSP_OBJECT_SRC = ("'none'",)
 CSP_FRAME_SRC = (

--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -1,4 +1,4 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static ac_extras ac_common %}
 
@@ -6,84 +6,66 @@
 
 {% block extracss %}
   <link href="{% static 'css/id_provider.css' %}" rel="stylesheet" />
-  <link href="{% static 'css/autocomplete.css' %}" rel="stylesheet" />
+  <link href="{% static 'css/users_search.css' %}" rel="stylesheet" />
 {% endblock extracss %}
 
 {% block content %}
-
-<div class="fr-container">
-  <div class="fr-grid-row fr-grid-row--gutters">
-    <div class="fr-col-12 fr-col-md-8">
-      <h1 id="welcome_aidant">Bienvenue sur votre Espace Aidants Connect, {{ aidant.first_name }}</h1>
-      <div class="container shadowed">
-
-          <h1>Sélectionnez l'usager que vous souhaitez FranceConnecter</h1>
-            <p id="instructions" class="subtitle">Seuls les usagers avec un mandat en cours sont affichés ici.</p>
-            {% if usagers %}
-            <form method="post">
-            <div class="form-grid-row fr-grid-row fr-grid-row--gutters">
-              <div class="fr-col-12">
-                <label id="filter-input-label" for="filter-input">
-                  Rechercher un usager :
-                </label>
-              </div>
-              <div class="fr-col-12">
-                <input type="text" id="filter-input" required />
-                <input id="filter-input-id" name="chosen_usager" hidden />
-                <div id="autocomplete" class="autocomplete-input_wrapper input-spinner-wrapper"></div>
-              </div>
-                {% csrf_token %}
-                <input type="hidden" name="connection_id" value="{{ connection_id }}" />
-
-            </div>
-            <div class="button-box">
-              <button id="submit-button" class="primary" type="submit">Séléctionner</button>
-            </div>
-          </form>
-          {% else %}
-            <div class="notification" role="alert">
-              Vous n’avez pas d'usagers avec au moins un mandat en cours.<br>
-              Pour créer un nouveau mandat, rendez-vous sur votre <a href="{% url 'espace_aidant_home' %}">Espace Aidant</a>.
-            </div>
-          {% endif %}
-      </div>
-    </div>
+<div class="hero">
+  <div class="hero__container">
+    <h1 id="welcome_aidant">Bienvenue sur votre Espace Aidants Connect, {{ aidant.first_name }}</h1>
   </div>
 </div>
-<br><br>
+<section
+  class="section section-grey mandat-select__section"
+  data-controller="search"
+>
+  <div class="container">
+    <form method="post">
+      <h2>Sélectionnez l'usager que vous souhaitez FranceConnecter</h2>
+      <p id="instructions">Seuls les usagers avec un mandat en cours sont affichés ici.</p>
+      {% if usagers %}
+        {% include "aidants_connect_web/users_search_bar.html" %}
+        <fieldset>
+          <div id="usagers" class="grid">
+            {% for usager in usagers %}
+              <div
+                class="tile usager"
+                data-search-target="item"
+                data-search-terms='{{ usager.search_terms|json_attribute }}'
+              >
+                <input
+                  id="button-{{ usager.id }}"
+                  type="submit"
+                  value="{{ usager.id }}"
+                  name="chosen_usager"
+                  aria-labelledby="label-usager-{{ usager.id }}"
+                />
+                <label
+                  id="label-usager-{{ usager.id }}"
+                  class="label-usager"
+                  for="button-{{ usager.id }}"
+                >
+                  {{ usager.given_name }} {% if usager.preferred_username %}{{ usager.preferred_username }}<br/>Né(e) {% endif %}{{ usager.family_name }}
+                </label>
+              </div>
+            {% endfor %}
+          </div>
+          {% csrf_token %}
+          <input type="hidden" name="connection_id" value="{{ connection_id }}" />
+        </fieldset>
+      {% else %}
+        <div class="notification" role="alert">
+          Vous n’avez pas d'usagers avec au moins un mandat en cours.<br>
+          Pour créer un nouveau mandat, rendez-vous sur votre <a href="{% url 'espace_aidant_home' %}">Espace Aidant</a>.
+        </div>
+      {% endif %}
+    </form>
+  </div>
+</section>
 {% endblock content %}
 
 {% block extrajs %}
-  <script src="https://code.jquery.com/jquery-3.6.1.js"></script>
-  <script src="https://code.jquery.com/ui/1.13.1/jquery-ui.js"></script>
-
- {{ data|json_script:"usagers_list" }}
-
-  <script>
-    $(function () {
-
-      const users = JSON.parse(document.querySelector("#usagers_list").textContent);
-
-      const autoWidget = $("#filter-input").autocomplete({
-        source: users,
-        minLength: 3,
-        focus : function(event, ui) {
-          $("#filter-input").val(ui.item.label);
-          return false;
-        },
-        select: function(event, ui) {
-          $("#filter-input").val(ui.item.label);
-          $("#filter-input-id").val(ui.item.value);
-          return false;
-        },
-        appendTo: $("#autocomplete"),
-      })
-      .data( "ui-autocomplete" )._renderItem = function( ul, item ) {
-        return $("<li class=ui-menu-item-wrapper>" )
-          .attr("data-value", item.value )
-          .append(item.label)
-          .appendTo( ul );
-      };
-    });
-  </script>
+  {% stimulusjs %}
+  <script src="{% static 'js/utils.js' %}"></script>
+  <script src="{% static 'js/users_search.js' %}"></script>
 {% endblock %}

--- a/aidants_connect_web/tests/test_functional/test_id_provider.py
+++ b/aidants_connect_web/tests/test_functional/test_id_provider.py
@@ -65,19 +65,30 @@ class IdProviderTest(FunctionalTestCase):
 
     def test_search_feature(self):
         self.open_live_url(f"/authorize/?{self.url_parameters}")
-
         login_aidant(self)
 
-        autocomplete = self.selenium.find_element(By.ID, "filter-input")
-        autocomplete.send_keys("Anne")
-        usager = self.selenium.find_element(
-            By.XPATH, f"//li[@data-value='{self.usager_anne.id}']"
+        users = self.selenium.find_elements(By.CSS_SELECTOR, "#usagers .usager")
+
+        self.assertEqual(len(users), 3)
+
+        self.selenium.find_element(By.ID, "filter-input").send_keys("Anne")
+
+        anne_result = self.selenium.find_element(
+            By.XPATH, "//*[contains(text(), 'Anne Cécile Gertrude EVALOUS')]"
         )
-        usager.click()
+        josephine_result = self.selenium.find_element(
+            By.XPATH, "//*[contains(text(), 'Joséphine ST-PIERRE')]"
+        )
+        corentin_result = self.selenium.find_element(
+            By.XPATH, "//*[contains(text(), 'Corentin Anne')]"
+        )
 
-        button = self.selenium.find_element(By.ID, "submit-button")
+        self.assertTrue(anne_result.is_displayed())
+        self.assertFalse(josephine_result.is_displayed())
+        self.assertTrue(corentin_result.is_displayed())
 
-        button.click()
         wait = WebDriverWait(self.selenium, 10)
+
+        corentin_result.click()
 
         wait.until(url_contains("/select_demarche/?connection_id="))

--- a/aidants_connect_web/tests/test_functional/test_use_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_use_autorisation.py
@@ -6,8 +6,6 @@ from django.test import tag
 from django.utils import timezone
 
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.expected_conditions import url_contains
-from selenium.webdriver.support.wait import WebDriverWait
 
 from aidants_connect_common.tests.testcases import FunctionalTestCase
 from aidants_connect_web.models import Mandat
@@ -99,21 +97,10 @@ class UseAutorisationTests(FunctionalTestCase):
         self.assertEqual(
             welcome_aidant, "BIENVENUE SUR VOTRE ESPACE AIDANTS CONNECT, THIERRY"
         )
-
-        self.selenium.find_element(By.CLASS_NAME, "ui-autocomplete-input")
-
-        autocomplete = self.selenium.find_element(By.ID, "filter-input")
-        autocomplete.send_keys("Joséphine ST-PIERRE")
-        usager = self.selenium.find_element(
-            By.XPATH, f"//li[@data-value='{self.usager_josephine.id}']"
-        )
-        usager.click()
-
-        button = self.selenium.find_element(By.ID, "submit-button")
-        button.click()
-        wait = WebDriverWait(self.selenium, 10)
-
-        wait.until(url_contains("/select_demarche/?connection_id="))
+        usagers = self.selenium.find_elements(By.CLASS_NAME, "label-usager")
+        self.assertEqual(len(usagers), 1)
+        self.assertEqual(usagers[0].text, "Joséphine ST-PIERRE")
+        usagers[0].click()
 
         # Select Démarche
         step2_title = self.selenium.find_element(By.ID, "instructions").text

--- a/aidants_connect_web/views/id_provider.py
+++ b/aidants_connect_web/views/id_provider.py
@@ -111,11 +111,6 @@ def authorize(request):
         )
         aidant = request.user
 
-        usagers = aidant.get_usagers_with_active_autorisation()
-        usagers_list = []
-        for user in usagers:
-            usagers_list += [{"value": user.id, "label": user.get_full_name()}]
-
         return render(
             request,
             "aidants_connect_web/id_provider/authorize.html",
@@ -123,7 +118,6 @@ def authorize(request):
                 "connection_id": connection.id,
                 "usagers": aidant.get_usagers_with_active_autorisation(),
                 "aidant": aidant,
-                "data": usagers_list,
             },
         )
 


### PR DESCRIPTION
## 🌮 Objectif

On reçoit beaucoup d'erreurs depuis la mise en prod de la nouvelle recherche usager hier. Cette partie du projet étant très sensible, je propose qu'on revienne temporairement à l'ancien code qui a été éprouvé pendant plusieurs mois en attendant que #762 et #763 soit prêtes.