### PR TITLE
Veille à ce que les référents d'organisation soient aussi membre de ces organisations

### DIFF
--- a/aidants_connect_web/admin/aidant.py
+++ b/aidants_connect_web/admin/aidant.py
@@ -469,7 +469,9 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
         super().save_related(request, form, formsets, change)
         organisation = form.cleaned_data["organisation"]
         if organisation is not None:
-            form.instance.organisations.add(organisation)
+            form.instance.organisations.add(
+                *{*form.instance.responsable_de.all(), organisation}
+            )
 
     def mass_deactivate(self, request: HttpRequest, queryset: QuerySet):
         queryset.update(is_active=False)

--- a/aidants_connect_web/models/aidant.py
+++ b/aidants_connect_web/models/aidant.py
@@ -143,16 +143,9 @@ class Aidant(AbstractUser):
         full_name = f"{self.first_name} {self.last_name}".strip()
         return full_name if full_name else self.username
 
-    def save(
-        self, force_insert=False, force_update=False, using=None, update_fields=None
-    ):
-        super().save(
-            force_insert=force_insert,
-            force_update=force_update,
-            using=using,
-            update_fields=update_fields,
-        )
-        self.organisations.add(self.organisation)
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        self.organisations.add(*{*self.responsable_de.all(), self.organisation})
 
     def deactivate(self):
         self.is_active = False

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -1602,6 +1602,25 @@ class AidantModelMethodsTests(TestCase):
         CarteTOTPFactory(aidant=self.aidant_patricia, serial_number="12121212")
         self.assertTrue(self.aidant_patricia.number_totp_card, "12121212")
 
+    def test_save_adds_current_and_referents_organisation_to_aidant(self):
+        aidant: Aidant = AidantFactory()
+        aidant_referent = [OrganisationFactory(), OrganisationFactory()]
+        aidant_former_org = aidant.organisation
+        aidant_current_org = OrganisationFactory()
+
+        aidant.refresh_from_db()
+        self.assertEqual({aidant_former_org}, set(aidant.organisations.all()))
+
+        aidant.organisation = aidant_current_org
+        aidant.responsable_de.add(*aidant_referent)
+        aidant.save()
+        aidant.refresh_from_db()
+
+        self.assertEqual(
+            {*aidant_referent, aidant_former_org, aidant_current_org},
+            set(aidant.organisations.all()),
+        )
+
 
 @tag("models", "journal")
 class JournalModelTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Veille à ce que les référents do'rganisation soient aussi membre de ces organisations en éditant le champ lors de la sauvegarde.