### PR TITLE
Passage des FK `usager` et `aidant` en `raw_id_fields` dans le modèle `ConnectionAdmin`

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -1292,6 +1292,7 @@ class MandatAdmin(VisibleToTechAdmin, ModelAdmin):
 
 class ConnectionAdmin(ModelAdmin):
     list_display = ("id", "usager", "aidant", "complete")
+    raw_id_fields = ("usager", "aidant")
 
 
 class JournalAdmin(VisibleToTechAdmin, ModelAdmin):


### PR DESCRIPTION
## 🌮 Objectif

Passage des FK `usager` et `aidant` en `raw_id_fields` dans le modèle `ConnectionAdmin`
