### PR TITLE
Fix script Matomo (encore)

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -417,7 +417,6 @@ CSP_SCRIPT_SRC = (
     "'sha256-oOHki3o/lOkQD0J+jC75068TFqQoV40dYK6wrkIXI1c='",  # statistiques.html
     "https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.0.0/chartjs-plugin-datalabels.min.js",
     "'sha256-CO4GFu3p1QNoCvjdyc+zNsVh77XOc5H2OcZYFb8YUPA='",  # home_page.html
-    "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js",
     "https://code.jquery.com/jquery-3.6.1.js",
     "https://code.jquery.com/ui/1.13.1/jquery-ui.js",
 )
@@ -619,6 +618,12 @@ if not GOUV_ADDRESS_SEARCH_API_DISABLED:
 
 MATOMO_INSTANCE_URL = os.getenv("MATOMO_INSTANCE_URL")
 MATOMO_INSTANCE_SITE_ID = os.getenv("MATOMO_INSTANCE_SITE_ID")
+
+if MATOMO_INSTANCE_URL:
+    CSP_SCRIPT_SRC = (
+        *CSP_SCRIPT_SRC,
+        f"{MATOMO_INSTANCE_URL.removesuffix('/')}/matomo.js",
+    )
 
 if "test" in sys.argv:
     # Force disable SMS API during tests

--- a/aidants_connect_common/static/js/matomo-init.js
+++ b/aidants_connect_common/static/js/matomo-init.js
@@ -1,16 +1,16 @@
 (function () {
-    const matomoUrl = document.querySelector("#matomo-script").dataset.matomoUrl;
-    const matomoSiteId = document.querySelector("#matomo-script").dataset.matomoSiteId;
+    const el = document.querySelector("#matomo-script");
+    const matomoUrl = el.dataset.matomoUrl.replace(/\/+$/, "");
+    const matomoSiteId = el.dataset.matomoSiteId;
     var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(["trackPageView"]);
     _paq.push(["enableLinkTracking"]);
     (function () {
-        _paq.push(["setTrackerUrl", matomoUrl + "matomo.php"]);
+        _paq.push(["setTrackerUrl", matomoUrl + "/matomo.php"]);
         _paq.push(["setSiteId", matomoSiteId]);
-        var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0];
-        g.async = true;
-        g.src = "https://cdn.matomo.cloud/gouv.matomo.cloud/matomo.js";
-        s.parentNode.insertBefore(g, s);
+        const script = document.createElement("script");
+        script.async = true;
+        script.src = matomoUrl + "/matomo.js";
+        document.querySelector("body").insertAdjacentElement("beforeend", script);
     })();
 })();


### PR DESCRIPTION
## 🌮 Objectif

Le [CDN Matomo](https://cdn.matomo.cloud) qu'on utilisait jusqu'ici est dans les choux. Aucune idée s'il est temporairement cassé ou s'il a été arrêté sans préavis. Le fait est qu'il n'est pas fiable [et la doc officielle de Matomo indique qu'il faut utiliser le script de l'instance](https://developer.matomo.org/guides/tracking-javascript-guide).

Le script est apparemment cassé depuis vendredi dernier.