### PR TITLE
Fix sur le bouton « Ajouter un ou une référente »

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/organisation.html
@@ -78,7 +78,7 @@
     <div class="title-with-item margin-top-2rem">
       <h2 class="clearfix">Aidants</h2>
       <div>
-        {% if organisation_active_aidants|length > 1 %}{# Organisation has more aidants than just the référent #}
+        {% if organisation_active_aidants|length >= 1 %}
           <a
             href="{% url 'espace_responsable_organisation_responsables' organisation_id=organisation.id %}"
             class="fr-btn fr-btn--icon-left fr-icon-settings-5-fill"


### PR DESCRIPTION
## 🌮 Objectif

Le bouton n'est pas affiché si l'organisation ne contient qu'une personne non référente.