### PR TITLE
Renomme `public_website/layout/main.html` en `public_website/layout/main-legacy.html`

### DIFF
--- a/aidants_connect_common/templates/public_website/layout/main-legacy.html
+++ b/aidants_connect_common/templates/public_website/layout/main-legacy.html
@@ -1,4 +1,4 @@
-{% extends 'layouts/main.html' %}
+{% extends 'layouts/main-habilitation.html' %}
 
 {% block nav %}
   {# Custom header for public website #}

--- a/aidants_connect_web/templates/public_website/cgu.html
+++ b/aidants_connect_web/templates/public_website/cgu.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/guide_utilisation.html
+++ b/aidants_connect_web/templates/public_website/guide_utilisation.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/home_page.html
+++ b/aidants_connect_web/templates/public_website/home_page.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/mentions_legales.html
+++ b/aidants_connect_web/templates/public_website/mentions_legales.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/ressource_page.html
+++ b/aidants_connect_web/templates/public_website/ressource_page.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 

--- a/aidants_connect_web/templates/public_website/statistiques.html
+++ b/aidants_connect_web/templates/public_website/statistiques.html
@@ -1,4 +1,4 @@
-{% extends 'public_website/layout/main.html' %}
+{% extends 'public_website/layout/main-legacy.html' %}
 
 {% load static %}
 


### PR DESCRIPTION
## 🌮 Objectif

Renomme `public_website/layout/main.html` en `public_website/layout/main-legacy.html` en vue de la migration DSFR du site public.