### PR TITLE
Ajout du bandeau "liste d'attente" sur l'espace responsable

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -19,6 +19,13 @@
       {% endif %}
       <h1>Mon organisation : {{ organisation.name }}</h1>
       {% include "aidants_connect_web/espace_aidant/notifications.html" with user=responsable %}
+      <div class="bandeau shadowed">
+        <p>
+          <span aria-hidden="true">⚠️</span> Attention : un grand nombre d’aidants sont en attente d’une formation Aidants Connect et les formations sont
+          complètes pour les prochains mois. Vous pouvez ajouter sur votre compte Responsable un montant maximum de
+          trois aidants à la fois. Au-delà de trois aidants, les aidants seront mis sur liste d’attente.
+        </p>
+      </div>
       {% include "aidants_connect_web/espace_aidant/statistics.html" with organisation=organisation %}
     </div>
   </section>


### PR DESCRIPTION
## 🌮 Objectif

Prévenir les responsables que les formations des aidants vont beaucoup ralentir les prochains mois.

## 🔍 Implémentation

- Ajout du bandeau sur l'accueil de l'espace responsable


## 🖼️ Images

![Capture d’écran 2022-12-22 à 11 43 46](https://user-images.githubusercontent.com/1035145/209117387-c429351e-ca1b-4fb5-895b-99d1493425fb.png)

