### PR TITLE
Le bouton "C’est moi ! Remplir avec mes infos" de l'habilitation remplit l'adresse du référent avec celle de l'organisation

### DIFF
--- a/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_personnel_form.py
@@ -428,6 +428,13 @@ class PersonnelRequestFormViewTests(FunctionalTestCase):
             field_value = getattr(issuer, field_name)
             self.assertEqual(element.get_attribute("value"), field_value)
 
+        for field_name in ("zipcode", "city", "address"):
+            element: WebElement = self.selenium.find_element(
+                By.CSS_SELECTOR, f"#manager-subform [name$='{field_name}']"
+            )
+            field_value = getattr(organisation, field_name)
+            self.assertEqual(element.get_attribute("value"), field_value)
+
     def test_cannot_submit_form_without_aidants_displays_errors(self):
         issuer: Issuer = IssuerFactory()
         manager: Manager = ManagerFactory(is_aidant=False)

--- a/aidants_connect_habilitation/views.py
+++ b/aidants_connect_habilitation/views.py
@@ -368,6 +368,9 @@ class PersonnelRequestFormView(
         issuer_data = model_to_dict(
             self.issuer, exclude=[*IssuerForm.Meta.exclude, "id"]
         )
+        issuer_data.update(
+            model_to_dict(self.organisation, fields=("zipcode", "city", "address"))
+        )
         # Fields of type PhoneNumberField are not natively JSON serializable
         issuer_data["phone"] = str(issuer_data["phone"])
         return {


### PR DESCRIPTION
Le bouton "C’est moi ! Remplir avec mes infos" de l'habilitation remplit l'adresse du référent avec celle de l'organisation