### PR TITLE
Nouvelle tentative de fix du test test_can_add_unconfirmed_otp_device 

### DIFF
--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_app_otp.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_app_otp.py
@@ -36,6 +36,7 @@ class AddAppOTPToAidantTests(TestCase):
         TOTPDevice.objects.create(
             user=cls.aidant_sarah,
             name=TOTPDevice.APP_DEVICE_NAME % cls.aidant_sarah.pk,
+            tolerance=2,
         )
 
         cls.other_organisation = OrganisationFactory()


### PR DESCRIPTION
## 🌮 Objectif

Le test `test_can_add_unconfirmed_otp_device` continue de se vautrer de manière aléatoire. Voyons si augmenter la tolérance du token répare les choses.