### PR TITLE
Suppression du titre création de mandat en doublon

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -49,8 +49,6 @@
         </li>
     </section>
 
-    <h3 class="h3-prime">{% block form_title %}Création de mandat{% endblock %}</h3>
-
     <form
       method="post"
       data-controller="mandate-form-controller"


### PR DESCRIPTION
## 🌮 Objectif

Le titre "Créer ou renouveler un mandat" apparait déjà sur la page création de mandat.

Suppression d'un sous titre "création de mandat" pour alléger la page.

_Un petit résumé de l'objectif de la PR en 1 ligne_

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
![image (18)](https://github.com/betagouv/Aidants_Connect/assets/77969214/c246dc74-b9d6-4d52-8820-edb6d961ebc9)

