### PR TITLE
Utilisation d'un <select> pour les filtres d'admin région et département

### DIFF
--- a/aidants_connect/admin.py
+++ b/aidants_connect/admin.py
@@ -1,8 +1,4 @@
-import operator
-from functools import reduce
-
-from django.contrib.admin import SimpleListFilter
-from django.db.models import CharField, Q
+from django.db.models import CharField
 from django.db.models.functions import Length
 
 from django_celery_beat.admin import ClockedScheduleAdmin, PeriodicTaskAdmin
@@ -17,7 +13,6 @@ from django_otp.admin import OTPAdminSite
 from magicauth.models import MagicToken
 
 from aidants_connect_common.lookups import IsNullOrBlank
-from aidants_connect_common.models import Department, Region
 
 admin_site = OTPAdminSite(OTPAdminSite.name)
 admin_site.login_template = "aidants_connect_web/admin/login.html"
@@ -67,83 +62,6 @@ class VisibleToTechAdmin:
 
     def has_delete_permission(self, request, obj=None):
         return self.has_module_permission(request)
-
-
-class RegionFilter(SimpleListFilter):
-    title = "Région"
-
-    parameter_name = "region"
-    filter_parameter_name = "zipcode"
-
-    def lookups(self, request, model_admin):
-        return [(r.insee_code, r.name) for r in Region.objects.all()] + [
-            ("other", "Autre")
-        ]
-
-    def queryset(self, request, queryset):
-        region_pk = self.value()
-
-        if not region_pk:
-            return
-
-        if region_pk == "other":
-            return queryset.filter(**{self.filter_parameter_name: 0})
-
-        region = Region.objects.get(pk=region_pk)
-        qgroup = reduce(
-            operator.or_,
-            (
-                Q(
-                    **{
-                        f"{self.filter_parameter_name}__startswith": d.zipcode  # noqa: E501
-                    }
-                )
-                for d in Department.objects.filter(region=region).all()
-            ),
-        )
-        return queryset.filter(qgroup)
-
-
-class DepartmentFilter(SimpleListFilter):
-    title = "Département"
-
-    parameter_name = "department"
-    filter_parameter_name = "zipcode"
-
-    @classmethod
-    def generate_filter_list(cls, region=None):
-        if not region:
-            return [
-                (d.insee_code, f"{d.name} ({d.zipcode})")
-                for d in Department.objects.all().order_by("name")
-            ] + [("other", "Autre")]
-        return [
-            (
-                dept.insee_code,
-                f"{dept.name} ({dept.zipcode})",
-            )
-            for dept in Department.objects.filter(region=region).order_by("name")
-        ]
-
-    def lookups(self, request, model_admin):
-        region = None
-        region_pk = request.GET.get("region", "other")
-        if region_pk != "other":
-            region = Region.objects.get(pk=region_pk)
-        return self.generate_filter_list(region=region)
-
-    def queryset(self, request, queryset):
-        department_value = self.value()
-        if not department_value:
-            return
-        if department_value == "other":
-            return queryset.filter(
-                Q(**{f"{self.filter_parameter_name}__isnull_or_blank": True})
-                | Q(**{f"{self.filter_parameter_name}__length__lt": 5})
-            )
-        return queryset.filter(
-            **{f"{self.filter_parameter_name}__startswith": department_value}
-        )
 
 
 # Also register the Django Celery Beat models

--- a/aidants_connect_common/admin.py
+++ b/aidants_connect_common/admin.py
@@ -1,4 +1,8 @@
-from django.contrib.admin import ModelAdmin, register
+import operator
+from functools import reduce
+
+from django.contrib.admin import ModelAdmin, SimpleListFilter, register
+from django.db.models import Q
 from django.forms import CharField, Media
 
 from import_export.admin import ImportMixin
@@ -159,3 +163,82 @@ class OrganisationAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
 
 admin_site.register(Region)
 admin_site.register(Department)
+
+
+class RegionFilter(SimpleListFilter):
+    template = "admin/filter-select.html"
+    title = "Région"
+
+    parameter_name = "region"
+    filter_parameter_name = "zipcode"
+
+    def lookups(self, request, model_admin):
+        return [(r.insee_code, r.name) for r in Region.objects.all()] + [
+            ("other", "Autre")
+        ]
+
+    def queryset(self, request, queryset):
+        region_pk = self.value()
+
+        if not region_pk:
+            return
+
+        if region_pk == "other":
+            return queryset.filter(**{self.filter_parameter_name: 0})
+
+        region = Region.objects.get(pk=region_pk)
+        qgroup = reduce(
+            operator.or_,
+            (
+                Q(
+                    **{
+                        f"{self.filter_parameter_name}__startswith": d.zipcode  # noqa: E501
+                    }
+                )
+                for d in Department.objects.filter(region=region).all()
+            ),
+        )
+        return queryset.filter(qgroup)
+
+
+class DepartmentFilter(SimpleListFilter):
+    template = "admin/filter-select.html"
+    title = "Département"
+
+    parameter_name = "department"
+    filter_parameter_name = "zipcode"
+
+    @classmethod
+    def generate_filter_list(cls, region=None):
+        if not region:
+            return [
+                (d.insee_code, f"{d.name} ({d.zipcode})")
+                for d in Department.objects.all().order_by("name")
+            ] + [("other", "Autre")]
+        return [
+            (
+                dept.insee_code,
+                f"{dept.name} ({dept.zipcode})",
+            )
+            for dept in Department.objects.filter(region=region).order_by("name")
+        ]
+
+    def lookups(self, request, model_admin):
+        region = None
+        region_pk = request.GET.get("region", "other")
+        if region_pk != "other":
+            region = Region.objects.get(pk=region_pk)
+        return self.generate_filter_list(region=region)
+
+    def queryset(self, request, queryset):
+        department_value = self.value()
+        if not department_value:
+            return
+        if department_value == "other":
+            return queryset.filter(
+                Q(**{f"{self.filter_parameter_name}__isnull_or_blank": True})
+                | Q(**{f"{self.filter_parameter_name}__length__lt": 5})
+            )
+        return queryset.filter(
+            **{f"{self.filter_parameter_name}__startswith": department_value}
+        )

--- a/aidants_connect_common/static/js/admin-select.js
+++ b/aidants_connect_common/static/js/admin-select.js
@@ -1,0 +1,14 @@
+"use strict";
+
+(function () {
+    class AdminFilterSelect extends Stimulus.Controller {
+        onChange(evt) {
+            window.location.href = evt.target.value;
+        }
+    }
+
+    new Promise(resolve => window.addEventListener("load", resolve)).then(() => {
+        const application = Stimulus.Application.start();
+        application.register("admin-filter-select", AdminFilterSelect);
+    });
+})();

--- a/aidants_connect_common/templates/admin/filter-select.html
+++ b/aidants_connect_common/templates/admin/filter-select.html
@@ -1,0 +1,20 @@
+{% load i18n static ac_common %}
+<details data-controller="admin-filter-select" data-filter-title="{{ title }}" open>
+  <summary>
+    {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+  </summary>
+  <ul>
+    <li>
+      <select data-action="admin-filter-select#onChange" name="state">
+        {% for choice in choices %}
+          <option value="{{ choice.query_string|iriencode }}"{% if choice.selected %} selected{% endif %}>
+            {{ choice.display }}
+          </option>
+        {% endfor %}
+      </select>
+    </li>
+  </ul>
+</details>
+
+{% stimulusjs %}
+<script defer type="module" src="{% static 'js/admin-select.js' %}"></script>

--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -14,13 +14,8 @@ from django.utils.safestring import mark_safe
 
 from django_reverse_admin import ReverseInlineModelAdmin, ReverseModelAdmin
 
-from aidants_connect.admin import (
-    DepartmentFilter,
-    RegionFilter,
-    VisibleToAdminMetier,
-    VisibleToTechAdmin,
-    admin_site,
-)
+from aidants_connect.admin import VisibleToAdminMetier, VisibleToTechAdmin, admin_site
+from aidants_connect_common.admin import DepartmentFilter, RegionFilter
 from aidants_connect_common.utils.email import render_email
 from aidants_connect_habilitation.forms import (
     AdminAcceptationOrRefusalForm,
@@ -129,7 +124,7 @@ class ManagerAdmin(VisibleToAdminMetier, ModelAdmin):
 
 
 class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
-    list_filter = ("status", RegionFilter, DepartmentFilter)
+    list_filter = (RegionFilter, DepartmentFilter, "status")
     list_display = ("name", "issuer", "status", "data_pass_id", "created_at")
     search_fields = ("data_pass_id", "name", "uuid")
     raw_id_fields = ("issuer", "organisation")

--- a/aidants_connect_web/admin.py
+++ b/aidants_connect_web/admin.py
@@ -38,14 +38,9 @@ from import_export.results import RowResult
 from import_export.widgets import ForeignKeyWidget, ManyToManyWidget
 from nested_admin import NestedModelAdmin, NestedTabularInline
 
-from aidants_connect.admin import (
-    DepartmentFilter,
-    RegionFilter,
-    VisibleToAdminMetier,
-    VisibleToTechAdmin,
-    admin_site,
-)
+from aidants_connect.admin import VisibleToAdminMetier, VisibleToTechAdmin, admin_site
 from aidants_connect.utils import strtobool
+from aidants_connect_common.admin import DepartmentFilter, RegionFilter
 from aidants_connect_common.models import Department
 from aidants_connect_common.utils.constants import JournalActionKeywords
 from aidants_connect_common.utils.email import render_email
@@ -260,12 +255,12 @@ class OrganisationAdmin(
     )
     search_fields = ("name", "siret", "data_pass_id")
     list_filter = (
+        RegionFilter,
+        DepartmentFilter,
         "is_active",
         "france_services_label",
         "type",
         WithoutDatapassIdFilter,
-        RegionFilter,
-        DepartmentFilter,
         "is_experiment",
     )
 
@@ -672,6 +667,8 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         "is_superuser",
     )
     list_filter = (
+        AidantRegionFilter,
+        AidantDepartmentFilter,
         "is_active",
         "aidant_type",
         "can_create_mandats",
@@ -679,8 +676,6 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         AidantGoneTooLong,
         "is_staff",
         "is_superuser",
-        AidantRegionFilter,
-        AidantDepartmentFilter,
     )
     search_fields = ("id", "first_name", "last_name", "email", "organisation__name")
     ordering = ("email",)
@@ -960,11 +955,11 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
     raw_id_fields = ("organisation",)
     actions = ("mark_validated", "mark_refused", "mark_processing")
     list_filter = (
+        HabilitationRequestRegionFilter,
+        HabilitationDepartmentFilter,
         "status",
         "origin",
         "test_pix_passed",
-        HabilitationRequestRegionFilter,
-        HabilitationDepartmentFilter,
     )
     search_fields = (
         "first_name",

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -4,7 +4,7 @@ from django.test import TestCase, tag
 from django.test.client import RequestFactory
 from django.utils.timezone import now
 
-from aidants_connect.admin import DepartmentFilter, RegionFilter
+from aidants_connect_common.admin import DepartmentFilter, RegionFilter
 from aidants_connect_common.models import Region
 from aidants_connect_common.utils.constants import AuthorizationDurations
 from aidants_connect_web.admin import (

--- a/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
+++ b/aidants_connect_web/tests/test_functional/test_filter_in_admin.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.test import tag
 
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.wait import WebDriverWait
 
 from aidants_connect_common.models import Region
@@ -83,8 +84,12 @@ class OrganisationFilterTests(RegionFilterTestCase):
         self.assertTrue("Orga des Yvelines" in self.selenium.page_source)
         self.assertTrue("Orga du Bas-Rhin" in self.selenium.page_source)
         self.assertTrue("Sans Code Postal" in self.selenium.page_source)
-        idf_link = self.selenium.find_element(By.LINK_TEXT, "Île-de-France")
-        idf_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Île-de-France")
 
         self.assertTrue(
             "Orga des Yvelines" in self.selenium.page_source,
@@ -93,8 +98,13 @@ class OrganisationFilterTests(RegionFilterTestCase):
             "Orga du Bas-Rhin" in self.selenium.page_source,
         )
         self.assertFalse("Sans Code Postal" in self.selenium.page_source)
-        grandest_link = self.selenium.find_element(By.LINK_TEXT, "Grand Est")
-        grandest_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Grand Est")
+
         self.assertFalse(
             "Orga des Yvelines" in self.selenium.page_source,
             "Orga des Yvelines should not appear after filter on grand est",
@@ -107,8 +117,13 @@ class OrganisationFilterTests(RegionFilterTestCase):
             "Orga du Haut-Rhin" in self.selenium.page_source,
             "Orga du Haut-Rhin is not there, it should",
         )
-        other_link = self.selenium.find_element(By.XPATH, "//a[@href='?region=other']")
-        other_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Autre")
+
         self.assertFalse("Orga du Bas-Rhin" in self.selenium.page_source)
         self.assertTrue("Sans Code Postal" in self.selenium.page_source)
 
@@ -142,12 +157,22 @@ class AidantFilterTestCase(RegionFilterTestCase):
         self.open_live_url(self.aidant_url)
         self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
         self.assertTrue("D'on ne sait où" in self.selenium.page_source)
-        other_link = self.selenium.find_element(By.LINK_TEXT, "Autre")
-        other_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Autre")
+
         self.assertFalse("Du Bas-Rhin" in self.selenium.page_source)
         self.assertTrue("D'on ne sait où" in self.selenium.page_source)
-        grand_est_link = self.selenium.find_element(By.LINK_TEXT, "Grand Est")
-        grand_est_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Grand Est")
+
         self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
         self.assertFalse("D'on ne sait où" in self.selenium.page_source)
 
@@ -175,13 +200,20 @@ class HabilitationRequestTestCase(RegionFilterTestCase):
         self.assertTrue("D'on ne sait où" in self.selenium.page_source)
         # cannot simply click on "Autre" because there is another "Autre" option
         # (in "origin" filter)
-        other_link = self.selenium.find_element(By.XPATH, "//a[@href='?region=other']")
-        other_link.click()
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Autre")
 
         self.assertFalse("Du Bas-Rhin" in self.selenium.page_source)
         self.assertTrue("D'on ne sait où" in self.selenium.page_source)
-        grand_est_link = self.selenium.find_element(By.LINK_TEXT, "Grand Est")
-        grand_est_link.click()
+
+        Select(
+            self.selenium.find_element(
+                By.CSS_SELECTOR, "[data-filter-title='Région'] select"
+            )
+        ).select_by_visible_text("Grand Est")
 
         self.assertTrue("Du Bas-Rhin" in self.selenium.page_source)
         self.assertFalse("D'on ne sait où" in self.selenium.page_source)


### PR DESCRIPTION
## 🌮 Objectif

Les modèles `Aidant` et `Organisation` ont un filtre dans l'admin pour les sélectionner par département et région mais ces filtres produisent un grand nombre de valeur ce qui encombre le panneau des filtres dans l'admin.

Cette PR remplace la liste des filtres par un menu déroulant pour améliorer la lisibilité.

## 🏕 Amélioration continue

- Les filtres département et région ont aussi été remontés en tête de la liste des filtres pour les modèles `Aidant` et `Organisation`.

## 🖼️ Images

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/302fefa0-6189-470c-9810-e7f84ef0a285)

