### PR TITLE
Fix du nettoyage du formulaire AidantRequestForm

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -154,10 +154,6 @@ class CleanEmailMixin:
         return self.cleaned_data["email"].lower().strip()
 
 
-def coerce(value):
-    return bool(strtobool(value))
-
-
 class ConseillerNumerique(Form):
     conseiller_numerique = TypedChoiceField(
         label=mark_safe(
@@ -165,12 +161,12 @@ class ConseillerNumerique(Form):
         ),
         label_suffix=" :",
         choices=(("", ""), (True, "Oui"), (False, "Non")),
-        coerce=coerce,
+        coerce=lambda value: bool(strtobool(value)),
     )
 
     def clean(self):
         result = super().clean()
-        if result["conseiller_numerique"] is True and not result.get(
+        if result.get("conseiller_numerique", None) is True and not result.get(
             "email", ""
         ).endswith(CONSEILLER_NUMERIQUE_EMAIL):
             self.add_error(


### PR DESCRIPTION
## 🌮 Objectif

Lorsqu'un formulaire fait partie d'un formeset, Django ne met pas de contrainte `required` sur les champs du formulaire. Ce qui fait qu'on peut soumettre un formulaire avec le champ `conseiller_numerique` non-rempli. Dans ce cas, le formulaire déclanche une erreur sur le champ en question et on peut se retrouver à l'état `Form.clean` sans valeur pour `conseiller_numerique`.