### PR TITLE
Ajout feature flag pour la fonctionalité OTP app

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -703,3 +703,4 @@ REST_FRAMEWORK = {
 
 FF_WELCOME_AIDANT = getenv_bool("FF_WELCOME_AIDANT", False)
 FF_DEACTIVATE_OLD_AIDANT = getenv_bool("FF_DEACTIVATE_OLD_AIDANT", False)
+FF_OTP_APP = getenv_bool("FF_OTP_APP", False)

--- a/aidants_connect_web/models/mandat.py
+++ b/aidants_connect_web/models/mandat.py
@@ -610,9 +610,15 @@ class CarteTOTP(models.Model):
     )
     is_functional = models.BooleanField("Fonctionne correctement", default=True)
 
+    @property
+    def totp_device_name(self):
+        return f"Carte n° {self.serial_number}"
+
     @cached_property
     def totp_device(self):
-        return TOTPDevice.objects.filter(user=self.aidant).first()
+        return TOTPDevice.objects.filter(
+            user=self.aidant, name=self.totp_device_name
+        ).first()
 
     class Meta:
         verbose_name = "carte TOTP"
@@ -628,5 +634,5 @@ class CarteTOTP(models.Model):
             step=60,  # todo: some devices may have a different step!
             confirmed=confirmed,
             tolerance=tolerance,
-            name=f"Carte n° {self.serial_number}",
+            name=self.totp_device_name,
         )

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/_organisation_aidants_list.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/_organisation_aidants_list.html
@@ -65,7 +65,7 @@
               Valider la carte
             </a>
           {% endif %}
-          {% if not aidant.has_otp_app %}
+          {% if not aidant.has_otp_app and FF_OTP_APP %}
             <a
               id="add-otp-app-to-aidant-{{ aidant.id }}"
               href="{% url 'espace_responsable_aidant_add_app_otp' aidant_id=aidant.id %}"
@@ -84,7 +84,7 @@
             Délier la carte
           </a>
         {% endif %}
-        {% if aidant.has_otp_app %}
+        {% if aidant.has_otp_app and FF_OTP_APP %}
           <a
             id="add-otp-app-to-aidant-{{ aidant.id }}"
             href="{% url 'espace_responsable_aidant_remove_app_otp' aidant_id=aidant.id %}"

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -2,13 +2,14 @@ import base64
 import contextlib
 from io import BytesIO
 
+from django.conf import settings
 from django.contrib import messages as django_messages
 from django.contrib.auth.decorators import login_required
 from django.db import transaction
 from django.forms import model_to_dict
 from django.http import Http404, HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.views.decorators.http import require_GET, require_http_methods, require_POST
 from django.views.generic import DeleteView, FormView, TemplateView
@@ -123,6 +124,7 @@ class OrganisationView(TemplateView):
             "organisation_active_aidants": organisation_active_aidants,
             "organisation_habilitation_requests": organisation_habilitation_requests,
             "organisation_inactive_aidants": organisation_inactive_aidants,
+            "FF_OTP_APP": settings.FF_OTP_APP,
         }
 
 
@@ -258,6 +260,9 @@ class AddAppOTPToAidant(FormView):
     success_url = reverse_lazy("espace_responsable_home")
 
     def dispatch(self, request, *args, **kwargs):
+        if not settings.FF_OTP_APP:
+            return HttpResponseRedirect(reverse("espace_responsable_home"))
+
         self.responsable: Aidant = request.user
         self.aidant: Aidant = get_object_or_404(Aidant, pk=kwargs["aidant_id"])
 
@@ -332,6 +337,8 @@ class RemoveAppOTPFromAidant(DeleteView):
     success_url = reverse_lazy("espace_responsable_home")
 
     def dispatch(self, request, *args, **kwargs):
+        if not settings.FF_OTP_APP:
+            return HttpResponseRedirect(reverse("espace_responsable_home"))
         self.responsable: Aidant = request.user
         self.aidant: Aidant = get_object_or_404(Aidant, pk=kwargs["aidant_id"])
 


### PR DESCRIPTION
## 🌮 Objectif

Ajout feature flag pour la fonctionalité OTP app

## 🏕 Amélioration continue

- Fix une typo faisant que `AddAppOTPToAidantForm` ne vérifiait pas le token lors de l'ajout,
- Ajout de tests pour `AddAppOTPToAidantForm`
- Fix définitif du test `test_can_add_unconfirmed_otp_device` renommé `test_can_add_otp_device`