### PR TITLE
Recherche de profil aidant insensible dans `LoginEmailForm`

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -149,7 +149,7 @@ class LoginEmailForm(MagicAuthEmailForm):
 
     def clean_email(self):
         user_email = super().clean_email()
-        if not Aidant.objects.filter(email=user_email, is_active=True).exists():
+        if not Aidant.objects.filter(email__iexact=user_email, is_active=True).exists():
             raise ValidationError(
                 "Votre compte existe mais il n’est pas encore actif. "
                 "Si vous pensez que c’est une erreur, prenez contact avec votre "


### PR DESCRIPTION
## 🌮 Objectif

On a trop de personnes qui utilisent des casses différentes pour leur email en prod produisant des tickets de support inutiles. La recherche est de toutes façons [déjà insensible à la casse dans Magicauth](https://github.com/betagouv/django-magicauth/blob/master/magicauth/forms.py#L19).