### PR TITLE
Fix d'une violation de contrainte lors de la dissociation d'une carte dans l'admin

### DIFF
--- a/aidants_connect_web/admin/otp_device.py
+++ b/aidants_connect_web/admin/otp_device.py
@@ -307,26 +307,22 @@ class CarteTOTPAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
 
     def __dissociate_from_aidant_post(self, request, object_id):
         try:
-            object = CarteTOTP.objects.get(id=object_id)
-            aidant = object.aidant
+            card = CarteTOTP.objects.get(id=object_id)
+            aidant = card.aidant
             if aidant is None:
                 self.message_user(
                     request,
-                    f"Aucun aidant n’est associé à la carte {object.serial_number}.",
+                    f"Aucun aidant n’est associé à la carte {card.serial_number}.",
                     messages.ERROR,
                 )
                 return HttpResponseRedirect(
                     reverse("otpadmin:aidants_connect_web_cartetotp_changelist")
                 )
 
-            totp_devices = TOTPDevice.objects.filter(user=aidant, key=object.seed)
-            for d in totp_devices:
-                d.delete()
-            object.aidant = None
-            object.save()
+            card.unlink_aidant()
 
             Journal.log_card_dissociation(
-                request.user, aidant, object.serial_number, "Admin action"
+                request.user, aidant, card.serial_number, "Admin action"
             )
 
             self.message_user(request, "Tout s'est bien passé.")

--- a/aidants_connect_web/models/mandat.py
+++ b/aidants_connect_web/models/mandat.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import logging
 from datetime import datetime, timedelta
 from os import walk as os_walk
@@ -624,6 +625,14 @@ class CarteTOTP(models.Model):
 
     def __str__(self):
         return self.serial_number
+
+    def unlink_aidant(self):
+        # AttributeError is thrown if totp_device is null
+        with contextlib.suppress(AttributeError):
+            self.totp_device.delete()
+        self.aidant = None
+        self.totp_device = None
+        self.save(update_fields={"aidant", "totp_device"})
 
     @transaction.atomic
     def get_or_create_totp_device(self, confirmed=False):

--- a/aidants_connect_web/tests/test_views/test_admin.py
+++ b/aidants_connect_web/tests/test_views/test_admin.py
@@ -440,8 +440,8 @@ class TOTPCardAdminPageTests(TestCase):
 
     def test_dissociate_aidant_whith_totp_device(self):
         aidant = AidantFactory()
-        totp_device = TOTPDeviceFactory(user=aidant)
-        card = CarteTOTPFactory(aidant=aidant, seed=totp_device.key)
+        card: CarteTOTP = CarteTOTPFactory(aidant=aidant)
+        card.get_or_create_totp_device()
         card_dissociate_url = reverse(
             "otpadmin:aidants_connect_web_carte_totp_dissociate",
             args=(card.id,),
@@ -455,8 +455,12 @@ class TOTPCardAdminPageTests(TestCase):
     def test_do_not_destroy_unrelated_totp_device(self):
         aidant_tim = AidantFactory()
         aidant_tom = AidantFactory()
-        totp_device = TOTPDeviceFactory(user=aidant_tim)
-        card = CarteTOTPFactory(aidant=aidant_tom, seed=totp_device.key)
+        CarteTOTPFactory(aidant=aidant_tim).get_or_create_totp_device()
+        card = CarteTOTPFactory(aidant=aidant_tom)
+        card.get_or_create_totp_device()
+
+        self.assertEqual(1, TOTPDevice.objects.filter(user=aidant_tim).count())
+
         card_dissociate_url = reverse(
             "otpadmin:aidants_connect_web_carte_totp_dissociate",
             args=(card.id,),

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_dissociate_totp_card.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 
-from aidants_connect_web.models import CarteTOTP, Journal
+from aidants_connect_web.models import Aidant, CarteTOTP, Journal
 from aidants_connect_web.tests.factories import AidantFactory, CarteTOTPFactory
 
 
@@ -14,11 +14,11 @@ class DissociateCarteTOTPTests(TestCase):
     def setUpTestData(cls):
         cls.client = Client()
         # Create one référent : Tom
-        cls.responsable_tom = AidantFactory(username="tom@tom.fr")
+        cls.responsable_tom: Aidant = AidantFactory(username="tom@tom.fr")
         cls.responsable_tom.responsable_de.add(cls.responsable_tom.organisation)
         cls.org_id = cls.responsable_tom.organisation.id
         # Create one aidant : Tim
-        cls.aidant_tim = AidantFactory(
+        cls.aidant_tim: Aidant = AidantFactory(
             username="tim@tim.fr",
             organisation=cls.responsable_tom.organisation,
             first_name="Tim",
@@ -34,14 +34,7 @@ class DissociateCarteTOTPTests(TestCase):
         )
 
     def create_device_for_tim(self, confirmed=True):
-        self.device = TOTPDevice(
-            tolerance=30,
-            key=self.carte.seed,
-            user=self.aidant_tim,
-            step=60,
-            confirmed=confirmed,
-        )
-        self.device.save()
+        self.device = self.aidant_tim.carte_totp.get_or_create_totp_device()
 
     def do_the_checks(self):
         # Submit post and check redirection is correct

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -1,5 +1,4 @@
 import base64
-import contextlib
 import logging
 from gettext import ngettext as _
 from io import BytesIO
@@ -214,12 +213,7 @@ class RemoveCardFromAidant(FormView):
         carte = CarteTOTP.objects.get(serial_number=sn)
 
         with transaction.atomic():
-            with contextlib.suppress(TOTPDevice.DoesNotExist):
-                TOTPDevice.objects.get(key=carte.seed, user=self.aidant).delete()
-
-            carte.aidant = None
-            carte.totp_device = None
-            carte.save()
+            carte.unlink_aidant()
 
             Journal.log_card_dissociation(
                 self.responsable, self.aidant, sn, form.cleaned_data["reason"]


### PR DESCRIPTION
## 🌮 Objectif

#987 a rajouté au modèle `CarteTOTP` une référence au `TOTPDevice` lié. Mais lors de la dissociation d'une carte dans l'admin, ce champ, qui est mis à nul lors de la suppresion du `TOTPDevice` lié est écrasé par l'ancienne valeur lors de l'appel de `save()`.