### PR TITLE
Corriger une erreur sur le filtrage d'organisation lors du rajout d'un aidant

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -452,15 +452,17 @@ class ChangeAidantOrganisationsForm(forms.Form):
 
 
 class HabilitationRequestCreationForm(forms.ModelForm, DsfrBaseForm2):
+    organisation = forms.ModelChoiceField(
+        queryset=Organisation.objects.none(),
+        empty_label="Choisir...",
+    )
+
     def __init__(self, referent, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.referent = referent
-        self.fields["organisation"] = forms.ModelChoiceField(
-            queryset=Organisation.objects.filter(responsables=self.referent).order_by(
-                "name"
-            ),
-            empty_label="Choisir...",
-        )
+        self.fields["organisation"].queryset = Organisation.objects.filter(
+            responsables=self.referent
+        ).order_by("name")
 
     class Meta:
         model = HabilitationRequest

--- a/aidants_connect_web/tests/test_forms.py
+++ b/aidants_connect_web/tests/test_forms.py
@@ -17,6 +17,7 @@ from aidants_connect_web.forms import (
     AidantChangeForm,
     AidantCreationForm,
     DatapassHabilitationForm,
+    HabilitationRequestCreationForm,
     MandatForm,
     MassEmailActionForm,
     RecapMandatForm,
@@ -576,3 +577,26 @@ class TestAddAppOTPToAidantForm(TestCase):
         form = AddAppOTPToAidantForm(self.otp_device, data={"otp_token": "123456"})
 
         self.assertTrue(form.is_valid())
+
+
+@tag("forms")
+class HabilitationRequestCreationFormTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation = OrganisationFactory()
+        OrganisationFactory()
+        OrganisationFactory()
+        cls.referent = AidantFactory(
+            first_name="Armand",
+            last_name="Giraud",
+            email="agiraud@domain.user",
+            username="agiraud@domain.user",
+            password="flkqgnfdùqlgnqùflkgnùqflkngw",
+            profession="Mediateur",
+            organisation=cls.organisation,
+        )
+        cls.referent.responsable_de.add(cls.organisation)
+
+    def test_filter_queryset_organisation(self):
+        form = HabilitationRequestCreationForm(referent=self.referent)
+        self.assertEqual(1, form.fields["organisation"].queryset.count())


### PR DESCRIPTION
## 🌮 Objectif

Corriger une erreur sur le filtrage d'organisation lors du rajout d'un aidant

## 🔍 Implémentation

- Changement sur la manière de déclarer le fields

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
