### PR TITLE
ne pas envoyer les emails concernant les mandats presque expirés aux responsables

### DIFF
--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -76,6 +76,14 @@ def delete_duplicated_static_tokens(*, logger=None):
             token.delete()
 
 
+def get_recipient_list_for_organisation(organisation):
+    return list(
+        organisation.aidants.filter(can_create_mandats=True).values_list(
+            "email", flat=True
+        )
+    )
+
+
 @shared_task
 def notify_soon_expired_mandates():
 
@@ -87,7 +95,7 @@ def notify_soon_expired_mandates():
     )
 
     for organisation in organisations:
-        recipient_list = list(organisation.aidants.values_list("email", flat=True))
+        recipient_list = get_recipient_list_for_organisation(organisation)
 
         org_mandates: List[Mandat] = list(
             mandates_qset.filter(organisation=organisation)

--- a/aidants_connect_web/tests/test_tasks.py
+++ b/aidants_connect_web/tests/test_tasks.py
@@ -6,10 +6,21 @@ import pytz
 
 from aidants_connect_habilitation.tasks import update_pix_and_create_aidant
 from aidants_connect_web.models import Aidant, HabilitationRequest
+from aidants_connect_web.tasks import get_recipient_list_for_organisation
 from aidants_connect_web.tests.factories import (
+    AidantFactory,
     HabilitationRequestFactory,
     OrganisationFactory,
 )
+
+
+class UtilsTaskTests(TestCase):
+    def test_get_recipient_list_for_organisation(self):
+        orga = OrganisationFactory()
+        AidantFactory(organisation=orga, can_create_mandats=True)
+        AidantFactory(organisation=orga, can_create_mandats=False)
+        self.assertEqual(1, Aidant.objects.filter(can_create_mandats=True).count())
+        self.assertEqual(1, len(get_recipient_list_for_organisation(orga)))
 
 
 class ImportPixTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

ne pas envoyer les emails concernant les mandats presque expirés aux responsables

## 🔍 Implémentation

Ajout d'une condition de filtre, extraction de la requete dans une fonction et ajout d'un test.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
