### PR TITLE
Ajout des résultats sous forme XML à CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,10 @@ jobs:
             coverage combine
             coverage report
             coverage html
+            coverage xml
 
       - store_artifacts:
           path: htmlcov
+
+      - store_test_results:
+          path: coverage.xml


### PR DESCRIPTION
## 🌮 Objectif

Ils devraient être disponibles dans l'onglet *TESTS* du job `coverage`.

https://circleci.com/docs/collect-test-data/
