### PR TITLE
Ajout d'un bouton pour revenir à l'état en attente de validation des demande d'habilitation

### DIFF
--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -370,6 +370,11 @@ class OrganisationRequest(models.Model):
             self.notify_issuer_request_modified()
 
     @transaction.atomic
+    def go_in_waiting_again(self):
+        self.status = RequestStatusConstants.AC_VALIDATION_PROCESSING.name
+        self.save()
+
+    @transaction.atomic
     def accept_request_and_create_organisation(self):
         if self.status != RequestStatusConstants.AC_VALIDATION_PROCESSING.name:
             return False

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/change_form.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/change_form.html
@@ -3,6 +3,15 @@
 
 {% block object-tools-items %}
   {% with status=adminform.form.instance.status %}
+
+      {% if status in "AC_VALIDATION_PROCESSING,CHANGES_REQUESTED,VALIDATED,REFUSED,CLOSED" %}
+          <li>
+              <a href="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_waiting' object_id=object_id %}">
+                  Remettre en attente
+              </a>
+          </li>
+      {% endif %}
+
     {% if status in "AC_VALIDATION_PROCESSING,CHANGES_REQUESTED" %}
       <li>
         <a href="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_accept' object_id=object_id %}">

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/in_waiting_form.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/admin/organisation_request/in_waiting_form.html
@@ -1,0 +1,34 @@
+{% extends "admin/base_site.html" %}
+{% load static admin_extras ac_extras i18n %}
+
+{% block extrastyle %}
+    {{ block.super }}
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}">
+    {{ media.css }}
+{% endblock %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media.js }}
+{% endblock %}
+
+{% block content %}
+    <h1>Remettre en attente la demande d'habilitation n° {{ object.data_pass_id }}</h1>
+    <h2>La demande est celle de l'organisation {{ object.name }}</h2>
+    <h2> La demande est actuellement en statut : {{ object.status_label }}</h2>
+    <form action="{% qurl 'otpadmin:aidants_connect_habilitation_organisationrequest_waiting' object_id=object_id %}"
+          method="POST">
+
+        <div class="submit-row">
+            <input type="submit" value="Remettre en attente la demande" class="default" name="_save">
+            <p class="deletelink-box">
+                <a href="{% url 'otpadmin:aidants_connect_habilitation_organisationrequest_change' object_id=object_id %}"
+                   class="closelink">Annuler</a>
+            </p>
+        </div>
+        {% csrf_token %}
+    </form>
+
+
+{% endblock %}

--- a/aidants_connect_habilitation/tests/test_models.py
+++ b/aidants_connect_habilitation/tests/test_models.py
@@ -324,6 +324,17 @@ class OrganisationRequestTests(TestCase):
             RequestStatusConstants.REFUSED.name,
         )
 
+    def test_go_in_waiting_again(self):
+        organisation_request = OrganisationRequestFactory(
+            status=RequestStatusConstants.REFUSED.name
+        )
+        organisation_request.go_in_waiting_again()
+
+        self.assertEqual(
+            RequestStatusConstants.AC_VALIDATION_PROCESSING.name,
+            organisation_request.status,
+        )
+
 
 class TestIssuerEmailConfirmation(TestCase):
     NOW = now()


### PR DESCRIPTION
## 🌮 Objectif

Assez régulierement les bizdev ont besoin de pouvoir remettre une demande d'habilitation dans l'état en attente de validation. Actuellement c'est fait par l'action de quelqu'un ayant un accès BD prod. Cette PR ajoute un bouton dans l'admin django pour que les bizzdev puissent être autonome sur le sujet. 


## 🔍 Implémentation

Ajout d'un bouton admin

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
