### PR TITLE
Encore un fix dans le design des email

### DIFF
--- a/aidants_connect_common/templates/layouts/email-base.mjml
+++ b/aidants_connect_common/templates/layouts/email-base.mjml
@@ -13,13 +13,12 @@
     {% if email_title %}<mj-title>{{ email_title }}</mj-title>{% endif %}
     <mj-style inline="inline">
       .wrapper {
-        border: 5px solid #FAD776;
         box-shadow: 10px 10px 0 #FAD776;
       }
     </mj-style>
   </mj-head>
   <mj-body>
-    <mj-wrapper padding="0" css-class="wrapper">
+    <mj-wrapper padding="0" css-class="wrapper" border="5px solid #FAD776">
       <mj-section padding="0">
         <mj-column padding="0">
           <mj-image


### PR DESCRIPTION
## 🌮 Objectif

L'attribut `inline` n'est pas pris en charge par MRML, ce qui signifie que le style est appliqué par un `<style>` dans `<head>`. Hors, GMail ne supporte pas cette fonctionnalité. Cette PR applique le style de la bordure inline pour avoir au moins un affichage correct.