### PR TITLE
Fix d'affichage des dates de formation et du nom de l'aidant sur la page formation

### DIFF
--- a/aidants_connect_common/models.py
+++ b/aidants_connect_common/models.py
@@ -8,6 +8,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import CASCADE, Count
+from django.template.defaultfilters import date
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.timezone import now
@@ -176,15 +177,9 @@ class Formation(models.Model):
 
     @property
     def date_range_str(self):
-        start_datetime_format = "%d"
-        if self.start_datetime.year != self.end_datetime.year:
-            start_datetime_format += " %B %Y"
-        elif self.start_datetime.month != self.end_datetime.month:
-            start_datetime_format += " %B"
-
         return (
-            f"Du {self.start_datetime.strftime(start_datetime_format)} "
-            f"au {self.end_datetime.strftime('%d %B %Y')}"
+            f"Du {date(self.start_datetime, 'd F Y à H:i')} "
+            f"au {date(self.end_datetime, 'd F Y à H:i')}"
         )
 
     def __str__(self):

--- a/aidants_connect_common/templates/formation/formation-registration.html
+++ b/aidants_connect_common/templates/formation/formation-registration.html
@@ -28,6 +28,7 @@
           <tr>
             <td>Organisame</td>
             <td>Dates</td>
+            <td>Durée</td>
             <td>Format</td>
             <td>Lieu</td>
             <td>Sélection</td>
@@ -38,6 +39,7 @@
             <tr>
               <td>{{ formation_widget.data.value.instance.type.label }}</td>
               <td>{{ formation_widget.data.value.instance.date_range_str }}</td>
+              <td>{{ formation_widget.data.value.instance.duration }}h</td>
               <td>{{ formation_widget.data.value.instance.get_status_display }}</td>
               <td>{{ formation_widget.data.value.instance.place }}</td>
               <td class="fr-radio-group option-container">

--- a/aidants_connect_common/views.py
+++ b/aidants_connect_common/views.py
@@ -79,7 +79,8 @@ class FormationRegistrationView(FormView):
             {
                 "registered_to": self.get_habilitation_request().formations.values_list(
                     "formation", flat=True
-                )
+                ),
+                "aidant": self.get_habilitation_request(),
             }
         )
         return super().get_context_data(**kwargs)

--- a/aidants_connect_web/models/other_models.py
+++ b/aidants_connect_web/models/other_models.py
@@ -88,6 +88,10 @@ class HabilitationRequest(models.Model):
     )
 
     @property
+    def get_full_name(self):
+        return self.aidant_full_name
+
+    @property
     def aidant_full_name(self):
         return f"{self.first_name} {self.last_name}".strip()
 


### PR DESCRIPTION
## 🌮 Objectif

Fix d'affichage des dates de formation et du nom de l'aidant sur la page formation

## 🖼️ Images

![image](https://github.com/betagouv/Aidants_Connect/assets/22097904/d6ba0093-fc80-426b-94c6-93d172446837)
