### PR TITLE
Textes: ajout de la mention 'actifs' au titre 'Référent' sur la page référents

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -61,7 +61,7 @@
     </h2>
 
     {% if organisation_active_referents %}
-      <h3>Référents</h3>
+      <h3>Référents actifs</h3>
       {% include "aidants_connect_web/espace_responsable/_organisation_aidants_list.html" with aidants=organisation_active_referents table_class="shadowed blue-green" %}
     {% endif %}
 


### PR DESCRIPTION
## 🌮 Objectif

Textes: ajout de la mention 'actifs' au titre 'Référent' sur la page référents