### PR TITLE
Ajout du bandeau "liste d'attente" sur la FAQ

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/habilitation.html
+++ b/aidants_connect_web/templates/public_website/faq/habilitation.html
@@ -21,6 +21,16 @@
       {% include 'public_website/faq/_nav.html' with active="habilitation" %}
       <div class="main">
         <div class="panel">
+          <div class="bandeau shadowed">
+            <p>
+              <span aria-hidden="true">⚠️ </span>
+              <strong>Attention</strong> : un grand nombre d’aidants sont en attente d’une formation Aidants Connect et
+              <strong>les
+                formations sont complètes pour les prochains mois.</strong> Vous pouvez vous inscrire sur <strong>liste
+              d’attente</strong> <a href="{% url 'habilitation_new' %}">ici</a> et nous vous contacterons en cas de
+              désistement.
+            </p>
+          </div>
           <h2>Questions sur l’habilitation</h2>
           <h3>Pourquoi les bénévoles ne peuvent pas être habilités Aidants Connect&nbsp;?</h3>
           <p>Les bénévoles ne peuvent pas utiliser le service Aidants Connect pour les raisons suivantes&nbsp;:</p>


### PR DESCRIPTION
## 🌮 Objectif

Prévenir le public que la formation est complète

## 🔍 Implémentation

- Ajout dans la FAQ du bandeau déjà fait par ailleurs


## 🖼️ Images

![Capture d’écran 2022-12-20 à 11 05 51](https://user-images.githubusercontent.com/1035145/208641530-69f9304d-6872-4abd-b1d5-6e5c4a5e890a.png)

