### PR TITLE
Remplacer case à cocher 'conseiller_numerique' par une option

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -1,4 +1,3 @@
-from distutils.util import strtobool
 from re import sub as re_sub
 from typing import List, Tuple, Union
 from urllib.parse import quote, unquote
@@ -23,6 +22,7 @@ from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext as _
 
+from aidants_connect.utils import strtobool
 from aidants_connect_common.constants import MessageStakeholders, RequestOriginConstants
 from aidants_connect_common.forms import (
     AcPhoneNumberField,
@@ -387,6 +387,13 @@ class ManagerForm(
         coerce=lambda value: bool(strtobool(value)),
     )
 
+    conseiller_numerique = TypedChoiceField(
+        label="Est un conseiller numérique",
+        label_suffix=" :",
+        choices=(("", ""), (True, "Oui"), (False, "Non")),
+        coerce=lambda value: bool(strtobool(value)),
+    )
+
     def get_address_for_search(self) -> str:
         return " ".join(
             [
@@ -443,6 +450,13 @@ class ManagerEmailOrganisationValidationError(EmailOrganisationValidationError):
 
 
 class AidantRequestForm(PatchedModelForm, CleanEmailMixin):
+    conseiller_numerique = TypedChoiceField(
+        label="Est un conseiller numérique",
+        label_suffix=" :",
+        choices=(("", ""), (True, "Oui"), (False, "Non")),
+        coerce=lambda value: bool(strtobool(value)),
+    )
+
     def __init__(self, organisation: OrganisationRequest, *args, **kwargs):
         self.organisation = organisation
         super().__init__(*args, **kwargs)

--- a/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.expected_conditions import url_matches
+from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.wait import WebDriverWait
 
 from aidants_connect_common.constants import RequestStatusConstants
@@ -79,9 +80,9 @@ class AddAidantsRequestViewTests(FunctionalTestCase):
                     f"#id_form-{i}-{field_name}",
                 )
 
-                if element.get_attribute("type") == "checkbox":
-                    if element.is_selected() == aidant_data[field_name]:
-                        element.click()
+                if "conseiller_numerique" in element.get_attribute("name"):
+                    select = Select(element)
+                    select.select_by_value(str(aidant_data["conseiller_numerique"]))
                 else:
                     element.clear()
                     element.send_keys(aidant_data[field_name])


### PR DESCRIPTION
## 🌮 Objectif

Remplacer case à cocher 'conseiller_numerique' par une option

## 🖼️ Images

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/d9a3df5e-4969-42cb-9dea-0773500e726a)
