### PR TITLE
Ajout d'un serialiseur CSV pour des exports de modèles plus faciles

### DIFF
--- a/aidants_connect_common/apps.py
+++ b/aidants_connect_common/apps.py
@@ -6,5 +6,10 @@ class AidantsConnectCommonConfig(AppConfig):
     name = "aidants_connect_common"
 
     def ready(self):
+        from django.core.serializers import register_serializer
+
         import aidants_connect_common.lookups  # noqa
         import aidants_connect_common.signals  # noqa
+        from aidants_connect_common.serializers import csv
+
+        register_serializer("csv", csv.__name__)

--- a/aidants_connect_common/serializers/csv.py
+++ b/aidants_connect_common/serializers/csv.py
@@ -1,0 +1,30 @@
+from csv import DictWriter
+
+from django.core.serializers.python import Serializer as PythonSerializer
+from django.db.models import Model
+
+
+class Serializer(PythonSerializer):
+    def end_object(self, obj: Model):
+        dumped = self.get_dump_object(obj)
+        if self.first:
+            self.writer = DictWriter(
+                self.stream,
+                fieldnames=[
+                    obj._meta.get_field(item).verbose_name
+                    for item in dumped["fields"].keys()
+                ],
+            )
+            self.writer.writeheader()
+
+        self.writer.writerow(
+            {
+                obj._meta.get_field(k).verbose_name: str(v)
+                for k, v in dumped["fields"].items()
+            }
+        )
+        super().end_object(obj)
+
+    def getvalue(self):
+        # Grandparent super
+        return super(PythonSerializer, self).getvalue()

--- a/aidants_connect_common/tests/serializers.py
+++ b/aidants_connect_common/tests/serializers.py
@@ -1,0 +1,18 @@
+from django.core import serializers
+from django.test import TestCase
+
+from aidants_connect_web.tests.factories import AidantFactory
+
+
+class TestCSVSerializer(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.aidants = [AidantFactory() for _ in range(10)]
+
+    def test_csv_serializer(self):
+        from aidants_connect_web.models import Aidant
+
+        result = serializers.serialize("csv", Aidant.objects.all())
+
+        # 10 records +  header
+        self.assertEqual(11, len(result.splitlines()))


### PR DESCRIPTION
## 🌮 Objectif

Utilisation :

```py
from django.core import serializers
serializers.serialize("csv", Model.objects.all())
```