### PR TITLE
Suppression d'une ressource en doublon

### DIFF
--- a/aidants_connect_web/templates/public_website/resource_list.html
+++ b/aidants_connect_web/templates/public_website/resource_list.html
@@ -3,18 +3,6 @@
 <div class="fr-grid-row fr-grid-row--gutters margin-bottom-2rem">
   <div class="fr-col-12 fr-col-md-3">
     <div class="card-ressource">
-      <img src="{% static 'images/aidantsconnect.png' %}" alt="" />
-      <div class="card-content">
-        <div><span class="tag">Équipe Aidants Connect</span></div>
-        <p class="description">Des ressources utiles pour mieux comprendre et utiliser le service Aidants Connect.</p>
-        <div class="button-box">
-          <a class="fr-btn" href="https://aidantsconnect.beta.gouv.fr/guide_utilisation/">Consulter</a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="fr-col-12 fr-col-md-3">
-    <div class="card-ressource">
       <img src="{% static 'images/kitintervention.png' %}" alt="" />
       <div class="card-content">
         <div><span class="tag">Mission Société Numérique</span></div>
@@ -34,6 +22,7 @@
       </div>
     </div>
   </div>
+</div>
   <div class="fr-col-12 fr-col-md-3">
     <div class="card-ressource">
       <img src="{% static 'images/CNIL.png' %}" alt="" />


### PR DESCRIPTION
## 🌮 Objectif

Suppression de la ressource "Equipe Aidants Connect: Des ressources utiles pour mieux comprendre et utiliser le service Aidants Connect" dans les ressources externes qui se trouve déjà dans la partie "Bien démarrer : Equipe Aidants Connect Fiches pratiques et vidéos" de la page ressource.

_Un petit résumé de l'objectif de la PR en 1 ligne_

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

![image](https://github.com/betagouv/Aidants_Connect/assets/77969214/a9722252-852d-4d42-a0be-6911773b0168)


_(optionnel) Une ou plusieurs captures d'écran_
