### PR TITLE
Automatic user creation in sandbox

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -785,6 +785,7 @@ FF_USE_PICO_CMS_FOR_FAQ = getenv_bool("FF_USE_PICO_CMS_FOR_FAQ", False)
 
 # URLS
 SANDBOX_URL = os.getenv("SANDBOX_URL", "")
+SANDBOX_URL_PADDING = os.getenv("SANDBOX_URL", "PADDING_SANDBOX")
 WEBINAIRE_SUBFORM_URL = os.getenv("WEBINAIRE_SUBFORM_URL", "#")
 
 REST_FRAMEWORK = {
@@ -816,5 +817,6 @@ FF_DEACTIVATE_OLD_AIDANT = getenv_bool("FF_DEACTIVATE_OLD_AIDANT", False)
 # ######################## SANDBOX SETTING ############################
 
 ACTIVATE_INFINITY_TOKEN = getenv_bool("ACTIVATE_INFINITY_TOKEN", False)
+AUTO_CREATE_SANDBOX_TOKEN = os.getenv("AUTO_CREATE_SANDBOX_TOKEN", None)
 
 # ######################## END SANDBOX SETTING ############################

--- a/aidants_connect_sandbox/admin.py
+++ b/aidants_connect_sandbox/admin.py
@@ -58,9 +58,9 @@ class AidantSandboxResource(resources.ModelResource):
                     city=row["organisation__city"],
                     zipcode=row["organisation__zipcode"],
                 )[0]
-        if row["Data pass Id Orga Responsable"]:
+        if row["datapass_id_managers"]:
             respo_orgas = []
-            data_pass_ids = row["Data pass Id Orga Responsable"].split("|")
+            data_pass_ids = row["datapass_id_managers"].split("|")
             for str_one_id in data_pass_ids:
                 if str_one_id and str_one_id.isdigit():
                     one_id = int(str_one_id)

--- a/aidants_connect_sandbox/serializers.py
+++ b/aidants_connect_sandbox/serializers.py
@@ -1,0 +1,69 @@
+from django.conf import settings
+
+import tablib
+from rest_framework import serializers
+
+from .admin import AidantSandboxResource
+
+
+class AutomaticCreationSerializer(serializers.Serializer):
+    first_name = serializers.CharField(max_length=150)
+    last_name = serializers.CharField(max_length=150)
+    profession = serializers.CharField(max_length=150)
+    email = serializers.CharField(max_length=150)
+    organisation__data_pass_id = serializers.CharField(max_length=150)
+    organisation__name = serializers.CharField(max_length=250)
+    organisation__siret = serializers.CharField(max_length=25)
+    organisation__address = serializers.CharField(max_length=500)
+    datapass_id_managers = serializers.CharField(max_length=250, required=False)
+
+    def save(self):
+        import_data = tablib.Dataset(
+            headers=[
+                "id",
+                "first_name",
+                "last_name",
+                "email",
+                "organisation__data_pass_id",
+                "organisation__name",
+                "organisation__siret",
+                "organisation__address",
+                "organisation__city",
+                "organisation__zipcode",
+                "organisation__type__id",
+                "organisation__type__name",
+                "datapass_id_managers",
+            ]
+        )
+        import_ressource = AidantSandboxResource()
+        if "datapass_id_managers" in self.validated_data:
+            datapass_id_managers = self.validated_data["datapass_id_managers"]
+        else:
+            datapass_id_managers = ""
+        import_data.append(
+            [
+                1,
+                self.validated_data["first_name"],
+                self.validated_data["last_name"],
+                self.validated_data["email"],
+                self.validated_data["organisation__data_pass_id"],
+                self.validated_data["organisation__name"],
+                self.validated_data["organisation__siret"],
+                self.validated_data["organisation__address"],
+                "",
+                "",
+                None,
+                "",
+                datapass_id_managers,
+            ]
+        )
+        import_ressource.import_data(import_data, dry_run=False)
+
+    def validate_token(self, value):
+        if settings.AUTO_CREATE_SANDBOX_TOKEN is None:
+            raise serializers.ValidationError("Invalid Token")
+
+        if value == settings.AUTO_CREATE_SANDBOX_TOKEN:
+            return value
+        else:
+            raise serializers.ValidationError("Invalid Token")

--- a/aidants_connect_sandbox/urls.py
+++ b/aidants_connect_sandbox/urls.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.urls import path
+
+from .views import AutomaticCreationViewAPI
+
+path_url = f"sandbox/{settings.SANDBOX_URL_PADDING}/automatic_creation/"
+urlpatterns = [
+    path(
+        path_url, AutomaticCreationViewAPI.as_view(), name="sandbox_automatic_creation"
+    )
+]

--- a/aidants_connect_sandbox/views.py
+++ b/aidants_connect_sandbox/views.py
@@ -1,0 +1,7 @@
+from rest_framework import generics
+
+from .serializers import AutomaticCreationSerializer
+
+
+class AutomaticCreationViewAPI(generics.CreateAPIView):
+    serializer_class = AutomaticCreationSerializer

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -3,6 +3,7 @@ from django.urls import include, path, re_path
 from magicauth import settings as magicauth_settings
 from magicauth.urls import urlpatterns as magicauth_urls
 
+from aidants_connect_sandbox.urls import urlpatterns as sandbox_urls
 from aidants_connect_web.api.urls import router as api_router
 from aidants_connect_web.views import (
     FC_as_FS,
@@ -281,3 +282,4 @@ urlpatterns = [
 ]
 
 urlpatterns.extend(magicauth_urls)
+urlpatterns.extend(sandbox_urls)


### PR DESCRIPTION
## 🌮 Objectif

Ajouter la création automatique d'utilisateur par API. Les appels sont fait à partir de la production. On a déjà un outil de création automatique d'utilisateurs par import de fichier et on veut le garder. 

Le but de la PR est de brancher les appels POST API sur le mécanisme d'import déjà en place.

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
