### PR TITLE
Répare le hook de précommit qui ne semble pas fonctionner dans tous les environnements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
     - id: missing-django-migrations
       name: Check for missing django migrations
-      entry: ./manage.py makemigrations --no-input --dry-run --check
+      entry: pipenv run python manage.py makemigrations --no-input --dry-run --check
       language: system
       pass_filenames: false
   - repo: https://github.com/psf/black


### PR DESCRIPTION
## 🌮 Objectif

Permettre à nous autres qui développons sur MacOS de pouvoir commiter.

## 🔍 Explication/Implémentation

Nous avons installé les dépendances avec pipenv et le script "vérifier les migrations" lève une erreur qui n'a rien à voir avec la choucroute, comme quoi il manque la dépendance "celery".

En exécutant le script "à la pipenv" ça marche bien chez nous, qu'est-ce que ça donne pour vous @christophehenry et @mrjmad ?
