### PR TITLE
Fix de l'affichage PDF dans Chrome

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation.html
@@ -23,11 +23,11 @@
 
     <div class="attestation-content">
       <header class="navbar fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
-        <div class="fr-col-12 fr-col-sm-5">
+        <div class="fr-col-8">
           {% include "layouts/_header_logos.html" %}
         </div>
         {% if qr_code_src %}
-          <div class="fr-col-12 fr-col-sm-7 clearfix">
+          <div class="fr-col-4 clearfix">
             <img alt="" class="float-right img-qrcode" src="{{ qr_code_src }}"/>
           </div>
         {% endif %}


### PR DESCRIPTION
## 🌮 Objectif

Fix de l'affichage PDF dans Chrome. Le principal problème de ce fix est que l'affichage n'est plus correct sur des tout petits écrans (<524px) :

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/eb620752-0acb-4bb4-ba7c-1f66956c918c)

Mais je doute qu'on visualise des mandats sur des écrans si petits.

## 🖼️ Images

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/46549e19-e346-4946-8675-1fcbf7aec3a3)