### PR TITLE
Fix du test `aidants_connect_web.tests.test_models.HabilitationRequestTests.test_trigger`

### DIFF
--- a/aidants_connect_common/tests/factories.py
+++ b/aidants_connect_common/tests/factories.py
@@ -33,7 +33,7 @@ class FormationFactory(DjangoModelFactory):
     start_datetime = LazyFunction(now)
     type = SubFactory(FormationTypeFactory)
     duration = LazyFunction(lambda: random.randint(1, 10))
-    max_attendants = LazyFunction(lambda: random.randint(1, 10))
+    max_attendants = LazyFunction(lambda: random.randint(10, 100))
     status = FuzzyChoice(Formation.Status.values)
 
     @factory.lazy_attribute


### PR DESCRIPTION
Fix du test `aidants_connect_web.tests.test_models.HabilitationRequestTests.test_trigger` qui casse aléatoirement.