### PR TITLE
Fix sur le modèle `CardSendingAdmin`

### DIFF
--- a/aidants_connect_erp/admin.py
+++ b/aidants_connect_erp/admin.py
@@ -51,9 +51,9 @@ class CardSendingAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
     search_fields = (
         "organisation__name",
         "organisation__city",
-        "responsable_first_name",
-        "responsable_last_name",
-        "responsable_email",
+        "responsable__first_name",
+        "responsable__last_name",
+        "responsable__email",
     )
 
 


### PR DESCRIPTION
## 🌮 Objectif

En prod, le modèle `CardSendingAdmin` crash parce que le champ `responsable_first_name` n'existe pas. Il s'agit en fait du champ relié `responsable__first_name`.