### PR TITLE
Ajout de la section statistiques dans le header

### DIFF
--- a/aidants_connect_common/templates/public_website/layout/_header_links.html
+++ b/aidants_connect_common/templates/public_website/layout/_header_links.html
@@ -23,6 +23,16 @@
   <a
     class="fr-nav__link"
     target="_self"
+    href="{% url 'statistiques' %}"
+    {% if view_name == 'statistiques' %}aria-current="true"{% endif %}
+  >
+    Statistiques
+  </a>
+</li>
+<li class="fr-nav__item">
+  <a
+    class="fr-nav__link"
+    target="_self"
     href="{% url 'ressources' %}"
     {% if view_name == 'ressources' %}aria-current="true"{% endif %}
   >


### PR DESCRIPTION
## 🌮 Objectif

Ajout d'une section statistiques dans le header entre habilitation et ressources afin que nos données soient plus visibles et accessibles. La page statistiques dans le footer n'est pas facilement accessible pour toutes les personnes qui ont besoin d'avoir des informations sur le dispositif.

_Un petit résumé de l'objectif de la PR en 1 ligne_

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
