### PR TITLE
Rendre accessible les pages du Pico CMS aux admins métier

### DIFF
--- a/aidants_connect_pico_cms/admin.py
+++ b/aidants_connect_pico_cms/admin.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import ModelAdmin, register
 from django.forms import models
 
-from aidants_connect.admin import admin_site
+from aidants_connect.admin import VisibleToAdminMetier, admin_site
 from aidants_connect_common.widgets import SearchableRadioSelect
 from aidants_connect_pico_cms.models import (
     FaqCategory,
@@ -11,7 +11,7 @@ from aidants_connect_pico_cms.models import (
 )
 
 
-class CmsAdmin(ModelAdmin):
+class CmsAdmin(VisibleToAdminMetier, ModelAdmin):
     list_display = (
         "__str__",
         "slug",
@@ -100,6 +100,6 @@ class MandateTranslationAdminForm(models.ModelForm):
 
 
 @register(MandateTranslation, site=admin_site)
-class MandateTranslationAdmin(ModelAdmin):
+class MandateTranslationAdmin(VisibleToAdminMetier, ModelAdmin):
     list_display = ("__str__",)
     form = MandateTranslationAdminForm

--- a/aidants_connect_pico_cms/tests/test_admin.py
+++ b/aidants_connect_pico_cms/tests/test_admin.py
@@ -1,0 +1,43 @@
+from django.test import TestCase, tag
+from django.test.client import Client
+from django.urls import reverse
+
+from django_otp import DEVICE_ID_SESSION_KEY
+from django_otp.plugins.otp_static.models import StaticDevice
+
+from aidants_connect_pico_cms.models import FaqQuestion, MandateTranslation, Testimony
+from aidants_connect_web.tests.factories import AidantFactory
+
+
+@tag("admin")
+class VisibilityAdminPageTests(TestCase):
+    amac_models = [
+        Testimony,
+        FaqQuestion,
+        MandateTranslation,
+    ]
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.amac_user = AidantFactory(
+            is_staff=True,
+            is_superuser=False,
+        )
+        cls.amac_user.set_password("password")
+        cls.amac_user.save()
+        amac_device = StaticDevice.objects.create(user=cls.amac_user, name="Device")
+
+        cls.amac_client = Client()
+        cls.amac_client.force_login(cls.amac_user)
+        # we need do this :
+        # https://docs.djangoproject.com/en/3.1/topics/testing/tools/#django.test.Client.session
+        amac_session = cls.amac_client.session
+        amac_session[DEVICE_ID_SESSION_KEY] = amac_device.persistent_id
+        amac_session.save()
+
+    def test_views_visible_by_amac_were_visible_by_amac_users(self):
+        for model in self.amac_models:
+            url_root = f"admin:{model._meta.app_label}_{model.__name__.lower()}"
+            list_url = reverse(url_root + "_changelist")
+            response = self.amac_client.get(list_url)
+            self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## 🌮 Objectif

Rendre accessible les pages du Pico CMS aux admins métier

## 🔍 Implémentation

Ajout du mixin qui va bien et d'un test.

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
