### PR TITLE
Màj de Stimulus JS vers 3.2.1

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -410,7 +410,7 @@ SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
 REFERRER_POLICY = "strict-origin"
 
-STIMULUS_JS_URL = "https://unpkg.com/stimulus@2.0.0/dist/stimulus.umd.js"
+STIMULUS_JS_URL = "https://unpkg.com/stimulus@3.2.1/dist/stimulus.umd.js"
 MD_EDITOR_JS_URL = "https://unpkg.com/easymde/dist/easymde.min.js"
 MD_EDITOR_CSS_URL = "https://unpkg.com/easymde/dist/easymde.min.css"
 


### PR DESCRIPTION
## 🌮 Objectif

Avec l'obligation de supporter IE11, on était bloqués à la version 2.0.0 de Stimulus. La fin du support actée fin avril nous permet de passer dans la dernière version.