### PR TITLE
Fix d'une petite typo sur le renommage de responsable en référent

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/home.html
@@ -39,7 +39,7 @@
           <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
             <a id="view_organisation" class="tile"
                href="{% url 'espace_responsable_home' %}">
-              <span aria-hidden="true">🏢<br/></span>Mon espace référetn
+              <span aria-hidden="true">🏢<br/></span>Mon espace référent
             </a>
           </div>
           {% if not aidant.has_a_totp_device %}


### PR DESCRIPTION
## 🌮 Objectif

Une petite typo a été introduite avec #959.