### PR TITLE
Fixes dans le design des emails

### DIFF
--- a/aidants_connect_common/templates/layouts/email-base.mjml
+++ b/aidants_connect_common/templates/layouts/email-base.mjml
@@ -8,7 +8,8 @@
         background-color="#EF4056"
         color="#FFF"
       />
-      <mj-all font-family="Marianne,arial,sans-serif" font-weight="400" />
+      <mj-section padding="0" />
+      <mj-all font-family="Marianne,arial,sans-serif" font-weight="400" line-height="1.2" />
     </mj-attributes>
     {% if email_title %}<mj-title>{{ email_title }}</mj-title>{% endif %}
     <mj-style inline="inline">
@@ -19,7 +20,7 @@
   </mj-head>
   <mj-body>
     <mj-wrapper padding="0" css-class="wrapper" border="5px solid #FAD776">
-      <mj-section padding="0">
+      <mj-section>
         <mj-column padding="0">
           <mj-image
             padding="0"


### PR DESCRIPTION
## 🌮 Objectif

Fixes dans le design des emails

## 🔍 Implémentation

- `line-height` à 1.2 au lieu de 1
- `padding` à 0 pour `<mj-section>` pour réduire l'espace entre le titre de l'email et le reste du contenu.

## 🖼️ Images

### Avant :

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/eb587a59-010c-411b-86c2-083a421442c8)

### Après :

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/92776dc8-e2fa-473e-b606-9b9522da0d0c)
