### PR TITLE
Correction d'une erreur sur les inscriptions des aidants

### DIFF
--- a/aidants_connect_habilitation/templates/_display_org_request.html
+++ b/aidants_connect_habilitation/templates/_display_org_request.html
@@ -172,7 +172,7 @@
           <div class="flex fr-mb-5v">
             <h4 class="h2 fr-col--middle fr-m-0">Aidant <span class="sr-only">{{ forloop.counter }}</span></h4>
             <span class="spacer"></span>
-            {% include "_formation_registration_button.html" with aidant=aidant_request %}
+            {% include "_formation_registration_button_aidant.html" with aidant=aidant_request %}
           </div>
 
           <div>

--- a/aidants_connect_habilitation/templates/_formation_registration_button.html
+++ b/aidants_connect_habilitation/templates/_formation_registration_button.html
@@ -11,11 +11,13 @@
       Cette personne est inscrite à une formation
     </button>
   {% else %}
-    <a
-      href="{% url 'habilitation_manager_formation_registration' issuer_id=organisation.issuer.issuer_id uuid=organisation.uuid %}"
-      class="fr-btn"
-    >
-      Inscrire à une formation
-    </a>
+    {% block url_registration %}
+        <a
+          href="{% url 'habilitation_manager_formation_registration' issuer_id=organisation.issuer.issuer_id uuid=organisation.uuid %}"
+          class="fr-btn"
+        >
+          Inscrire à une formation
+        </a>
+    {% endblock %}
   {% endif %}
 {% endif %}

--- a/aidants_connect_habilitation/templates/_formation_registration_button_aidant.html
+++ b/aidants_connect_habilitation/templates/_formation_registration_button_aidant.html
@@ -1,0 +1,9 @@
+{% extends "_formation_registration_button.html" %}
+    {% block url_registration %}
+        <a
+          href="{% url 'habilitation_new_aidant_formation_registration' issuer_id=organisation.issuer.issuer_id uuid=organisation.uuid aidant_id=aidant.id %}"
+          class="fr-btn"
+        >
+          Inscrire à une formation
+        </a>
+    {% endblock %}


### PR DESCRIPTION


## 🌮 Objectif

Suite à un bug les aidants ne pouvaient plus s'inscrire uniquement les  référents.

## 🔍 Implémentation

utiliser deux templates différents pour les deux urls

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
