### PR TITLE
Suppression du mot "bientôt" dans le bandeau d'information

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -8,7 +8,7 @@
   <div class="fr-alert fr-alert--info">
     <h3 class="fr-alert__title">🎉 Nouveauté : Les inscriptions aux formations Aidants Connect sont de retour ! </h3>
     <p>Plusieurs webinaires d'information présenteront les nouvelles modalités de formation et de financement. Ces webinaires se dérouleront à partir du mois d'avril : mercredi 17 avril 14h ; mercredi 24 avril 14h ; jeudi 2 mai 10h ; mardi 7 mai 10h (heure métropole).</p>
-    <p> Pour y accéder, il vous suffit de <a href="https://webinaire.numerique.gouv.fr//meeting/signin/31150/creator/9817/hash/9a27df264fb8c0dec8c66ddfee02e1e11246d4c7" class="fr-link" target="_blank">cliquer sur ce lien .</a></p>
+    <p> Pour y accéder, il vous suffit de <a href="https://webinaire.numerique.gouv.fr//meeting/signin/31150/creator/9817/hash/9a27df264fb8c0dec8c66ddfee02e1e11246d4c7" class="fr-link" target="_blank">cliquer sur ce lien.</a></p>
   </div>
   <h3>Comment être habilité Aidants Connect ? </h3>
   <div class="fr-callout">

--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -6,22 +6,9 @@
 
 {% block body %}
   <div class="fr-alert fr-alert--info">
-    <h3 class="fr-alert__title">
-      🎉 Nouveauté : Les inscriptions aux formations Aidants Connect sont bientôt de retour !
-    </h3>
-    <p>
-      Plusieurs webinaires d'information présenteront les nouvelles modalités de formation et de financement. Ces
-      webinaires se dérouleront à partir du mois d'avril : mercredi 17 avril 14h ; mercredi 24 avril 14h ;
-      jeudi 2 mai 10h ; mardi 7 mai 10h (heure métropole).
-    </p>
-    <p>
-      Pour y accéder, il vous suffit de <a
-        href="https://webinaire.numerique.gouv.fr//meeting/signin/31150/creator/9817/hash/9a27df264fb8c0dec8c66ddfee02e1e11246d4c7"
-        class="fr-link"
-        target="_blank"
-      >
-        cliquer sur ce lien .</a>
-    </p>
+    <h3 class="fr-alert__title">🎉 Nouveauté : Les inscriptions aux formations Aidants Connect sont de retour ! </h3>
+    <p>Plusieurs webinaires d'information présenteront les nouvelles modalités de formation et de financement. Ces webinaires se dérouleront à partir du mois d'avril : mercredi 17 avril 14h ; mercredi 24 avril 14h ; jeudi 2 mai 10h ; mardi 7 mai 10h (heure métropole).</p>
+    <p> Pour y accéder, il vous suffit de <a href="https://webinaire.numerique.gouv.fr//meeting/signin/31150/creator/9817/hash/9a27df264fb8c0dec8c66ddfee02e1e11246d4c7" class="fr-link" target="_blank">cliquer sur ce lien .</a></p>
   </div>
   <h3>Comment être habilité Aidants Connect ? </h3>
   <div class="fr-callout">


### PR DESCRIPTION
## 🌮 Objectif
Suppression du mot "bientôt" dans le bandeau d'information concernant l'ouverture des formation + d'un espace inutile dans le lien


## 🖼️ Images

![image](https://github.com/betagouv/Aidants_Connect/assets/19302155/6bf88115-251d-4dbb-be38-39e70e0f3400)