### PR TITLE
[Habilitation] Recherche d'aidant par email insensible à la casse

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -458,7 +458,7 @@ class AidantRequestForm(PatchedModelForm, CleanEmailMixin):
     def clean_email(self):
         email = super().clean_email()
 
-        query = Q(organisation=self.organisation) & Q(email=email)
+        query = Q(organisation=self.organisation) & Q(email__iexact=email)
         if getattr(self.instance, "pk"):
             # This user already exists, and we need to verify that
             # we are not trying to modify its email with the email


### PR DESCRIPTION
## 🌮 Objectif

On a encore des erreurs en prod sur des emails en majuscule. Même si tous les `Forms` de l'habilitationnettoient l'email pour la mettre en minuscule, il me semble plus sûr de vérifier la présence de doublons de manière insensible à la casse.