### PR TITLE
Stockage de la connexion dans la session uniquement à la toute fin de la vue lorsqu'utilisé comme fournisseur d'identité.

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/authorize.html
@@ -24,10 +24,11 @@
                 <div class="fr-col-12">
                   <label id="filter-input-label" for="anonymous-filter-input">Rechercher un usager :</label>
                   <input type="text" id="anonymous-filter-input" required/>
-                  <input id="anonymous-filter-input-id" name="chosen_usager" aria-hidden="true" hidden/>
+                  <input id="anonymous-filter-input-id" name="chosen_usager" type="hidden"/>
                   <div id="autocomplete" class="autocomplete-input_wrapper input-spinner-wrapper"></div>
                 </div>
                 {% for field in oauth_parameters_form %}{{ field.as_hidden }}{% endfor %}
+                <input name="connection_id" value="{{ connection_id }}" type="hidden"/>
                 {% csrf_token %}
               </div>
               <button id="submit-button" class="primary float-right" type="submit">Séléctionner</button>
@@ -51,13 +52,13 @@
               <form class="user-detail-item" method="post">
                 {% csrf_token %}
                 {% for field in oauth_parameters_form %}{{ field.as_hidden }}{% endfor %}
+                  <input name="connection_id" value="{{ connection_id }}" type="hidden"/>
                 <span>{{ usager.get_full_name }}</span>
                 <input
                   id="filter-input-id"
                   name="chosen_usager"
                   value="{{ usager.id }}"
-                  aria-hidden="true"
-                  hidden
+                  type="hidden"
                 />
                 <button class="primary" type="submit" data-user-id="{{ usager.id }}">Sélectionner</button>
               </form>

--- a/aidants_connect_web/tests/test_views/test_id_provider.py
+++ b/aidants_connect_web/tests/test_views/test_id_provider.py
@@ -181,14 +181,11 @@ class AuthorizeTests(TestCase):
             state="avalidstate123", nonce="avalidnonce456", usager=self.usager
         )
 
-        session = self.client.session
-        session["connection"] = connection.id
-        session.save()
-
         response = self.client.post(
             "/authorize/",
             data={
                 "chosen_usager": connection.usager.id,
+                "connection_id": connection.id,
                 # Pass valid OAuth data for changing user feature
                 **self.valid_oauth_data,
             },
@@ -210,14 +207,12 @@ class AuthorizeTests(TestCase):
         self,
     ):
         self.client.force_login(self.aidant_thierry)
-        session = self.client.session
-        session["connection"] = self.connection.pk
-        session.save()
 
         response = self.client.post(
             "/authorize/",
             data={
                 "chosen_usager": 1,
+                "connection_id": self.connection.pk,
                 # Pass valid OAuth data for changing user feature
                 **self.valid_oauth_data,
             },
@@ -231,9 +226,20 @@ class AuthorizeTests(TestCase):
 
     def test_post_to_authorize_with_unknown_connection_triggers_forbidden(self):
         self.client.force_login(self.aidant_thierry)
-        session = self.client.session
-        session["connection"] = self.connection.id + 1
-        session.save()
+
+        response = self.client.post(
+            "/authorize/",
+            data={
+                "chosen_usager": 1,
+                "connection_id": self.connection.id + 1,
+                # Pass valid OAuth data for changing user feature
+                **self.valid_oauth_data,
+            },
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_post_to_authorize_omitting_connection_triggers_forbidden(self):
+        self.client.force_login(self.aidant_thierry)
 
         response = self.client.post(
             "/authorize/",
@@ -251,14 +257,11 @@ class AuthorizeTests(TestCase):
             state="avalidstate123", nonce="avalidnonce456", usager=self.usager
         )
 
-        session = self.client.session
-        session["connection"] = connection.pk
-        session.save()
-
         response = self.client.post(
             "/authorize/",
             data={
                 "chosen_usager": "",
+                "connection_id": connection.pk,
                 # Pass valid OAuth data for changing user feature
                 **self.valid_oauth_data,
             },


### PR DESCRIPTION
## 🌮 Objectif

Cette PR pourrait résoudre une petite partie des erreurs *`NoneType` object is not iterable* qu'on a en prod.

Je pense que ces erreurs proviennent de #419 et #819 ne résout pas totalement le problème. Par exemple, si les aidants utilisent un favoris navigateur plutôt que le bouton « *Créer un mandat* » de l'accueil. 

Actuellement, la connection est crée au `GET` et stockée en session pour être réutilisée dans le `POST`. Cette PR réintroduit le passage de connection par le formulaire présent initialement dans #788 et modifié dans #842 pour le fonctionnement actuel. La connexion n'est maintenant plus stockée dans le `SessionStore` avant la toute fin de la vue lorsqu'on est sûrs que toute la procédure s'est bien déroulée.

De manière générale, il faudrait réécrire les vues pour arrêter de stocker les connexions dans le `SessionStore` puisqu'on arrive pas à l'invalider efficacement.

## 🔍 Implémentation

Après la création de la conexion dans le `GET`, la connexion est stockée dans le formulaire et passé lors du `POST`. Elle n'est stockée dans le `SessionStore` dans la méthode `form_valid` juste avant la redirection.