### PR TITLE
Ajout de la possibilité de chercher sur les organisations et les aidants par ID exact

### DIFF
--- a/aidants_connect_web/admin/aidant.py
+++ b/aidants_connect_web/admin/aidant.py
@@ -298,6 +298,8 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         "aidants_connect_web/admin/aidants/change_list.html"
     )
 
+    search_fields = ("id__exact", *DjangoUserAdmin.search_fields)
+
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
 

--- a/aidants_connect_web/admin/organisation.py
+++ b/aidants_connect_web/admin/organisation.py
@@ -202,7 +202,7 @@ class OrganisationAdmin(
         "display_aidants",
         "display_habilitation_requests",
     )
-    search_fields = ("name", "siret", "data_pass_id")
+    search_fields = ("id__exact", "name", "siret", "data_pass_id")
     list_filter = (
         RegionFilter,
         DepartmentFilter,


### PR DESCRIPTION
## 🌮 Objectif

Lorsqu'on cherche un enregistrement particulier en à partir d'un évènement dans les logs, on n'a souvent que l'ID passé dans l'URL. Actuellement, si on veut trouver l'enregistrement concerné, il faut utilise le shell Django.