### PR TITLE
Notifier seulement les aidants actifs à propos des mandats bientôt expirés

### DIFF
--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -96,9 +96,9 @@ def delete_duplicated_static_tokens(*, logger=None):
 
 def get_recipient_list_for_organisation(organisation):
     return list(
-        organisation.aidants.filter(can_create_mandats=True).values_list(
-            "email", flat=True
-        )
+        organisation.aidants.filter(
+            can_create_mandats=True, is_active=True
+        ).values_list("email", flat=True)
     )
 
 

--- a/aidants_connect_web/tests/test_tasks.py
+++ b/aidants_connect_web/tests/test_tasks.py
@@ -45,7 +45,8 @@ class UtilsTaskTests(TestCase):
         orga = OrganisationFactory()
         AidantFactory(organisation=orga, can_create_mandats=True)
         AidantFactory(organisation=orga, can_create_mandats=False)
-        self.assertEqual(1, Aidant.objects.filter(can_create_mandats=True).count())
+        AidantFactory(organisation=orga, can_create_mandats=True, is_active=False)
+        self.assertEqual(2, Aidant.objects.filter(can_create_mandats=True).count())
         self.assertEqual(1, len(get_recipient_list_for_organisation(orga)))
 
 


### PR DESCRIPTION
## 🌮 Objectif

Notifier seulement les aidants actifs à propos des mandats bientôt expirés