### PR TITLE
Ajout du bouton *Espace aidant* à la nouvelle navbar

### DIFF
--- a/aidants_connect_habilitation/templates/layouts/_header.html
+++ b/aidants_connect_habilitation/templates/layouts/_header.html
@@ -19,6 +19,9 @@
               <li>
                 <a {% if view_name == 'home_page' %}class="active"{% endif %} href="{% url 'home_page' %}">Accueil</a>
               </li>
+              {% if user_is_authenticated %}<li>
+                <a {% if view_name == 'espace_aidant' %}class="active"{% endif %} href="{% url 'espace_aidant_home' %}">Espace aidant</a>
+              </li>{% endif %}
               <li>
                 <a {% if 'habilitation' in view_name %}class="active"{% endif %}
                    href="{% url 'habilitation' %}">Premiers pas</a>
@@ -31,9 +34,9 @@
                 <a {% if 'faq' in view_name %}class="active"{% endif %}
                    href="{% url 'faq_generale' %}">Aide</a>
               </li>
-              <li>
-                {% if not user_is_authenticated %}<a class="button primary" href="{% url 'login' %}">Se connecter</a>{% endif %}
-              </li>
+              {% if not user_is_authenticated %}<li>
+                <a class="button primary" href="{% url 'login' %}">Se connecter</a>
+              </li>{% endif %}
             {% endwith %}
           </ul>
         </nav>


### PR DESCRIPTION
## 🌮 Objectif

Depuis #822, le bouton pour se connecter n'est plus affiché quand l'utilisateur est connecté. Ce bouton état la seule voie d'entrée vers l'espace aidant depuis l'accueil. Cette PR rajoute le bouton pour aller à l'espace aidant dans la navbar.

## 🖼️ Images

![](https://user-images.githubusercontent.com/22097904/224058365-94bc2752-e17c-4d2c-bdf6-2c97f12fcd71.png)

