### PR TITLE
Ajout des champs `created_at` et `updated_at` au serialiseur du modèle `Organisation`

### DIFF
--- a/aidants_connect_web/api/serializers.py
+++ b/aidants_connect_web/api/serializers.py
@@ -20,6 +20,12 @@ class OrganisationSerializer(serializers.HyperlinkedModelSerializer):
         model_field=_organisation_meta.get_field("address")
     )
     service = serializers.SerializerMethodField()
+    date_de_creation = serializers.ModelField(
+        model_field=_organisation_meta.get_field("created_at")
+    )
+    date_de_modification = serializers.ModelField(
+        model_field=_organisation_meta.get_field("updated_at")
+    )
 
     def get_service(self, _):
         return "Réaliser des démarches administratives avec un accompagnement"
@@ -36,5 +42,7 @@ class OrganisationSerializer(serializers.HyperlinkedModelSerializer):
             "code_insee",
             "adresse",
             "service",
+            "date_de_creation",
+            "date_de_modification",
         ]
         extra_kwargs = {"url": {"lookup_field": "uuid"}}

--- a/aidants_connect_web/tests/api/test_views.py
+++ b/aidants_connect_web/tests/api/test_views.py
@@ -44,6 +44,12 @@ class OrganisationViewSetTests(APITestCase):
                         "pivot": orga.siret,
                         "nom": orga.name,
                         "commune": orga.city,
+                        "date_de_creation": (
+                            f"{orga.created_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
+                        ),
+                        "date_de_modification": (
+                            f"{orga.updated_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
+                        ),
                         "code_postal": orga.zipcode,
                         "code_insee": orga.city_insee_code,
                         "adresse": orga.address,
@@ -87,6 +93,12 @@ class OrganisationViewSetTests(APITestCase):
                 ),
                 "nom": self.orgas[1].name,
                 "commune": self.orgas[1].city,
+                "date_de_creation": (
+                    f"{self.orgas[1].created_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
+                ),
+                "date_de_modification": (
+                    f"{self.orgas[1].updated_at.strftime('%Y-%m-%dT%H:%M:%S.%fZ')}"
+                ),
                 "pivot": self.orgas[1].siret,
                 "code_postal": self.orgas[1].zipcode,
                 "code_insee": self.orgas[1].city_insee_code,


### PR DESCRIPTION
## 🌮 Objectif

Ajout des champs `created_at` et `updated_at` au serialiseur du modèle `Organisation`