### PR TITLE
Ne pas avertir les aidants de l'acceptation d'une demande d'organisation

### DIFF
--- a/aidants_connect_habilitation/admin.py
+++ b/aidants_connect_habilitation/admin.py
@@ -411,9 +411,9 @@ class OrganisationRequestAdmin(VisibleToAdminMetier, ReverseModelAdmin):
                 f"{organisation.data_pass_id} a été acceptée"
             )
 
-        recipients = set(organisation.aidant_requests.values_list("email", flat=True))
-        recipients.add(organisation.manager.email)
-        recipients.add(organisation.issuer.email)
+        recipients = {organisation.issuer.email}
+        if organisation.manager:
+            recipients.add(organisation.manager.email)
 
         send_mail(
             from_email=settings.EMAIL_ORGANISATION_REQUEST_FROM,

--- a/aidants_connect_habilitation/tests/test_admin.py
+++ b/aidants_connect_habilitation/tests/test_admin.py
@@ -70,14 +70,8 @@ class OrganisationRequestAdminTests(TestCase):
         )
         # check recipients are as expected
         self.assertEqual(
-            len(acceptance_message.recipients()), 5
-        )  # 3 aidants + 1 issuer + 1 manager
-        self.assertTrue(
-            all(
-                aidant.email in acceptance_message.recipients()
-                for aidant in org_request.aidant_requests.all()
-            )
-        )
+            len(acceptance_message.recipients()), 2
+        )  # 1 issuer + 1 manager
         self.assertTrue(org_request.manager.email in acceptance_message.recipients())
         self.assertTrue(org_request.issuer.email in acceptance_message.recipients())
 
@@ -135,14 +129,8 @@ class OrganisationRequestAdminTests(TestCase):
 
         # check recipients are as expected
         self.assertEqual(
-            len(acceptance_message.recipients()), 5
-        )  # 3 aidants + 1 issuer + 1 manager
-        self.assertTrue(
-            all(
-                aidant.email in acceptance_message.recipients()
-                for aidant in org_request.aidant_requests.all()
-            )
-        )
+            len(acceptance_message.recipients()), 2
+        )  # 1 issuer + 1 manager
         self.assertTrue(org_request.manager.email in acceptance_message.recipients())
         self.assertTrue(org_request.issuer.email in acceptance_message.recipients())
 


### PR DESCRIPTION
## 🌮 Objectif

Ne pas avertir les aidants de l'acceptation d'une demande d'organisation