### PR TITLE
Suppression de l'imposition du format de la carte TOTP dans le formulaire d'ajout de carte

### DIFF
--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -30,10 +30,7 @@ from aidants_connect_web.models import (
     UsagerQuerySet,
 )
 from aidants_connect_web.models.other_models import CoReferentNonAidantRequest
-from aidants_connect_web.utilities import (
-    generate_sha256_hash,
-    normalize_totp_cart_serial,
-)
+from aidants_connect_web.utilities import generate_sha256_hash
 from aidants_connect_web.widgets import MandatDemarcheSelect, MandatDureeRadioSelect
 
 
@@ -358,8 +355,14 @@ class RecapMandatForm(OTPForm, forms.Form):
 class CarteOTPSerialNumberForm(forms.Form):
     serial_number = forms.CharField()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["serial_number"].widget.attrs.update(
+            {"placeholder": "Ex : GADT000XXXX"}
+        )
+
     def clean_serial_number(self):
-        serial_number = normalize_totp_cart_serial(self.cleaned_data["serial_number"])
+        serial_number = self.cleaned_data["serial_number"]
         try:
             carte = CarteTOTP.objects.get(serial_number=serial_number)
         except CarteTOTP.DoesNotExist:

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/write-carte-totp-sn.html
@@ -34,7 +34,7 @@
                       Entrez le numéro de série
                     </label>
                     <div class="margin-top-1rem">
-                      <span>GADT000 </span>{{ form.serial_number }}
+                      {{ form.serial_number }}
                     </div>
                     {% if form.errors.serial_number %}
                       <div id="{{ form.serial_number.id_for_label }}__errors">

--- a/aidants_connect_web/tests/factories.py
+++ b/aidants_connect_web/tests/factories.py
@@ -31,7 +31,6 @@ from aidants_connect_web.models import (
     OrganisationType,
     Usager,
 )
-from aidants_connect_web.utilities import normalize_totp_cart_serial
 
 
 class OrganisationFactory(DjangoModelFactory):
@@ -49,7 +48,7 @@ class CarteTOTPFactory(DjangoModelFactory):
     @lazy_attribute
     def serial_number(self):
         for _ in range(10):
-            serial = normalize_totp_cart_serial(random.randint(0, 9999))
+            serial = f"GADT000{random.randint(0, 9999):04}"
             if not CarteTOTP.objects.filter(serial_number=serial).exists():
                 return serial
         else:

--- a/aidants_connect_web/utilities.py
+++ b/aidants_connect_web/utilities.py
@@ -114,8 +114,3 @@ def generate_id_token(connection: "Connection"):
         "nonce": connection.nonce,
         "acr": "eidas1",
     }
-
-
-def normalize_totp_cart_serial(serial):
-    serial = int(f"{serial}".removeprefix("GADT000"))
-    return f"GADT000{serial:04}"


### PR DESCRIPTION
## 🌮 Objectif

On a régulièrement des erreurs en prod avec des cartes qui n'ont pas le format *GADT000XXXX*.