### PR TITLE
Changement de nom de l'administration Pôle Emploi par France Travail

### DIFF
--- a/aidants_connect_common/constants.py
+++ b/aidants_connect_common/constants.py
@@ -239,7 +239,7 @@ class RequestOriginConstants(IntegerChoices):
     GUICHET_AUTRE = (7, "Autre guichet d’accueil de service public de proximité")
     GUICHET_OPERATEUR = (
         8,
-        "Guichet d’accueil d’opérateur de service public (CAF, Pôle Emploi, etc.)",
+        "Guichet d’accueil d’opérateur de service public (CAF, France Travail, etc.)",
     )
     AUTRES_ASSOS = (
         9,


### PR DESCRIPTION
## 🌮 Objectif

Le projet de loi pour le plein emploi [a été validé le jeudi 14 décembre 2023 par le Conseil constitutionnel](https://travail-emploi.gouv.fr/actualites/presse/communiques-de-presse/article/le-conseil-constitutionnel-valide-le-projet-de-loi-pour-le-plein-emploi-qui). Il définit les contours de France Travail, nouvel opérateur du service public de l’emploi, qui a remplacé Pôle emploi depuis le 1er janvier 2024, avec des missions élargies et un accompagnement renforcé pour les demandeurs d’emploi.

Changement du nom Pôle Emploi sur l'interface par France Travail.

_Un petit résumé de l'objectif de la PR en 1 ligne_

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
