### PR TITLE
Oblige à entrer une adresse connue dans le formulaire d'habilitation

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -29,6 +29,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 
 from aidants_connect.postgres_url import turn_psql_url_into_param
 from aidants_connect.utils import strtobool
+from aidants_connect_common.utils import build_url
 
 load_dotenv(verbose=True)
 
@@ -444,13 +445,16 @@ AUTOCOMPLETE_SCRIPT_SRC = "https://cdn.jsdelivr.net/npm/@tarekraafat/autocomplet
 MATOMO_INSTANCE_URL = os.getenv("MATOMO_INSTANCE_URL", "https://stats.beta.gouv.fr")
 MATOMO_INSTANCE_SITE_ID = os.getenv("MATOMO_INSTANCE_SITE_ID")
 
+GOUV_ADDRESS_SEARCH_API_MOCK_BASE_URL = "test-address-api/segur/"
 if "test" in sys.argv:
     GOUV_ADDRESS_SEARCH_API_DISABLED = True
+    GOUV_ADDRESS_SEARCH_API_UNDER_TEST = True
     GOUV_ADDRESS_SEARCH_API_BASE_URL = ""
 else:
     GOUV_ADDRESS_SEARCH_API_DISABLED = getenv_bool(
         "GOUV_ADDRESS_SEARCH_API_DISABLED", True
     )
+    GOUV_ADDRESS_SEARCH_API_UNDER_TEST = False
     GOUV_ADDRESS_SEARCH_API_BASE_URL = os.getenv(
         "GOUV_ADDRESS_SEARCH_API_BASE_URL", "https://api-adresse.data.gouv.fr/search/"
     )

--- a/aidants_connect_habilitation/static/js/address_autocomplete.js
+++ b/aidants_connect_habilitation/static/js/address_autocomplete.js
@@ -39,12 +39,6 @@
         initialize() {
             this.addresses = {};
             this.labels = [];
-
-            // Insert <input> to disable backend validation for address
-            this.autcompleteInputTarget.insertAdjacentHTML(
-                "afterend", '<input name="skip_backend_validation" value="true" hidden>'
-            );
-
             super.initialize();
         }
 

--- a/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
@@ -159,7 +159,6 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
         field_names.remove("is_aidant")
         field_names.remove("conseiller_numerique")
         field_names.remove("alternative_address")
-        field_names.remove("skip_address_validation")
 
         element: WebElement = self.selenium.find_element(
             By.XPATH,
@@ -210,7 +209,6 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
         field_names.remove("is_aidant")
         field_names.remove("conseiller_numerique")
         field_names.remove("alternative_address")
-        field_names.remove("skip_address_validation")
 
         prefix = PersonnelForm.MANAGER_FORM_PREFIX
 
@@ -262,7 +260,6 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
         for field_name in form.fields:
             if field_name not in (
                 "alternative_address",
-                "skip_address_validation",
                 "conseiller_numerique",
             ):
                 self.assertEqual(


### PR DESCRIPTION
## 🌮 Objectif

Oblige à entrer une adresse connue dans le formulaire d'habilitation

- [ ] le comportement du bouton « mon adresse n'apparaît pas dans la liste » est défini
- [ ] les tests passent

## 🖼️ Images

![](https://github.com/betagouv/Aidants_Connect/assets/22097904/c010e017-b51f-4536-bee9-b0ab6ab40468)
