### PR TITLE
Nettoyage de la connection avant toute création ou renouvellement de mandat 

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -7,6 +7,7 @@ from os.path import dirname
 from os.path import join as path_join
 from re import sub as regex_sub
 from typing import Collection, Iterable, Optional, Union
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -677,6 +678,13 @@ class Usager(models.Model):
             search_term.append(self.preferred_username)
 
         return search_term
+
+    @property
+    def renew_mandate_url(self):
+        parameters = urlencode(
+            {"next": reverse("renew_mandat", kwargs={"usager_id": self.id})}
+        )
+        return f"{reverse('clear_connection')}?{parameters}"
 
     def __str__(self):
         return f"{self.given_name} {self.family_name}"

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -50,7 +50,7 @@
             <a id="view_mandats" class="tile text-center background-color-grey" href="{% url 'usagers' %}">
               <span aria-hidden="true">📂<br/></span>Mes mandats
             </a>
-            <a id="add_usager" class="tile text-center background-color-grey" href="{% url 'new_mandat' %}">
+            <a id="add_usager" class="tile text-center background-color-grey" href="{{ new_mandat_url }}">
               <span aria-hidden="true">📝<br/></span>Créer un mandat
             </a>
           {% endif %}

--- a/aidants_connect_web/templates/aidants_connect_web/usager_details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager_details.html
@@ -39,7 +39,7 @@
             </h4>
             <div class="float-right text-right">
               <a id="view_mandat_attestation" class="button" href="{% url 'mandat_visualisation' mandat_id=mandat.id %}"><span aria-hidden="true">🖨&nbsp;</span>Voir l’attestation</a>
-                <a id="renew_mandat" class="button" href="{% url 'renew_mandat' usager_id=usager.id %}"><span aria-hidden="true">🖨&nbsp;</span>Renouveler le mandat</a>
+                <a id="renew_mandat" class="button" href="{{ usager.renew_mandate_url }}"><span aria-hidden="true">🖨&nbsp;</span>Renouveler le mandat</a>
               <a id="cancel_mandat" class="button-outline warning" href="{% url 'confirm_mandat_cancelation' mandat_id=mandat.id %}">
                 Révoquer le mandat <span aria-hidden="true">&nbsp;🗑️</span>
               </a>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
@@ -29,6 +29,6 @@
   {% if has_no_autorisations %}
   <td></td>
   {% else %}
-  <td><a href="{% url 'renew_mandat' usager_id=usager.id %}">Renouveler le mandat</a></td>
+  <td><a href="{{ usager.renew_mandate_url }}">Renouveler le mandat</a></td>
   {% endif %}
 </tr>

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlencode
+
 from django.conf import settings
 from django.test import TestCase, tag
 from django.test.client import Client
@@ -183,7 +185,10 @@ class UsagersDetailsPageTests(TestCase):
         response = self.client.get(f"/usagers/{self.usager.id}/")
         response_content = response.content.decode("utf-8")
         self.assertIn("Renouveler le mandat", response_content)
-        self.assertIn(reverse("renew_mandat", args=(self.usager.pk,)), response_content)
+        parameters = urlencode(
+            {"next": reverse("renew_mandat", kwargs={"usager_id": self.usager.id})}
+        )
+        self.assertIn(f"{reverse('clear_connection')}?{parameters}", response_content)
 
 
 @tag("responsable-structure")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -95,6 +95,11 @@ urlpatterns = [
         name="renew_mandat_waiting_room_json",
     ),
     # new mandat
+    path(
+        "clear_connection/",
+        mandat.ClearConnectionView.as_view(),
+        name="clear_connection",
+    ),
     path("creation_mandat/", mandat.NewMandat.as_view(), name="new_mandat"),
     path(
         "creation_mandat/recapitulatif/",

--- a/aidants_connect_web/views/espace_aidant.py
+++ b/aidants_connect_web/views/espace_aidant.py
@@ -1,4 +1,4 @@
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode
 
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -16,11 +16,14 @@ from aidants_connect_web.models import Aidant, Journal
 @login_required
 def home(request):
     aidant = request.user
-
+    parameters = urlencode({"next": reverse("new_mandat")})
     return render(
         request,
         "aidants_connect_web/espace_aidant/home.html",
-        {"aidant": aidant},
+        {
+            "new_mandat_url": f"{reverse('clear_connection')}?{parameters}",
+            "aidant": aidant,
+        },
     )
 
 


### PR DESCRIPTION
## 🌮 Objectif

#806 tentait de régler le problème de connection qui persiste à travers les sessions mais nous avons dû la revert avec #812 car elle introduisait une régression. Cette PR tente dé régler le problème d'une autre manière. Nous continuons d'avoir des soucis avec des données de connection manquante sur la prod. Peut-être que régler ce problème pourrait nous aider à y voir plus clair.

## 🔍 Implémentation

- Ajout d'une vue `ClearConnectionView` dont le seul usage est de nettoyer la session des propriétés `connection` et `qr_code_mandat_id` et rediriger vers la route renseignée par le paramètre d'URL `next`.
- Les boutons *Créer un mandat* et *Renouveler le mandat* passent maintenant par cette vue pour nettoyer la session.
- Le modèle `Usager` contient maintenant une propriété `renew_mandate_url` qui contient l'URL à suivre pour nettoyer la session puis renouveler le mandat actuel de la personne accompagnée.
