### PR TITLE
Consentement par SMS partie 8 : travail des textes des SMS pour le consentement à distance

### DIFF
--- a/aidants_connect_common/tests/test_templatetags.py
+++ b/aidants_connect_common/tests/test_templatetags.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 from urllib.parse import quote
 
 from django.template import Context, Template
@@ -62,6 +63,33 @@ class LinebreaklessTests(TestCase):
             "<li>item 3</li>\n</ul>",
             result.strip(),
         )
+
+    def test_keeplinebreak_keeps_witespace_on_option(self):
+        result = self._render_template(
+            dedent(
+                """\
+                {% load ac_common %}
+                {% linebreakless dont_rstrip=True %}
+                This is a line;
+                 this is line
+                {% endlinebreakless %}"""
+            )
+        )
+
+        self.assertEqual("This is a line; this is line", result.strip())
+
+        result = self._render_template(
+            dedent(
+                """\
+                {% load ac_common %}
+                {% linebreakless dont_lstrip=True %}
+                This is a line; 
+                this is line
+                {% endlinebreakless %}"""  # noqa: W291
+            )
+        )
+
+        self.assertEqual("This is a line; this is line", result.strip())
 
     def test_keeplinebreak_throws_expception_when_not_followed_by_a_linebreak(self):
         template = """

--- a/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
@@ -4,7 +4,7 @@ Aidant Connect, bonjour.
 
 {% linebreakless dont_rstrip=True %}
 {% autoescape off %}{# Turn off HTML autoescape. That would mess with apostrophies #}
-{{ aidant.get_full_name }} de l'organisation {{ organisation.name }} souhaite créer un mandat {{ duree_text }} en votre nom
+L'organisation {{ organisation.name }} souhaite créer un mandat {{ duree_text }} en votre nom
 {% if demarches|length == 1 %}
  pour la démarche {{ demarches.0 }}.
 {% else %}
@@ -16,7 +16,6 @@ Aidant Connect, bonjour.
 {% endif %}
 {% keeplinebreak %}
 {% keeplinebreak %}
-Répondez « {{ sms_response_consent }} » sans ponctuation pour accepter le mandat.
- Toute autre réponse sera considéré comme un refus explicite.
+Répondez « {{ sms_response_consent }} » pour accepter le mandat.
 {% endautoescape %}
 {% endlinebreakless %}

--- a/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
@@ -1,6 +1,22 @@
+{% load ac_common %}
+
 Aidant Connect, bonjour.
 
-Un aidant a créé un mandat en votre nom. Confirmez-vous la création de ce mandat ?
-Répondez « {{ sms_response_consent }} » sans ponctuation à ce message pour confirmer votre consentement.
-
-Notez que toute autre réponse que « oui » sera interprétée comme un refus explicite.
+{% linebreakless dont_rstrip=True %}
+{% autoescape off %}{# Turn off HTML autoescape. That would mess with apostrophies #}
+{{ aidant.get_full_name }} de l'organisation {{ organisation.name }} souhaite créer un mandat {{ duree_text }} en votre nom
+{% if demarches|length == 1 %}
+ pour la démarche {{ demarches.0 }}
+{% else %}
+ pour les démarches suivantes :{% keeplinebreak %}
+{% for demarche in demarches %}
+{% keeplinebreak %}
+- {{ demarche }}{% list_term %}
+{% endfor %}
+{% endif %}
+{% keeplinebreak %}
+{% keeplinebreak %}
+Répondez « {{ sms_response_consent }} » sans ponctuation à ce message pour accepter le mandat.
+ Toute autre réponse que « {{ sms_response_consent }} » équivaut à un refus explicite.
+{% endautoescape %}
+{% endlinebreakless %}

--- a/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
+++ b/aidants_connect_web/templates/aidants_connect_web/sms/consent_request.txt
@@ -6,7 +6,7 @@ Aidant Connect, bonjour.
 {% autoescape off %}{# Turn off HTML autoescape. That would mess with apostrophies #}
 {{ aidant.get_full_name }} de l'organisation {{ organisation.name }} souhaite créer un mandat {{ duree_text }} en votre nom
 {% if demarches|length == 1 %}
- pour la démarche {{ demarches.0 }}
+ pour la démarche {{ demarches.0 }}.
 {% else %}
  pour les démarches suivantes :{% keeplinebreak %}
 {% for demarche in demarches %}
@@ -16,7 +16,7 @@ Aidant Connect, bonjour.
 {% endif %}
 {% keeplinebreak %}
 {% keeplinebreak %}
-Répondez « {{ sms_response_consent }} » sans ponctuation à ce message pour accepter le mandat.
- Toute autre réponse que « {{ sms_response_consent }} » équivaut à un refus explicite.
+Répondez « {{ sms_response_consent }} » sans ponctuation pour accepter le mandat.
+ Toute autre réponse sera considéré comme un refus explicite.
 {% endautoescape %}
 {% endlinebreakless %}

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -364,8 +364,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         )[0]
 
         self.assertIn(
-            "Un aidant a créé un mandat en votre nom. "
-            "Confirmez-vous la création de ce mandat ?",
+            "Aidant Connect, bonjour",
             consent_request_log.additional_information,
         )
 
@@ -493,7 +492,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         )
 
     def _user_consents(self, phone_number: str):
-        self._user_responds(phone_number, settings.SMS_RESPONSE_CONSENT)
+        self._user_responds(phone_number, "Oui")
 
     def _user_denies(self, phone_number: str):
         self._user_responds(phone_number, "Nope")

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -208,7 +208,7 @@ class RenewMandatTests(FunctionalTestCase):
         LM_SMS_SERVICE_OAUTH2_ENDPOINT=reverse("test_sms_api_token"),
         LM_SMS_SERVICE_SND_SMS_ENDPOINT=reverse("test_sms_api_sms"),
     )
-    @mock.patch("aidants_connect_web.views.renew_mandat.uuid4")
+    @mock.patch("aidants_connect_web.views.mandat.uuid4")
     def test_renew_mandat_remote_mandat_with_sms_consent(self, uuid4_mock: Mock):
         uuid4_mock.return_value = UUID
         wait = WebDriverWait(self.selenium, 10)
@@ -288,8 +288,7 @@ class RenewMandatTests(FunctionalTestCase):
         )[0]
 
         self.assertIn(
-            "Un aidant a créé un mandat en votre nom. "
-            "Confirmez-vous la création de ce mandat ?",
+            "Aidant Connect, bonjour",
             consent_request_log.additional_information,
         )
 
@@ -370,7 +369,7 @@ class RenewMandatTests(FunctionalTestCase):
         )
 
     def _user_consents(self, phone_number: str):
-        self._user_responds(phone_number, settings.SMS_RESPONSE_CONSENT)
+        self._user_responds(phone_number, "Oui")
 
     def _user_denies(self, phone_number: str):
         self._user_responds(phone_number, "Nope")

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -78,7 +78,9 @@ class TestRemoteMandateMixin(TestCase):
     def test_process_sms_template(self, send_sms_mock: Mock, uuid4_mock: Mock):
         uuid4_mock.return_value = UUID
 
-        form = self._get_form(["papiers", "logement"], RemoteConsentMethodChoices.SMS)
+        form = self._get_form(
+            list(settings.DEMARCHES.keys()), RemoteConsentMethodChoices.SMS
+        )
 
         RemoteMandateMixin().process_consent(
             self.aidant_thierry, self.aidant_thierry.organisation, form
@@ -90,15 +92,22 @@ class TestRemoteMandateMixin(TestCase):
             self._trim_margin(
                 """Aidant Connect, bonjour.
                 |
-                |Thierry Goneau de l'organisation COMMUNE D'HOULBEC COCHEREL souhaite\
-                | créer un mandat pour une durée d'un mois (31 jours) en votre nom pour\
-                | les démarches suivantes :
+                |L'organisation COMMUNE D'HOULBEC COCHEREL souhaite créer un mandat\
+                | pour une durée d'un mois (31 jours) en votre nom pour les démarches\
+                | suivantes :
                 |
+                |- Argent,
+                |- Étranger,
+                |- Famille,
+                |- Justice,
                 |- Logement,
-                |- Papiers - citoyenneté.
+                |- Loisirs,
+                |- Papiers - citoyenneté,
+                |- Social - santé,
+                |- Transports,
+                |- Travail.
                 |
-                |Répondez « Oui » sans ponctuation pour accepter le mandat.\
-                | Toute autre réponse sera considéré comme un refus explicite."""
+                |Répondez « Oui » pour accepter le mandat."""
             ),
         )
 
@@ -119,12 +128,11 @@ class TestRemoteMandateMixin(TestCase):
             self._trim_margin(
                 """Aidant Connect, bonjour.
                 |
-                |Thierry Goneau de l'organisation COMMUNE D'HOULBEC COCHEREL souhaite\
+                |L'organisation COMMUNE D'HOULBEC COCHEREL souhaite\
                 | créer un mandat pour une durée d'un mois (31 jours) en votre nom pour\
                 | la démarche Papiers - citoyenneté.
                 |
-                |Répondez « Oui » sans ponctuation pour accepter le mandat.\
-                | Toute autre réponse sera considéré comme un refus explicite."""
+                |Répondez « Oui » pour accepter le mandat."""
             ),
         )
 

--- a/aidants_connect_web/tests/test_views/test_mandat.py
+++ b/aidants_connect_web/tests/test_views/test_mandat.py
@@ -1,8 +1,13 @@
 from datetime import datetime, timedelta
+from textwrap import dedent
+from typing import List
+from unittest import mock
+from unittest.mock import ANY, MagicMock, Mock
 from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.contrib import messages as django_messages
+from django.db import transaction
 from django.test import TestCase, override_settings, tag
 from django.test.client import Client
 from django.urls import resolve, reverse
@@ -20,8 +25,128 @@ from aidants_connect_web.tests.factories import (
     UsagerFactory,
 )
 from aidants_connect_web.views import mandat
+from aidants_connect_web.views.mandat import RemoteMandateMixin
 
 fc_callback_url = settings.FC_AS_FI_CALLBACK_URL
+
+UUID = "7ce05928-979c-49ab-8e10-a1a221d39acb"
+
+
+@tag("new_mandat")
+class TestRemoteMandateMixin(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.client = Client()
+        cls.phone_number = "0 800 840 800"
+        cls.aidant_thierry = AidantFactory()
+
+    def test_process_consent_returns_none_if_not_remote_or_not_blocked_method(self):
+        target = RemoteMandateMixin()
+
+        form = self._get_form(["papiers", "logement"])
+
+        for method in RemoteConsentMethodChoices.blocked_methods():
+            setattr(target, f"_process_{method}_method", MagicMock())
+
+        result = target.process_consent(
+            self.aidant_thierry, self.aidant_thierry.organisation, form
+        )
+
+        for method in RemoteConsentMethodChoices.blocked_methods():
+            getattr(target, f"_process_{method}_method").assert_not_called()
+
+        self.assertIs(None, result)
+
+        form = self._get_form(
+            ["papiers", "logement"], RemoteConsentMethodChoices.LEGACY
+        )
+
+        for method in RemoteConsentMethodChoices.blocked_methods():
+            setattr(target, f"_process_{method}_method", MagicMock())
+
+        result = target.process_consent(
+            self.aidant_thierry, self.aidant_thierry.organisation, form
+        )
+
+        for method in RemoteConsentMethodChoices.blocked_methods():
+            getattr(target, f"_process_{method}_method").assert_not_called()
+
+        self.assertIs(None, result)
+
+    @mock.patch("aidants_connect_web.views.mandat.uuid4")
+    @mock.patch("aidants_connect_common.utils.sms_api.SmsApiMock.send_sms")
+    def test_process_sms_template(self, send_sms_mock: Mock, uuid4_mock: Mock):
+        uuid4_mock.return_value = UUID
+
+        form = self._get_form(["papiers", "logement"], RemoteConsentMethodChoices.SMS)
+
+        RemoteMandateMixin().process_consent(
+            self.aidant_thierry, self.aidant_thierry.organisation, form
+        )
+
+        send_sms_mock.assert_called_once_with(
+            ANY,
+            UUID,
+            dedent(
+                f"""\
+                Aidant Connect, bonjour.
+
+                Thierry Goneau de l'organisation COMMUNE D'HOULBEC COCHEREL souhaite créer un mandat pour une durée d'un mois (31 jours) en votre nom pour les démarches suivantes :
+                
+                - LOGEMENT: Allocations logement, Permis de construire, Logement social, Fin de bail…,
+                - PAPIERS - CITOYENNETÉ: État-civil, Passeport, Élections, Papiers à conserver, Carte d'identité….
+                
+                Répondez « Oui » sans ponctuation à ce message pour accepter le mandat. Toute autre réponse que « Oui » équivaut à un refus explicite."""  # noqa
+            ),
+        )
+
+        send_sms_mock.reset_mock()
+
+        with transaction.atomic():
+            Journal.objects.filter(consent_request_id=UUID).delete()
+
+        form = self._get_form(["papiers"], RemoteConsentMethodChoices.SMS)
+
+        RemoteMandateMixin().process_consent(
+            self.aidant_thierry, self.aidant_thierry.organisation, form
+        )
+
+        send_sms_mock.assert_called_once_with(
+            ANY,
+            UUID,
+            dedent(
+                f"""\
+                Aidant Connect, bonjour.
+                
+                Thierry Goneau de l'organisation COMMUNE D'HOULBEC COCHEREL souhaite créer un mandat pour une durée d'un mois (31 jours) en votre nom pour la démarche PAPIERS - CITOYENNETÉ: État-civil, Passeport, Élections, Papiers à conserver, Carte d'identité…
+                
+                Répondez « Oui » sans ponctuation à ce message pour accepter le mandat. Toute autre réponse que « Oui » équivaut à un refus explicite."""  # noqa
+            ),
+        )
+
+    def _get_form(
+        self,
+        demarche: List[str],
+        remote_constent_method: RemoteConsentMethodChoices | None = None,
+    ):
+        data = {
+            "demarche": demarche,
+            "duree": "MONTH",
+            "is_remote": remote_constent_method is not None,
+            "user_phone": self.phone_number,
+        }
+
+        if remote_constent_method:
+            data["remote_constent_method"] = remote_constent_method.value
+
+        form = MandatForm(data=data)
+
+        if not form.is_valid():
+            self.fail(
+                f"Test form is invalid because of the following errors: {form.errors}"
+            )
+
+        return form
 
 
 @tag("new_mandat")
@@ -327,13 +452,15 @@ class NewMandatRecapTests(TestCase):
 
             self.assertEqual(Autorisation.objects.count(), 3)
 
-            last_usager_organisation_papiers_autorisations = (
-                Autorisation.objects.filter(  # noqa
-                    demarche="papiers",
-                    mandat__usager=self.test_usager,
-                    mandat__organisation=self.aidant_thierry.organisation,
-                ).order_by("-mandat__creation_date")
+            last_usager_organisation_papiers_autorisations = Autorisation.objects.filter(  # noqa: E501
+                # noqa
+                demarche="papiers",
+                mandat__usager=self.test_usager,
+                mandat__organisation=self.aidant_thierry.organisation,
+            ).order_by(
+                "-mandat__creation_date"
             )
+
             new_papiers_autorisation = last_usager_organisation_papiers_autorisations[0]
             old_papiers_autorisation = last_usager_organisation_papiers_autorisations[1]
             self.assertEqual(new_papiers_autorisation.duration_for_humans, 366)  # noqa

--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -128,7 +128,7 @@ class RemoteMandateMixin:
                 "aidant": aidant,
                 "organisation": organisation,
                 "demarches": [
-                    humanize_demarche_names(demarche)
+                    settings.DEMARCHES[demarche]["titre"].capitalize()
                     for demarche in sorted(form.cleaned_data["demarche"])
                 ],
                 "duree_text": AuthorizationDurationChoices(

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -8,10 +8,7 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 
-
-from aidants_connect_common.templatetags.ac_common import mailto
 from aidants_connect_common.utils.constants import AuthorizationDurations
-from aidants_connect_common.utils.sms_api import SmsApi
 from aidants_connect_web.constants import RemoteConsentMethodChoices
 from aidants_connect_web.decorators import aidant_logged_with_activity_required
 from aidants_connect_web.forms import MandatForm

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -1,19 +1,13 @@
 import logging
 from secrets import token_urlsafe
-from typing import Callable
-from uuid import uuid4
 
 from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.hashers import make_password
 from django.http import HttpResponse
 from django.shortcuts import redirect
-from django.template.loader import render_to_string
 from django.urls import reverse
-from django.utils import timezone
-from django.utils.html import format_html
 
-from phonenumbers import PhoneNumber
 
 from aidants_connect_common.templatetags.ac_common import mailto
 from aidants_connect_common.utils.constants import AuthorizationDurations
@@ -22,14 +16,17 @@ from aidants_connect_web.constants import RemoteConsentMethodChoices
 from aidants_connect_web.decorators import aidant_logged_with_activity_required
 from aidants_connect_web.forms import MandatForm
 from aidants_connect_web.models import Aidant, Connection, Journal, Mandat, Usager
-from aidants_connect_web.views.mandat import MandatCreationJsFormView
+from aidants_connect_web.views.mandat import (
+    MandatCreationJsFormView,
+    RemoteMandateMixin,
+)
 from aidants_connect_web.views.mandat import WaitingRoom as MandatWaitingRoom
 
 logger = logging.getLogger()
 
 
 @aidant_logged_with_activity_required
-class RenewMandat(MandatCreationJsFormView):
+class RenewMandat(RemoteMandateMixin, MandatCreationJsFormView):
     form_class = MandatForm
     template_name = "aidants_connect_web/new_mandat/renew_mandat.html"
 
@@ -54,21 +51,11 @@ class RenewMandat(MandatCreationJsFormView):
         access_token = make_password(token_urlsafe(64), settings.FC_AS_FI_HASH_SALT)
         self.consent_request_id = ""
 
-        if (
-            data["is_remote"]
-            and data["remote_constent_method"]
-            in RemoteConsentMethodChoices.blocked_methods()
+        if isinstance(
+            result := self.process_consent(self.aidant, self.aidant.organisation, form),
+            HttpResponse,
         ):
-            # Processes remote blocked method (SMS, email)
-            # To add another consent method, add a ``process_x_method``
-            # For instance ``process_email_method`` and do what you need to do in it
-            method = str(data["remote_constent_method"]).lower()
-            process: Callable[[MandatForm], None | HttpResponse] = getattr(
-                self, f"process_{method}_method", self.process_unknown_method
-            )
-            result = process(form)
-            if isinstance(result, HttpResponse):
-                return result
+            return result
 
         self.connection = Connection.objects.create(
             aidant=self.aidant,
@@ -109,72 +96,6 @@ class RenewMandat(MandatCreationJsFormView):
             if self.connection.remote_constent_method
             not in RemoteConsentMethodChoices.blocked_methods()
             else reverse("renew_mandat_waiting_room")
-        )
-
-    def process_sms_method(self, form: MandatForm) -> None | HttpResponse:
-        data = form.cleaned_data
-        user_phone: PhoneNumber = data["user_phone"]
-        self.consent_request_id = str(uuid4())
-
-        # Try to choose another UUID if there's already one
-        # associated with this number in DB.
-        while Journal.objects.find_sms_consent_requests(
-            user_phone, self.consent_request_id
-        ).exists():
-            self.consent_request_id = str(uuid4())
-
-        user_consent_request_sms_text = render_to_string(
-            "aidants_connect_web/sms/consent_request.txt",
-            context={"sms_response_consent": settings.SMS_RESPONSE_CONSENT},
-        )
-        try:
-            SmsApi().send_sms(
-                user_phone,
-                self.consent_request_id,
-                user_consent_request_sms_text,
-            )
-        except SmsApi.HttpRequestExpection:
-            logger.exception(
-                "An error happend while trying to send an SMS consent request"
-            )
-            error_datetime = timezone.now()
-            email_body = render_to_string(
-                "aidants_connect_web/sms/support_email_send_failure_body.txt",
-                context={
-                    "datetime": error_datetime,
-                    "number": str(user_phone),
-                    "consent_request_id": self.consent_request_id,
-                },
-            )
-            django_messages.error(
-                self.request,
-                format_html(
-                    "Une erreur est survenue pendant l'envoi du SMS de "
-                    "consentement. Merci de réessayer plus tard. Si l'erreur persiste, "
-                    "merci de nous la signaler {}.",
-                    mailto(
-                        "en suivant ce lien pour nous envoyer un email",
-                        settings.SMS_SUPPORT_EMAIL,
-                        settings.SMS_SUPPORT_EMAIL_SEND_FAILURE_SUBJET,
-                        email_body,
-                    ),
-                ),
-            )
-            return redirect("espace_aidant_home")
-
-        Journal.log_user_consent_request_sms_sent(
-            aidant=self.aidant,
-            demarche=data["demarche"],
-            duree=data["duree"],
-            remote_constent_method=data["remote_constent_method"],
-            user_phone=user_phone,
-            consent_request_id=self.consent_request_id,
-            message=user_consent_request_sms_text,
-        )
-
-    def process_unknown_method(self, form: MandatForm):
-        raise NotImplementedError(
-            f"Unknown remote consent method {form['remote_constent_method']}"
         )
 
 


### PR DESCRIPTION
## 🌮 Objectif

Après une réunion avec le juridique, il semble nécessaire de mettre plus d'informations dans le SMS pour être carrés d'un point de vue juridique. 

## 🔍 Implémentation

- Retravail des textes des SMS

## 🏕 Amélioration continue

- Refacto pour mutualiser le code entre la création et le renouvellement de mandat
- Ajout de tests sur les textes des SMS
