### PR TITLE
Limitation de la taille du slug calculé à 45 dans le CMS

### DIFF
--- a/aidants_connect_pico_cms/utils.py
+++ b/aidants_connect_pico_cms/utils.py
@@ -12,7 +12,7 @@ def is_lang_rtl(lang_code):
 
 
 def compute_correct_slug(cls, name):
-    slug = slugify(name)
+    slug = slugify(name)[:45]  # slug field is limited to 50
 
     if not cls._meta.model.objects.filter(slug=slug).exists():
         return slug


### PR DESCRIPTION
## 🌮 Objectif

Le champ `SlugField` est limité à 50 caractères. Le slug calculé peut être trop long pour le champ.
