### PR TITLE
Modification du filtrage des aidants désactivable

### DIFF
--- a/aidants_connect_web/models/aidant.py
+++ b/aidants_connect_web/models/aidant.py
@@ -32,7 +32,11 @@ class AidantManager(UserManager):
         )
 
     def deactivation_warnable(self):
-        return self.not_connected_recently().filter(deactivation_warning_at=None)
+        return self.not_connected_recently().filter(
+            deactivation_warning_at=None,
+            can_create_mandats=True,
+            carte_totp__created_at__lte=timezone.now() - relativedelta(months=5),
+        )
 
     def deactivable(self):
         return self.not_connected_recently().filter(

--- a/aidants_connect_web/tests/test_tasks.py
+++ b/aidants_connect_web/tests/test_tasks.py
@@ -11,13 +11,14 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 
 from aidants_connect_habilitation.tasks import update_pix_and_create_aidant
-from aidants_connect_web.models import Aidant, HabilitationRequest
+from aidants_connect_web.models import Aidant, CarteTOTP, HabilitationRequest
 from aidants_connect_web.tasks import (
     email_old_aidants,
     get_recipient_list_for_organisation,
 )
 from aidants_connect_web.tests.factories import (
     AidantFactory,
+    CarteTOTPFactory,
     HabilitationRequestFactory,
     OrganisationFactory,
 )
@@ -163,6 +164,10 @@ class EmailOldAidants(TestCase):
                 is_active=True,
                 last_login=timezone.now() - relativedelta(months=5),
                 deactivation_warning_at=None,
+            )
+            warnable_totp = CarteTOTPFactory(aidant=cls.aidants_selected)
+            CarteTOTP.objects.filter(pk=warnable_totp.pk).update(
+                created_at=timezone.now() - relativedelta(months=7)
             )
 
     @freeze_time(NOW)


### PR DESCRIPTION
## 🌮 Objectif

On veut sortir des aidants désactivables : 
- les responsables
- les gens ayant eu une carte TOTP depuis moins de 5 mois

## 🔍 Implémentation

modification de la méthode de filtrage et modification des tests

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
