### PR TITLE
Réparation du lien FAQ sur la page habilitation

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -88,7 +88,7 @@ Plus d’informations seront prochainement disponibles sur cette page et via not
         </ul>
         <p><strong>Les aidants familiaux, les bénévoles, les services civiques et les élus ne sont donc pas éligibles.
           Pour plus d'informations, nous vous invitons à consulter
-          <a href="https://aidantsconnect.beta.gouv.fr/faq/mandat/">notre FAQ.</a></strong></p>
+          <a href="{% url 'faq_generale' %}">notre FAQ.</a></strong></p>
       </div>
     </details>
   </div>


### PR DESCRIPTION
## 🌮 Objectif

Réparation du lien FAQ sur la page habilitation