### PR TITLE
Remplacement du lien vers MobileConnect et moi (obselète) par un lien vers Yris dans generale.html

### DIFF
--- a/aidants_connect_web/templates/public_website/faq/generale.html
+++ b/aidants_connect_web/templates/public_website/faq/generale.html
@@ -106,7 +106,7 @@
           <li><a href="https://www.ameli.fr/" target="_blank" rel="noopener">ameli.fr</a>,</li>
           <li><a href="https://www.msa.fr/" target="_blank" rel="noopener">msa.fr</a>,</li>
           <li><a href="https://lidentitenumerique.laposte.fr/" target="_blank" rel="noopener">l’Identité Numérique La Poste</a>,</li>
-          <li><a href="https://www.mobileconnectetmoi.fr" target="_blank" rel="noopener">MobileConnect et moi</a>.</li>
+          <li><a href="https://www.yris.eu/fr/" target="_blank" rel="noopener">Yris</a>.</li>
         </ul>
         <p>
           Si le mandant ne possède pas d'adresse e-mail, le mandataire peut dans le cadre de son mandat, s’engager à accomplir, au nom et pour le compte du mandant, les missions suivantes :


### PR DESCRIPTION
Changement fournisseur d'identité : Mobile Connect et moi a été remplacé par Yris

## 🌮 Objectif

_Un petit résumé de l'objectif de la PR en 1 ligne_

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
