### PR TITLE
Revert "nettoyage de la session après avoir créé un mandat avec succès"

### DIFF
--- a/aidants_connect_web/views/mandat.py
+++ b/aidants_connect_web/views/mandat.py
@@ -363,18 +363,8 @@ class NewMandatRecap(RequireConnectionMixin, FormView):
 
 
 @aidant_logged_with_activity_required
-class NewMandateSuccess(RequireConnectionMixin, TemplateView):
+class NewMandateSuccess(RequireConnectionView, TemplateView):
     template_name = "aidants_connect_web/new_mandat/new_mandat_success.html"
-
-    def dispatch(self, request, *args, **kwargs):
-        if isinstance(result := self.check_connection(request), HttpResponse):
-            return result
-
-        self.connection = result
-        self.aidant: Aidant = request.user
-        # Clear the session
-        self.request.session.pop("connection")
-        return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         return {


### PR DESCRIPTION
Nettoyer la session à ce point ne fonctionne pas parce qu'on a encore besoin du numéro de connection à l'étape d'après pour visualiser le mandat final.