### PR TITLE
Test de l'email insensible à la casse dans `LoginEmailForm`

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -458,7 +458,7 @@ class AidantRequestForm(PatchedModelForm, CleanEmailMixin):
     def clean_email(self):
         email = super().clean_email()
 
-        query = Q(organisation=self.organisation) & Q(email=email)
+        query = Q(organisation=self.organisation) & Q(email__iexact=email)
         if getattr(self.instance, "pk"):
             # This user already exists, and we need to verify that
             # we are not trying to modify its email with the email

--- a/aidants_connect_habilitation/models.py
+++ b/aidants_connect_habilitation/models.py
@@ -448,7 +448,7 @@ class OrganisationRequest(models.Model):
     def create_aidants(self, organisation: Organisation):
         for aidant in self.aidant_requests.all():
             HabilitationRequest.objects.get_or_create(
-                email=aidant.email,
+                email__iexact=aidant.email,
                 organisation=organisation,
                 defaults=dict(
                     origin=HabilitationRequest.ORIGIN_HABILITATION,

--- a/aidants_connect_habilitation/tasks.py
+++ b/aidants_connect_habilitation/tasks.py
@@ -17,7 +17,7 @@ def update_pix_and_create_aidant(json_result):
             person["date d'envoi"], "%Y-%m-%d"
         ).astimezone(ZoneInfo("Europe/Paris"))
         aidants_a_former = HabilitationRequest.objects.filter(
-            email=person["email saisi"]
+            email__iexact=person["email saisi"]
         )
 
         if aidants_a_former.exists():

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -772,7 +772,9 @@ class HabilitationRequestImportDateFormationResource(resources.ModelResource):
             instance.validate_and_create_aidant()
 
     def after_save_instance(self, instance, using_transactions, dry_run):
-        aidants_a_former = HabilitationRequest.objects.filter(email=instance.email)
+        aidants_a_former = HabilitationRequest.objects.filter(
+            email__iexact=instance.email
+        )
         for aidant in aidants_a_former:
             if not aidant.formation_done:
                 aidant.formation_done = True

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -149,7 +149,7 @@ class LoginEmailForm(MagicAuthEmailForm):
 
     def clean_email(self):
         user_email = super().clean_email()
-        if not Aidant.objects.filter(email=user_email, is_active=True).exists():
+        if not Aidant.objects.filter(email__iexact=user_email, is_active=True).exists():
             raise ValidationError(
                 "Votre compte existe mais il n’est pas encore actif. "
                 "Si vous pensez que c’est une erreur, prenez contact avec votre "

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -130,7 +130,7 @@ class AidantChangeForm(forms.ModelForm):
 
         if data_email != initial_email:
             if (
-                Aidant.objects.filter(email=data_email).exists()
+                Aidant.objects.filter(email__iexact=data_email).exists()
                 or Aidant.objects.exclude(id=initial_id)
                 .filter(username=data_email)
                 .exists()

--- a/aidants_connect_web/tests/test_views/test_login.py
+++ b/aidants_connect_web/tests/test_views/test_login.py
@@ -11,6 +11,16 @@ class LoginTests(TestCase):
     def setUpTestData(cls):
         cls.client = Client()
         cls.aidant = AidantFactory(is_active=False, post__with_otp_device=True)
+        cls.aidant_active = AidantFactory(is_active=True, post__with_otp_device=True)
+
+    def test_user_can_connect_with_uppercase_email(self):
+        response = self.client.post(
+            "/accounts/login/",
+            {"email": self.aidant_active.email.upper(), "otp_token": "123456"},
+        )
+        self.assertEqual(response.status_code, 302)
+        # Check no email was sent
+        self.assertEqual(len(mail.outbox), 1)
 
     def test_inactive_aidant_with_valid_totp_cannot_login(self):
         response = self.client.post(

--- a/aidants_connect_web/views/datapass.py
+++ b/aidants_connect_web/views/datapass.py
@@ -46,7 +46,7 @@ def habilitation_already_exists(content):
     if email:
         email = email.lower()
     return HabilitationRequest.objects.filter(
-        email=email,
+        email__iexact=email,
         organisation__data_pass_id=content["data_pass_id"],
     )
 

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -471,7 +471,7 @@ def new_habilitation_request(request):
     habilitation_request = form.save(commit=False)
 
     if Aidant.objects.filter(
-        email=habilitation_request.email,
+        email__iexact=habilitation_request.email,
         organisation__in=responsable.responsable_de.all(),
     ).exists():
         django_messages.warning(


### PR DESCRIPTION
## 🌮 Objectif

Certains et certaines de nos utilisatrice s'enregistrent avec leur nom de famille en majuscule dans l'email. `LoginEmailForm` teste que le profil est actif avant de valider la connexion mais ce test est sensible à la casse.

Cette PR rend le test insensible à la casse.