### PR TITLE
Nettoyage de la session sytématique en créant un mandat

### DIFF
--- a/aidants_connect_web/models.py
+++ b/aidants_connect_web/models.py
@@ -7,7 +7,6 @@ from os.path import dirname
 from os.path import join as path_join
 from re import sub as regex_sub
 from typing import Collection, Iterable, Optional, Union
-from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -728,10 +727,7 @@ class Usager(models.Model):
 
     @property
     def renew_mandate_url(self):
-        parameters = urlencode(
-            {"next": reverse("renew_mandat", kwargs={"usager_id": self.id})}
-        )
-        return f"{reverse('clear_connection')}?{parameters}"
+        return reverse("renew_mandat", kwargs={"usager_id": self.id})
 
     def __str__(self):
         return f"{self.given_name} {self.family_name}"

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -65,7 +65,7 @@
             </a>
           </div>
           <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
-            <a id="add_usager" class="tile" href="{{ new_mandat_url }}">
+            <a id="add_usager" class="tile" href="{% url 'new_mandat' %}">
               <span aria-hidden="true">📝<br/></span>Créer un mandat
             </a>
           </div>

--- a/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
+++ b/aidants_connect_web/tests/test_views/test_espace_aidant/test_espace_aidant.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlencode
-
 from django.conf import settings
 from django.test import TestCase, tag
 from django.test.client import Client
@@ -185,10 +183,10 @@ class UsagersDetailsPageTests(TestCase):
         response = self.client.get(f"/usagers/{self.usager.id}/")
         response_content = response.content.decode("utf-8")
         self.assertIn("Renouveler le mandat", response_content)
-        parameters = urlencode(
-            {"next": reverse("renew_mandat", kwargs={"usager_id": self.usager.id})}
+        self.assertIn(
+            reverse("renew_mandat", kwargs={"usager_id": self.usager.id}),
+            response_content,
         )
-        self.assertIn(f"{reverse('clear_connection')}?{parameters}", response_content)
 
 
 @tag("responsable-structure")

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -101,11 +101,6 @@ urlpatterns = [
         name="renew_mandat_waiting_room_json",
     ),
     # new mandat
-    path(
-        "clear_connection/",
-        mandat.ClearConnectionView.as_view(),
-        name="clear_connection",
-    ),
     path("creation_mandat/", mandat.NewMandat.as_view(), name="new_mandat"),
     path(
         "creation_mandat/recapitulatif/",

--- a/aidants_connect_web/views/espace_aidant.py
+++ b/aidants_connect_web/views/espace_aidant.py
@@ -1,4 +1,4 @@
-from urllib.parse import unquote, urlencode
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.contrib import messages as django_messages
@@ -19,7 +19,6 @@ from aidants_connect_web.models import Aidant, Journal, Organisation
 @login_required
 def home(request):
     aidant = request.user
-    parameters = urlencode({"next": reverse("new_mandat")})
     sos_href = mailto_href(
         recipient="contact@aidantsconnect.beta.gouv.fr",
         subject="sos",
@@ -33,7 +32,6 @@ def home(request):
         request,
         "aidants_connect_web/espace_aidant/home.html",
         {
-            "new_mandat_url": f"{reverse('clear_connection')}?{parameters}",
             "aidant": aidant,
             "sos_href": sos_href,
             "sandbox_url": settings.SANDBOX_URL,

--- a/aidants_connect_web/views/renew_mandat.py
+++ b/aidants_connect_web/views/renew_mandat.py
@@ -33,6 +33,9 @@ class RenewMandat(RemoteMandateMixin, MandatCreationJsFormView):
     mandat_form_path = "renew_mandat"
 
     def dispatch(self, request, *args, **kwargs):
+        request.session.pop("connection", None)
+        request.session.pop("qr_code_mandat_id", None)
+
         self.aidant: Aidant = request.user
         self.usager: Usager = self.aidant.get_usager(kwargs.get("usager_id"))
 


### PR DESCRIPTION
## 🌮 Objectif

Cette PR est une suite de la reflexion engagée sur #866. #419 a introduit une reprise de la création de mandat sur erreur France Connect qui nous empêchait, jusqu'ici, de systématiquement nettoyer la session avant la création ou le renouvellement d'un mandat. #819 tentait de contourner le problème en introduisant une vue interméidiaire pour le faire mais cette vue n'est pas atteinte si, par exemple, la page de création de mandat est chargé depuis un favoris navigateur.

En passant l'ID de connection en paramètre de requête URL lors de la reprise sur erreur plutôt que de reposer sur la session, on contourne le problème et on peut enfin systématiquement nettoyer la session.
