### PR TITLE
Pouvoir habiliter des HabilitationRequest en statut annulée

### DIFF
--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -1043,6 +1043,7 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
                 HabilitationRequest.STATUS_NEW,
                 HabilitationRequest.STATUS_WAITING_LIST_HABILITATION,
                 HabilitationRequest.STATUS_VALIDATED,
+                HabilitationRequest.STATUS_CANCELLED,
             )
         )
         treated_emails = set()

--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -611,6 +611,7 @@ class HabilitationRequest(models.Model):
             self.STATUS_NEW,
             self.STATUS_WAITING_LIST_HABILITATION,
             self.STATUS_VALIDATED,
+            self.STATUS_CANCELLED,
         ):
             return False
 

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1828,20 +1828,18 @@ class HabilitationRequestMethodTests(TestCase):
         self.assertIn(habilitation_request.organisation, aidant.organisations.all())
 
     def test_do_not_validate_if_invalid_status(self):
-        for status in (
-            HabilitationRequest.STATUS_REFUSED,
-            HabilitationRequest.STATUS_CANCELLED,
-        ):
-            habilitation_request = HabilitationRequestFactory(status=status)
-            self.assertEqual(
-                0, Aidant.objects.filter(email=habilitation_request.email).count()
-            )
-            self.assertFalse(habilitation_request.validate_and_create_aidant())
-            self.assertEqual(
-                0, Aidant.objects.filter(email=habilitation_request.email).count()
-            )
-            db_hab_request = HabilitationRequest.objects.get(id=habilitation_request.id)
-            self.assertEqual(db_hab_request.status, status)
+        habilitation_request = HabilitationRequestFactory(
+            status=HabilitationRequest.STATUS_REFUSED
+        )
+        self.assertEqual(
+            0, Aidant.objects.filter(email=habilitation_request.email).count()
+        )
+        self.assertFalse(habilitation_request.validate_and_create_aidant())
+        self.assertEqual(
+            0, Aidant.objects.filter(email=habilitation_request.email).count()
+        )
+        db_hab_request = HabilitationRequest.objects.get(id=habilitation_request.id)
+        self.assertEqual(db_hab_request.status, HabilitationRequest.STATUS_REFUSED)
 
 
 @tag("models", "manndat", "usager", "journal")


### PR DESCRIPTION
## 🌮 Objectif

Pouvoir habiliter des HabilitationRequest en statut annulée

## 🔍 Implémentation

-  Modification des statuts permis pour l'habilitation de masse et ajout d'un test

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
