### PR TITLE
Fixes sur l'inscription à la formation

### DIFF
--- a/aidants_connect_common/static/css/formation-registration.css
+++ b/aidants_connect_common/static/css/formation-registration.css
@@ -1,21 +1,9 @@
-.checkbox-container {
+.option-container {
   position: relative;
 }
 
-.checkbox-container .fr-label {
-  position: absolute !important;
-  height: 100% !important;
-  width: 100% !important;
-  top: 0 !important;
-  right: 0 !important;
-  bottom: 0 !important;
-  left: 0 !important;
-  margin: 0 !important;
-}
-
-.checkbox-container .fr-label::before {
-    left: 1rem !important;
-    top: unset !important;
+.option-container .fr-label::before {
+  position: unset !important;
 }
 
 table {

--- a/aidants_connect_common/templates/formation/formation-registration.html
+++ b/aidants_connect_common/templates/formation/formation-registration.html
@@ -36,16 +36,16 @@
           <tbody>
           {% for formation_widget in form.formations.subwidgets %}
             <tr>
-              <td>{{ formation_widget.data.label }}</td>
+              <td>{{ formation_widget.data.value.instance.type.label }}</td>
               <td>{{ formation_widget.data.value.instance.date_range_str }}</td>
-              <td>{{ formation_widget.data.value.instance.get_type_display }}</td>
+              <td>{{ formation_widget.data.value.instance.get_status_display }}</td>
               <td>{{ formation_widget.data.value.instance.place }}</td>
-              <td class="fr-checkbox-group checkbox-container">
+              <td class="fr-radio-group option-container">
                 <input
                   name="{{ formation_widget.data.name }}"
                   value="{{ formation_widget.data.value }}"
                   id="formation-{{ formation_widget.data.value }}"
-                  type="checkbox"
+                  type="radio"
                   {% if formation_widget.data.selected or formation_widget.data.value in registered_to %}checked{% endif %} 
                 >
                 <label class="fr-label" for="formation-{{ formation_widget.data.value }}">

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -186,7 +186,7 @@
                   {% if request.status in request.ReferentRequestStatuses.formation_registerable %}
                     <a
                       id="register-habilitation-request-{{ request.id }}"
-                      href="{% url "espace_responsable_cancel_habilitation" request_id=request.id %}"
+                      href="{% url "espace_responsable_register_formation" request_id=request.id %}"
                       class="fr-btn fr-btn--secondary "
                     >
                       Inscrire à une formation


### PR DESCRIPTION
## 🌮 Objectif

Fixes sur l'inscription à la formation

## 🔍 Implémentation

- Afficher uniquement le label de la formation et non le label + les dates dans la colone « organisme »
- Afficher le statut de la formation (à distance/présentiel)
- Inscription à partir de l'espace référent
- Changer la case à cocher par un bouton radio

## :camera: Photos

![image](https://github.com/betagouv/Aidants_Connect/assets/22097904/4bcc76b2-c77d-45bc-80d7-4e618a83435f)
