### PR TITLE
Permettre aux responsables de délier une carte d'un aidant

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -358,21 +358,42 @@ class CarteTOTPValidationForm(forms.Form):
     )
 
 
-class RemoveCardFromAidantForm(forms.Form):
+class RemoveCardFromAidantForm(PatchedForm):
     reason = forms.ChoiceField(
         choices=(
-            ("perte", "Perte : La carte a été perdue."),
-            ("casse", "Casse : La carte a été détériorée."),
+            ("perte", "Perte : La carte a été perdue."),
+            ("casse", "Casse : La carte a été détériorée."),
             (
                 "dysfonctionnement",
-                "Dysfonctionnement : La carte ne fonctionne pas ou plus.",
+                "Disfonctionnement : La carte ne fonctionne pas ou plus.",
             ),
-            ("depart", "Départ : L’aidant concerné quitte la structure."),
-            ("erreur", "Erreur : J’ai lié cette carte à ce compte par erreur."),
-            ("autre", "Autre : Je complète ci-dessous."),
+            ("depart", "Départ : L’aidant concerné quitte la structure."),
+            ("erreur", "Erreur : J’ai lié cette carte à ce compte par erreur."),
+            ("autre", "Autre : Je complète ci-dessous."),
         )
     )
     other_reason = forms.CharField(required=False)
+
+    def clean(self):
+        cleaned_data = super().clean()
+        reason = cleaned_data.get("reason").lower()
+        other_reason = cleaned_data.get("other_reason")
+
+        if reason != "autre":
+            return cleaned_data
+
+        if not other_reason:
+            self.add_error(
+                "other_reason",
+                ValidationError(
+                    "Vous devez remplir ce champ si la raison indiquée est autre.",
+                    code="required",
+                ),
+            )
+        else:
+            cleaned_data["reason"] = other_reason
+
+        return cleaned_data
 
 
 class SwitchMainAidantOrganisationForm(forms.Form):

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/_aidant_remove_card.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/_aidant_remove_card.html
@@ -1,0 +1,27 @@
+<form
+  method="post"
+  action="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}"
+>
+  {% csrf_token %}
+  <p>
+    Pour supprimer l'association entre la carte {{ aidant.carte_totp.serial_number }}
+    et le compte de l'aidant {{ aidant.get_full_name }},
+    cliquez sur le bouton «&nbsp;Dissocier&nbsp;».
+  </p>
+  {% if form.reason.errors %}<div class="notification error" role="alert">{{ form.reason.errors }}</div>{% endif %}
+  <p>
+    <label for="{{ form.reason.id_for_label }}">Pourquoi séparer cette carte du compte ?</label>
+    {{ form.reason }}
+  </p>
+
+  {% if form.other_reason.errors %}<div class="notification error" role="alert">
+    {{ form.other_reason.errors }}
+  </div>{% endif %}
+  <p>
+    <label for="{{ form.other_reason.id_for_label }}">Autre raison :</label>
+    {{ form.other_reason }}
+  </p>
+  <p>
+    <button class="button warning" type="submit">Dissocier</button>
+  </p>
+</form>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
@@ -5,11 +5,6 @@
 
 {% block title %}Aidants Connect - Fiche aidant : {{ aidant.get_full_name }}{% endblock %}
 
-{% block extracss %}
-  <link href="{% static 'css/espace_aidant.css' %}" rel="stylesheet">
-  <link href="{% static 'css/form.css' %}" rel="stylesheet">
-{% endblock extracss %}
-
 {% block content %}
   <section class="section">
     <div class="container">
@@ -45,26 +40,7 @@
         {% if aidant.carte_totp.serial_number %}
           <details class="background-color-grey">
             <summary>Dissocier la carte {{ aidant.carte_totp.serial_number }} du compte</summary>
-            <form method="post"
-                  action="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}">
-              {% csrf_token %}
-              <p>
-                Pour supprimer l'association entre la carte {{ aidant.carte_totp.serial_number }}
-                et le compte de l'aidant {{ aidant.get_full_name }},
-                cliquez sur le bouton «&nbsp;Dissocier&nbsp;».
-              </p>
-              <div class="form__group">
-                <label for="{{ form.reason.id_for_label }}">Pourquoi séparer cette carte du compte ?</label>
-                {{ form.reason }}
-              </div>
-              <p>
-                <label for="{{ form.other_reason.id_for_label }}">Autre raison :</label>
-                {{ form.other_reason }}
-              </p>
-              <p>
-                <button class="button warning" type="submit">Dissocier</button>
-              </p>
-            </form>
+            {% include "aidants_connect_web/espace_responsable/_aidant_remove_card.html" %}
           </details>
         {% else %}
           <p>

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant_remove_card.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant_remove_card.html
@@ -1,0 +1,23 @@
+{% extends 'layouts/main.html' %}
+
+{% load static %}
+{% load ac_extras %}
+
+{% block title %}Aidants Connect - Fiche aidant : {{ aidant.get_full_name }}{% endblock %}
+
+{% block content %}
+  <section class="section">
+    <div class="container">
+      {% if messages %}
+        {% for message in messages %}
+          <div class="notification {% if message.tags %}{{ message.tags }}{% endif %}" role="alert">{{ message }}</div>
+        {% endfor %}
+      {% endif %}
+      <h1>
+        Dissocier la carte {{ aidant.carte_totp.serial_number }} du compte
+        de lʼaidant {{ aidant.get_full_name }}, {{ aidant.profession }}
+      </h1>
+      {% include "aidants_connect_web/espace_responsable/_aidant_remove_card.html" %}
+    </div>
+  </section>
+{% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -77,7 +77,13 @@
         <tbody class="shadowed">
         {% for aidant in organisation_active_aidants %}
           <tr>
-            <td>{{ aidant.get_full_name }}{% if aidant.pk == responsable.pk %} (Responsable){% endif %}</td>
+            <td>
+              {% if aidant.pk == responsable.pk %}
+                {{ aidant.get_full_name }} (Responsable)
+              {% else %}
+                <a href="{% url 'espace_responsable_aidant' aidant_id=aidant.id %}">{{ aidant.get_full_name }}</a>
+              {% endif %}
+            </td>
             <td>{% mailto recipient=aidant.email %}</td>
             <td>
               {{ aidant.number_totp_card }}
@@ -109,9 +115,18 @@
                 <a href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}" class="button">
                   Lier une carte
                 </a>
-              {% elif not aidant.carte_totp.totp_device.confirmed %}
-                <a href="{% url "espace_responsable_validate_totp" aidant_id=aidant.id %}" class="button">
-                  Valider la carte
+              {% else %}
+                {% if not aidant.carte_totp.totp_device.confirmed %}
+                  <a href="{% url "espace_responsable_validate_totp" aidant_id=aidant.id %}" class="button">
+                    Valider la carte
+                  </a>
+                {% endif %}
+                <a
+                  id="remove-totp-card-from-aidant-{{ aidant.id }}"
+                  href="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}"
+                  class="button"
+                >
+                  Délier la carte
                 </a>
               {% endif %}
             </td>
@@ -185,7 +200,9 @@
         <tbody class="shadowed grey">
         {% for aidant in organisation_inactive_aidants %}
           <tr>
-            <td>{{ aidant.get_full_name }}</td>
+            <td>
+              <a href="{% url 'espace_responsable_aidant' aidant_id=aidant.id %}">{{ aidant.get_full_name }}</a>
+            </td>
             <td>{% mailto recipient=aidant.email %}</td>
             <td>
               {{ aidant.number_totp_card }}
@@ -198,13 +215,13 @@
               {% endif %}
             </td>
             <td>
-              {% if not aidant.has_a_carte_totp %}
-                <a href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}" class="button">
-                  Lier une carte
-                </a>
-              {% elif not aidant.carte_totp.totp_device.confirmed %}
-                <a href="{% url "espace_responsable_validate_totp" aidant_id=aidant.id %}" class="button">
-                  Valider la carte
+              {% if aidant.has_a_carte_totp %}
+                <a
+                  id="remove-totp-card-from-aidant-{{ aidant.id }}"
+                  href="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}"
+                  class="button"
+                >
+                  Délier la carte
                 </a>
               {% endif %}
             </td>

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -91,6 +91,10 @@ class AidantFactory(DjangoModelFactory):
         if kwargs.get("is_organisation_manager", False):
             self.responsable_de.add(self.organisation)
 
+        if kwargs.get("with_carte_totp", False):
+            carte: CarteTOTP = CarteTOTPFactory(aidant=self)
+            carte.createTOTPDevice(confirmed=True).save()
+
     @post_generation
     def password(self, create, value, **_):
         if not create:

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -102,7 +102,9 @@ class CreateNewMandatTests(FunctionalTestCase):
         # FC - Validate the information
         submit_button = self.selenium.find_element(By.TAG_NAME, "button")
         submit_button.click()
-        self.wait.until(self.path_matches("new_mandat_recap", {"state": ".+"}))
+        self.wait.until(
+            self.path_matches("new_mandat_recap", query_params={"state": ".+"})
+        )
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element(By.TAG_NAME, "h1").text
@@ -228,7 +230,9 @@ class CreateNewMandatTests(FunctionalTestCase):
         # FC - Validate the information
         submit_button = self.selenium.find_element(By.TAG_NAME, "button")
         submit_button.click()
-        self.wait.until(self.path_matches("new_mandat_recap", {"state": ".+"}))
+        self.wait.until(
+            self.path_matches("new_mandat_recap", query_params={"state": ".+"})
+        )
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element(By.TAG_NAME, "h1").text
@@ -414,7 +418,9 @@ class CreateNewMandatTests(FunctionalTestCase):
         # FC - Validate the information
         submit_button = self.selenium.find_element(By.TAG_NAME, "button")
         submit_button.click()
-        self.wait.until(self.path_matches("new_mandat_recap", {"state": ".+"}))
+        self.wait.until(
+            self.path_matches("new_mandat_recap", query_params={"state": ".+"})
+        )
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element(By.TAG_NAME, "h1").text

--- a/aidants_connect_web/tests/test_functional/test_remove_card.py
+++ b/aidants_connect_web/tests/test_functional/test_remove_card.py
@@ -1,0 +1,115 @@
+from django.test import tag
+from django.urls import reverse
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.expected_conditions import url_matches
+
+from aidants_connect_common.tests.testcases import FunctionalTestCase
+from aidants_connect_web.models import Aidant
+from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
+
+
+@tag("functional")
+class RemoveAidantFromOrganisationTests(FunctionalTestCase):
+    def setUp(self):
+        self.organisation = OrganisationFactory()
+        self.aidant_responsable: Aidant = AidantFactory(
+            organisation=self.organisation,
+            post__with_otp_device=True,
+            post__is_organisation_manager=True,
+        )
+
+        self.aidant_disabled_with_card: Aidant = AidantFactory(
+            organisation=self.organisation,
+            post__with_carte_totp=True,
+        )
+        self.aidant_disabled_with_card.remove_from_organisation(self.organisation)
+
+        self.aidant_with_card = AidantFactory(
+            organisation=self.organisation,
+            post__with_carte_totp=True,
+        )
+
+    def __get_live_url(self, organisation_id: int):
+        return reverse(
+            "espace_responsable_organisation",
+            kwargs={"organisation_id": organisation_id},
+        )
+
+    def test_remove_card_from_aidant(self):
+        root_path = self.__get_live_url(self.organisation.id)
+
+        self.open_live_url(root_path)
+
+        # Login
+        self.login_aidant(self.aidant_responsable)
+        self.wait.until(url_matches(f"^.+{root_path}$"))
+
+        # First aidant: disabled
+        self.assertIsNotNone(self.aidant_disabled_with_card.carte_totp)
+        button1 = self.selenium.find_element(
+            By.ID,
+            f"remove-totp-card-from-aidant-{ self.aidant_disabled_with_card.id }",
+        )
+        self.assertEqual("Délier la carte", button1.text)
+
+        button1.click()
+        self.wait.until(
+            self.path_matches(
+                "espace_responsable_aidant_remove_card",
+                kwargs={"aidant_id": self.aidant_disabled_with_card.id},
+            )
+        )
+
+        self.selenium.find_element(
+            By.XPATH, "//button[@type='submit' and normalize-space(text())='Dissocier']"
+        ).click()
+
+        self.wait.until(
+            self.path_matches(
+                "espace_responsable_organisation",
+                kwargs={"organisation_id": self.aidant_responsable.organisation.pk},
+            )
+        )
+
+        self.assertElementNotFound(
+            By.ID, f"remove-totp-card-from-aidant-{self.aidant_disabled_with_card.id}"
+        )
+
+        self.aidant_disabled_with_card.refresh_from_db()
+        with self.assertRaises(Aidant.carte_totp.RelatedObjectDoesNotExist):
+            self.aidant_disabled_with_card.carte_totp
+
+        self.assertIsNotNone(self.aidant_with_card.carte_totp)
+        button2 = self.selenium.find_element(
+            By.ID, f"remove-totp-card-from-aidant-{self.aidant_with_card.id}"
+        )
+        self.assertEqual("Délier la carte", button2.text)
+
+        # First aidant: active
+        button2.click()
+        self.wait.until(
+            self.path_matches(
+                "espace_responsable_aidant_remove_card",
+                kwargs={"aidant_id": self.aidant_with_card.id},
+            )
+        )
+
+        self.selenium.find_element(
+            By.XPATH, "//button[@type='submit' and normalize-space(text())='Dissocier']"
+        ).click()
+
+        self.wait.until(
+            self.path_matches(
+                "espace_responsable_organisation",
+                kwargs={"organisation_id": self.aidant_responsable.organisation.pk},
+            )
+        )
+
+        self.assertElementNotFound(
+            By.ID, f"remove-totp-card-from-aidant-{self.aidant_with_card.id}"
+        )
+
+        self.aidant_with_card.refresh_from_db()
+        with self.assertRaises(Aidant.carte_totp.RelatedObjectDoesNotExist):
+            self.aidant_with_card.carte_totp

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
@@ -1,5 +1,6 @@
 from django.test import TestCase, tag
 from django.test.client import Client
+from django.urls import reverse
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
@@ -26,7 +27,6 @@ class DissociateCarteTOTPTests(TestCase):
         cls.dissociation_url = (
             f"/espace-responsable/aidant/{cls.aidant_tim.id}/supprimer-carte/"
         )
-        cls.aidant_url = f"/espace-responsable/aidant/{cls.aidant_tim.id}/"
 
     def create_carte_for_tim(self):
         self.carte = CarteTOTPFactory(
@@ -50,8 +50,10 @@ class DissociateCarteTOTPTests(TestCase):
             self.dissociation_url,
             data={"reason": "perte"},
         )
-        self.assertRedirects(response, self.aidant_url, fetch_redirect_response=False)
-        response = self.client.get(self.aidant_url)
+        self.assertRedirects(
+            response, reverse("espace_responsable_home"), fetch_redirect_response=False
+        )
+        response = self.client.get(response.url, follow=True)
         response_content = response.content.decode("utf-8")
         self.assertIn("Tout s’est bien passé", response_content)
         # Check card still exists but that TOTP Device doesn't

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -188,7 +188,7 @@ urlpatterns = [
     ),
     path(
         "espace-responsable/aidant/<int:aidant_id>/supprimer-carte/",
-        espace_responsable.remove_card_from_aidant,
+        espace_responsable.RemoveCardFromAidant.as_view(),
         name="espace_responsable_aidant_remove_card",
     ),
     path(


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux responsables de délier une carte d'un aidant. J'ai aussi rajouté un lien sur le nom des aidants pour atteindre la page `espace-responsable/aidant/<int:aidant_id>/` qui était un peu cachée. Peut-être que cette page sera supprimée dans le futur, notamment parce que les fonctionnalités qui y sont disponibles sont maintenant aussi disponibles sur l'espace aidant.

J'ai aussi supprimé la possibilité de lier ou valider une carte sur un aidant désactivé. 

## 🖼️ Images

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/cec794b6-4d7f-4980-b27f-e1ad0bf7492f)


