### PR TITLE
Mise en place du statut Liste d'attente pour les HabilitationRequest

### DIFF
--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -430,6 +430,7 @@ class OrganisationRequest(models.Model):
                 email=self.manager.email,
                 organisation=organisation,
                 defaults=dict(
+                    origin=HabilitationRequest.ORIGIN_HABILITATION,
                     first_name=self.manager.first_name,
                     last_name=self.manager.last_name,
                     profession=self.manager.profession,
@@ -445,6 +446,7 @@ class OrganisationRequest(models.Model):
                 email=aidant.email,
                 organisation=organisation,
                 defaults=dict(
+                    origin=HabilitationRequest.ORIGIN_HABILITATION,
                     first_name=aidant.first_name,
                     last_name=aidant.last_name,
                     profession=aidant.profession,

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -154,7 +154,9 @@ class OrganisationRequestTests(TestCase):
             # check if responsable is on the list of aidants too
             self.assertTrue(
                 HabilitationRequest.objects.filter(
-                    organisation=organisation, email=organisation_request.manager.email
+                    organisation=organisation,
+                    email=organisation_request.manager.email,
+                    origin=HabilitationRequest.ORIGIN_HABILITATION,
                 ).exists()
             )
 

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -1238,7 +1238,11 @@ class AddAidantsRequestViewTests(TestCase):
 
         self.assertEqual(RequestStatusConstants.VALIDATED.name, org_req.status)
         self.assertEqual(
-            3, HabilitationRequest.objects.filter(organisation=organisation).count()
+            3,
+            HabilitationRequest.objects.filter(
+                organisation=organisation,
+                origin=HabilitationRequest.ORIGIN_HABILITATION,
+            ).count(),
         )
 
         furthermore = get_form(

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -496,6 +496,7 @@ class Aidant(AbstractUser):
 
 
 class HabilitationRequest(models.Model):
+    STATUS_WAITING_LIST_HABILITATION = "habilitation_waitling_list"
     STATUS_NEW = "new"
     STATUS_PROCESSING = "processing"
     STATUS_VALIDATED = "validated"
@@ -505,8 +506,10 @@ class HabilitationRequest(models.Model):
     ORIGIN_DATAPASS = "datapass"
     ORIGIN_RESPONSABLE = "responsable"
     ORIGIN_OTHER = "autre"
+    ORIGIN_HABILITATION = "habilitation"
 
     STATUS_LABELS = {
+        STATUS_WAITING_LIST_HABILITATION: "Liste d'attente demande habilitation",
         STATUS_NEW: "Nouvelle",
         STATUS_PROCESSING: "En cours",
         STATUS_VALIDATED: "Validée",
@@ -518,6 +521,7 @@ class HabilitationRequest(models.Model):
         ORIGIN_DATAPASS: "Datapass",
         ORIGIN_RESPONSABLE: "Responsable Structure",
         ORIGIN_OTHER: "Autre",
+        ORIGIN_HABILITATION: "Formulaire Habilitation",
     }
 
     first_name = models.CharField("Prénom", max_length=150)
@@ -536,7 +540,7 @@ class HabilitationRequest(models.Model):
         "État",
         blank=False,
         max_length=150,
-        default=STATUS_NEW,
+        default=STATUS_WAITING_LIST_HABILITATION,
         choices=((status, label) for status, label in STATUS_LABELS.items()),
     )
     origin = models.CharField(
@@ -571,6 +575,7 @@ class HabilitationRequest(models.Model):
         if self.status not in (
             self.STATUS_PROCESSING,
             self.STATUS_NEW,
+            self.STATUS_WAITING_LIST_HABILITATION,
             self.STATUS_VALIDATED,
         ):
             return False

--- a/aidants_connect_web/tests/test_import.py
+++ b/aidants_connect_web/tests/test_import.py
@@ -56,6 +56,28 @@ class ImportEricLastFileTests(TestCase):
             )
         )
 
+    def test_change_status_habilitation_request_already_exists_waiting_list(self):
+        HabilitationRequestFactory(
+            last_name="Simpson",
+            first_name="Marge",
+            email="m.simpson@test.com",
+            organisation=self.orga1,
+            status=HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
+        )
+        self.assertEqual(2, HabilitationRequest.objects.all().count())
+        import_one_row([3234, "Marge", "Simpson", "m.simpson@test.com"])
+        self.assertEqual(2, HabilitationRequest.objects.all().count())
+
+        self.assertTrue(
+            HabilitationRequest.objects.filter(
+                last_name="Simpson",
+                first_name="Marge",
+                email="m.simpson@test.com",
+                organisation__data_pass_id=3234,
+                status=HabilitationRequest.STATUS_PROCESSING,
+            )
+        )
+
     def test_dont_habilitation_request_with_invalid_orga(self):
         self.assertEqual(1, HabilitationRequest.objects.all().count())
         import_one_row([113234, "Marge", "Simpson", "m.simpson@test.com"])

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1645,6 +1645,9 @@ class HabilitationRequestMethodTests(TestCase):
         for habilitation_request in (
             HabilitationRequestFactory(status=HabilitationRequest.STATUS_PROCESSING),
             HabilitationRequestFactory(status=HabilitationRequest.STATUS_NEW),
+            HabilitationRequestFactory(
+                status=HabilitationRequest.STATUS_WAITING_LIST_HABILITATION
+            ),
         ):
             self.assertEqual(
                 0, Aidant.objects.filter(email=habilitation_request.email).count()

--- a/aidants_connect_web/tests/test_tasks.py
+++ b/aidants_connect_web/tests/test_tasks.py
@@ -21,7 +21,9 @@ class ImportPixTests(TestCase):
         )
         self.assertEqual(aidant_a_former.test_pix_passed, False)
         self.assertEqual(aidant_a_former.date_test_pix, None)
-        self.assertEqual(aidant_a_former.status, HabilitationRequest.STATUS_NEW)
+        self.assertEqual(
+            aidant_a_former.status, HabilitationRequest.STATUS_WAITING_LIST_HABILITATION
+        )
         self.assertEqual(0, Aidant.objects.filter(email=aidant_a_former.email).count())
 
         data = [
@@ -48,7 +50,9 @@ class ImportPixTests(TestCase):
         self.assertEqual(aidant_a_former.date_formation, None)
         self.assertEqual(aidant_a_former.test_pix_passed, False)
         self.assertEqual(aidant_a_former.date_test_pix, None)
-        self.assertEqual(aidant_a_former.status, HabilitationRequest.STATUS_NEW)
+        self.assertEqual(
+            aidant_a_former.status, HabilitationRequest.STATUS_WAITING_LIST_HABILITATION
+        )
         self.assertEqual(0, Aidant.objects.filter(email=aidant_a_former.email).count())
 
         data = [
@@ -63,7 +67,9 @@ class ImportPixTests(TestCase):
             email=aidant_a_former.email
         )[0]
         self.assertTrue(aidant_a_former.test_pix_passed)
-        self.assertEqual(aidant_a_former.status, HabilitationRequest.STATUS_NEW)
+        self.assertEqual(
+            aidant_a_former.status, HabilitationRequest.STATUS_WAITING_LIST_HABILITATION
+        )
 
         self.assertEqual(0, Aidant.objects.filter(email=aidant_a_former.email).count())
 
@@ -86,8 +92,14 @@ class ImportPixTests(TestCase):
         self.assertEqual(aidant_a_former_1.date_test_pix, None)
         self.assertEqual(aidant_a_former_2.test_pix_passed, False)
         self.assertEqual(aidant_a_former_2.date_test_pix, None)
-        self.assertEqual(aidant_a_former_1.status, HabilitationRequest.STATUS_NEW)
-        self.assertEqual(aidant_a_former_2.status, HabilitationRequest.STATUS_NEW)
+        self.assertEqual(
+            aidant_a_former_1.status,
+            HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
+        )
+        self.assertEqual(
+            aidant_a_former_2.status,
+            HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
+        )
         self.assertEqual(
             0, Aidant.objects.filter(email=aidant_a_former_1.email).count()
         )

--- a/aidants_connect_web/tests/test_views/test_datapass.py
+++ b/aidants_connect_web/tests/test_views/test_datapass.py
@@ -179,4 +179,7 @@ class HabilitationDatapass(DatapassMixin, TestCase):
         self.assertEqual(
             habilitation_request.origin, HabilitationRequest.ORIGIN_DATAPASS
         )
-        self.assertEqual(habilitation_request.status, HabilitationRequest.STATUS_NEW)
+        self.assertEqual(
+            habilitation_request.status,
+            HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
+        )

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_habilitation_requests.py
@@ -97,7 +97,8 @@ class HabilitationRequestsTests(TestCase):
                 HabilitationRequest.ORIGIN_RESPONSABLE,
             )
             self.assertEqual(
-                created_habilitation_request.status, HabilitationRequest.STATUS_NEW
+                created_habilitation_request.status,
+                HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
             )
 
     def test_email_is_lowercased(self):


### PR DESCRIPTION
add habilitation origin for HabilitationRequest

## 🌮 Objectif

Avoir un statut liste d'attente pour les demandes d'aidant à former. Pouvoir savoir si une demande d'aidant à former vient du formulaire d'habilitation ou de l'espace responsable

## 🔍 Implémentation

Ajout du statut
Ajout d'une origine
Modification du code de création des habilitationRequest par le formulaire d'habilitation ou l'espace responsable
modification des tests.

petite boyscout modification ( ou cheval de troie) , neplus utiliser update sur un queryset pour marquer les habilitations requests en "en cours", mais boucler pour lancer le save ( et du coup mettre à jour la date de modification [ce qu'on aurait pu faire dans le update ] et être sur que si du métier est fait dans le save, il sera fait aussi par ce biais. 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
