### PR TITLE
Recherche de demandeur insensible à la casse dans `NewIssuerFormView`

### DIFF
--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -125,6 +125,24 @@ class NewIssuerFormViewTests(TestCase):
             html_message=ANY,
         )
 
+        # Also test when user gives their email with capitals
+        send_mail_mock.reset_mock()
+        send_mail_mock.assert_not_called()
+
+        data["email"] = issuer.email.capitalize()
+
+        self.assertNotEqual(issuer.email, data["email"])
+
+        self.client.post(reverse(self.pattern_name), data)
+
+        send_mail_mock.assert_called_with(
+            from_email=settings.EMAIL_ORGANISATION_REQUEST_FROM,
+            recipient_list=[issuer.email],
+            subject=settings.EMAIL_HABILITATION_ISSUER_EMAIL_ALREADY_EXISTS_SUBJECT,
+            message=ANY,
+            html_message=ANY,
+        )
+
     def test_render_warning_when_issuer_already_exists(self):
         issuer: Issuer = IssuerFactory()
 

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -194,9 +194,10 @@ class NewIssuerFormView(HabilitationStepMixin, FormView):
         )
 
     def send_issuer_profile_reminder_mail(self, email: str):
+        issuer: Issuer = Issuer.objects.get(email__iexact=email)
         path = reverse(
             "habilitation_issuer_page",
-            kwargs={"issuer_id": str(Issuer.objects.get(email=email).issuer_id)},
+            kwargs={"issuer_id": str(issuer.issuer_id)},
         )
         context = {"url": self.request.build_absolute_uri(path)}
         text_message = loader.render_to_string(
@@ -207,7 +208,7 @@ class NewIssuerFormView(HabilitationStepMixin, FormView):
         )
         send_mail(
             from_email=settings.EMAIL_ORGANISATION_REQUEST_FROM,
-            recipient_list=[email],
+            recipient_list=[issuer.email],
             subject=settings.EMAIL_HABILITATION_ISSUER_EMAIL_ALREADY_EXISTS_SUBJECT,
             message=text_message,
             html_message=html_message,


### PR DESCRIPTION
## 🌮 Objectif

Une erreur nous a été remontée dans Sentry lorsqu'un demandeur tente de créer une nouvelle fiche demandeur dans dans `NewIssuerFormView` alors qu'un profil avec cet email existe déjà.

Concrètement, ce qu'il se passe, c'est que le `Form` généré valide l'unicité de l'adresse email de manière insensible à la casse. Si l'adresse email existe déjà, alors nous tentons d'y envoyer un email de rappel. Cepdnant, à cette étape, la recherche est sensible à la casse. Ce qui signifie que, si la personne tente de créer un nouveau profil avec la même adresse email mais une casse différente, nous échouons à retrouver le profil à cette étape.

Cette PR corrige cette erreur.