### PR TITLE
Consentement par SMS partie 7 : traitement du cas du point final dans la réponse SMS

### DIFF
--- a/aidants_connect_web/tests/test_views/test_sms.py
+++ b/aidants_connect_web/tests/test_views/test_sms.py
@@ -9,3 +9,12 @@ class CallbackTests(TestCase):
     def test_sms_callback_url_triggers_the_correct_view(self):
         found = resolve(reverse("sms_callback"))
         self.assertEqual(found.func.view_class, sms.Callback)
+
+    def test__check_user_consents(self):
+        target = sms.Callback()
+        self.assertTrue(target._check_user_consents("Oui"))
+        self.assertTrue(target._check_user_consents("  Oui  "))
+        self.assertTrue(target._check_user_consents("  Oui  ."))
+        self.assertTrue(target._check_user_consents("  Oui  .  "))
+        self.assertFalse(target._check_user_consents("Oui;"))
+        self.assertFalse(target._check_user_consents("Oui non"))

--- a/aidants_connect_web/views/sms.py
+++ b/aidants_connect_web/views/sms.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import re
 
 from django.conf import settings
 from django.http import HttpResponse, QueryDict
@@ -98,8 +99,7 @@ class Callback(View):
             "message": sms_response.message,
         }
 
-        consent_response = settings.SMS_RESPONSE_CONSENT.lower().strip()
-        if sms_response.message.lower() != consent_response:  # No consent case
+        if not self._check_user_consents(sms_response.message):  # No consent case
             Journal.log_user_denies_sms(**kwargs)
             api.send_sms(
                 consent_request.user_phone,
@@ -118,3 +118,17 @@ class Callback(View):
 
     def get(self, request, *args, **kwargs):
         return HttpResponse("Status=0")
+
+    def _check_user_consents(self, user_response: str) -> bool:
+        """
+        Matches user response against parametered consent response.
+
+        User response will be trimmed and any existing period, removed
+        :returns: True if user response matches the parametered consent response,
+                  False otherwise.
+        """
+        # Regex to strip spaces and remove possible final period.
+        # Test on https://regex101.com/ for explanation
+        actual_response = re.sub(r"(^\s*)|(\s*\.?\s*$)", "", user_response).lower()
+        expected_response = settings.SMS_RESPONSE_CONSENT.lower().strip()
+        return actual_response == expected_response


### PR DESCRIPTION
## 🌮 Objectif

Initialement, le code du consentement par SMS ne gérait que la réponse sans ponctuation. Mais avec claviers virtuels sur téléphone, il n'est pas rare d'avoir le réflexe de mettre un point final ou de taper 2 fois sur la barre d'espace pour insérer un point final par réflexe. Il semble plus logique de prendre en compte ce cas aussi.

## 🔍 Implémentation

Le message reçu est passé par une regex qui supprime les caractère blanc en début et fin de message et un éventuel point final.