### PR TITLE
Suppression de la partie « vos échanges avec aidants connect » dans l'habilitation

### DIFF
--- a/aidants_connect_habilitation/templates/view_organisation_request.html
+++ b/aidants_connect_habilitation/templates/view_organisation_request.html
@@ -17,7 +17,6 @@ Aidants Connect — Demande d'habilitation pour {{ organisation.name }}
     <br>
     {% include "edito/_aide_etats_demandes_habilitation.html" with status=organisation.status %}
   </p>
-  {% include "request_messages/_messages.html" with issuer=organisation.issuer messages=organisation.messages form=form %}
   <h2>Rappel de votre saisie</h2>
   {% if display_modify_button %}
   <a
@@ -32,9 +31,8 @@ Aidants Connect — Demande d'habilitation pour {{ organisation.name }}
 
   <div class="fr-grid-row fr-grid-row--gutters">
     <p class="fr-col more-info">
-      Pour modifier cette demande (ajouter un aidant, etc.), utilisez
-      <a href="#messages_with_ac">l'interface «&nbsp;Vos échanges avec Aidants Connect&nbsp;»</a>
-      ci-dessus.
+      Pour modifier cette demande (ajouter un aidant, etc.), envoyez votre requête par mail à lʼadresse 
+      {% mailto SUPPORT_EMAIL %}.
     </p>
   </div>
 

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from unittest import skip
 from unittest.mock import ANY, Mock, patch
 from uuid import UUID, uuid4
 
@@ -1165,6 +1166,7 @@ class RequestReadOnlyViewTests(TestCase):
             response, RequestStatusConstants.AC_VALIDATION_PROCESSING.label
         )
 
+    @skip
     def test_issuer_can_post_a_message(self):
         organisation = OrganisationRequestFactory(
             status=RequestStatusConstants.AC_VALIDATION_PROCESSING.value
@@ -1177,6 +1179,7 @@ class RequestReadOnlyViewTests(TestCase):
         response = self.client.get(organisation.get_absolute_url())
         self.assertContains(response, "Bonjour bonjour")
 
+    @skip
     def test_correct_message_is_shown_when_empty_messages_history(self):
         organisation = OrganisationRequestFactory(
             status=RequestStatusConstants.AC_VALIDATION_PROCESSING.value


### PR DESCRIPTION
## 🌮 Objectif

Suppression de la partie « vos échanges avec aidants connect » dans l'habilitation