### PR TITLE
Ajout des classes BaseMultiForm & BaseModelMultiForm

### DIFF
--- a/aidants_connect_common/forms.py
+++ b/aidants_connect_common/forms.py
@@ -1,14 +1,26 @@
+from copy import deepcopy
 from datetime import timedelta
 from inspect import signature
+from itertools import accumulate
+from typing import Iterable, Union
 
 from django import forms
 from django.conf import settings
 from django.core import validators
-from django.core.exceptions import ValidationError
-from django.db.models import Model
-from django.forms import Form
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
+from django.db.models import Model, QuerySet
+from django.db.models.utils import AltersData
+from django.forms import (
+    BaseForm,
+    BaseFormSet,
+    BaseModelForm,
+    BaseModelFormSet,
+    Media,
+    MediaDefiningClass,
+)
 from django.forms.utils import ErrorList
 from django.utils.datastructures import MultiValueDict
+from django.utils.translation import ngettext
 
 from dsfr.forms import DsfrBaseForm
 from phonenumber_field.formfields import PhoneNumberField
@@ -53,7 +65,7 @@ class PatchedModelForm(forms.ModelForm, WidgetAttrMixin):
         super().__init__(*sig.args, **sig.kwargs)
 
 
-class PatchedForm(Form, WidgetAttrMixin):
+class PatchedForm(forms.Form, WidgetAttrMixin):
     def __init__(self, *args, **kwargs):
         sig = signature(super().__init__).bind_partial(*args, **kwargs)
         sig.arguments.setdefault("label_suffix", "")
@@ -142,3 +154,272 @@ class FollowMyHabilitationRequesrForm(DsfrBaseForm):
                 "Il nʼexiste pas de demande dʼhabilitation associée à cet email. "
                 "Veuillez vérifier votre saisie ou renseigner une autre adresse email."
             )
+
+
+FormLike = Union[BaseForm, BaseFormSet]
+ModelFormLike = Union[BaseModelForm, BaseModelFormSet]
+
+
+class DeclarativeFormMetaclass(MediaDefiningClass):
+    def __new__(mcs, name, bases, attrs):
+        attrs["declared_form_classes"] = {
+            key: attrs.pop(key)
+            for key, value in list(attrs.items())
+            if isinstance(value, type) and issubclass(value, FormLike)
+        }
+
+        new_class = super().__new__(mcs, name, bases, attrs)
+
+        # Walk through the MRO.
+        declared_form_classes = {}
+        for base in reversed(new_class.__mro__):
+            # Collect fields from base class.
+            if hasattr(base, "declared_form_classes"):
+                declared_form_classes.update(base.declared_form_classes)
+
+            # Field shadowing.
+            for attr, value in base.__dict__.items():
+                if value is None and attr in declared_form_classes:
+                    declared_form_classes.pop(attr)
+
+        new_class.base_form_casses = declared_form_classes
+
+        return new_class
+
+
+class BaseMultiForm(metaclass=DeclarativeFormMetaclass):
+    def __init__(
+        self,
+        data=None,
+        files=None,
+        auto_id="id_%s",
+        prefix=None,
+        initial=None,
+        error_class=ErrorList,
+        form_kwargs=None,
+        renderer=None,
+    ):
+        self.is_bound = data is not None or files is not None
+        self.prefix = prefix or self.get_default_prefix()
+        self.auto_id = auto_id
+        self.data = MultiValueDict() if data is None else data
+        self.files = MultiValueDict() if files is None else files
+        self.initial = initial or {}
+        self.error_class = error_class or ErrorList
+        self.form_kwargs = form_kwargs or {}
+        self.renderer = renderer
+        self._errors = None  # Stores the errors after clean() has been called.
+        self.form_classes = deepcopy(self.base_form_casses)
+
+        self._forms_cache = {}
+
+    def __repr__(self):
+        if self._errors is None:
+            is_valid = "Unknown"
+        else:
+            is_valid = self.is_bound and not self._errors
+        return (
+            f"<{self.__class__.__name__} "
+            f"bound={self.is_bound}, "
+            f"valid={is_valid}, "
+            f"form_classes={self.form_classes}>"
+        )
+
+    def __iter__(self) -> Iterable[FormLike]:
+        for name in self.forms:
+            yield self[name]
+
+    def __getitem__(self, name) -> FormLike:
+        try:
+            return self.forms[name]
+        except KeyError:
+            raise KeyError(
+                f"Key '{name}' not found in '{self.__class__.__name__}'. "
+                f"Choices are: {', '.join(sorted(self.form_classes.values()))}."
+            )
+
+    @property
+    def forms(self) -> dict[str, FormLike]:
+        if not self._forms_cache:
+            for name in self.form_classes:
+                self._forms_cache[name] = self.get_form(name)
+        return self._forms_cache
+
+    @classmethod
+    def get_default_prefix(cls):
+        return "multiform"
+
+    def get_form(self, name):
+        try:
+            form_class = self.form_classes[name]
+        except KeyError:
+            raise KeyError(
+                f"Key '{name}' not found in '{self.__class__.__name__}'. "
+                f"Choices are: {', '.join(sorted(self.form_classes.values()))}."
+            )
+        return self._construct_form(
+            name, form_class, **self.get_form_kwargs(name, form_class)
+        )
+
+    def get_form_kwargs(self, name, form_class):
+        return self.form_kwargs.get(name, {}).copy()
+
+    def _construct_form(self, name, form_class, **kwargs):
+        """Instantiate and return the i-th form instance in a formset."""
+        defaults = {
+            "auto_id": self.auto_id,
+            "prefix": self.add_prefix(name),
+            "error_class": self.error_class,
+            "renderer": self.renderer,
+        }
+        if self.is_bound:
+            defaults["data"] = self.data
+            defaults["files"] = self.files
+        if self.initial and (initial := self.initial.get(name)):
+            defaults["initial"] = initial
+
+        defaults.update(kwargs)
+
+        if issubclass(form_class, BaseFormSet):
+            # renderer is not a constructor argument of formsets
+            # It need to be processed differently
+            renderer = defaults.pop("renderer", None)
+            form = form_class(**defaults)
+            if renderer:
+                form.renderer = renderer
+            return form
+
+        return form_class(**defaults)
+
+    def add_non_field_error(self, form: str | None, error: str | ValidationError):
+        if not isinstance(error, ValidationError):
+            error = ValidationError(error)
+
+        if hasattr(error, "error_dict"):
+            raise TypeError(
+                "The `error` argument cannot contains errors for multiple fields."
+            )
+
+        form = form or NON_FIELD_ERRORS
+
+        if form in self.forms and isinstance(self.forms[form], BaseFormSet):
+            self.forms[form].non_form_errors().extend(error.error_list)
+            self.errors.setdefault(NON_FIELD_ERRORS, {})
+            self.errors[NON_FIELD_ERRORS].update(
+                {form: self.forms[form].non_form_errors()}
+            )
+        elif form in self.forms:
+            self.forms[form].add_error(None, error)
+            self.errors.setdefault(form, self.forms[form].errors)
+        elif form == NON_FIELD_ERRORS:
+            self.errors.setdefault(NON_FIELD_ERRORS, {})
+            self.errors[NON_FIELD_ERRORS].setdefault(
+                NON_FIELD_ERRORS,
+                self.error_class(error_class="nonfield", renderer=self.renderer),
+            )
+            self.errors[NON_FIELD_ERRORS][NON_FIELD_ERRORS].extend(error.error_list)
+        else:
+            raise ValueError(
+                "'form' argument must be a form name present in "
+                f"{self.form_classes.keys()} or None (was {form})"
+            )
+
+    def add_prefix(self, name):
+        return "%s-%s" % (self.prefix, name)
+
+    def is_valid(self):
+        return self.is_bound and not self.errors
+
+    @property
+    def errors(self) -> dict[str, ErrorList | dict[str, ErrorList]] | None:
+        """Return a list of form.errors for every form in self.forms."""
+        if self._errors is None:
+            self.full_clean()
+        return self._errors
+
+    def full_clean(self):
+        self._errors = {}
+
+        if not self.is_bound:  # Stop further processing.
+            return
+
+        for name, form in self.forms.items():
+            if form.is_valid():
+                if not hasattr(self, "cleaned_data"):
+                    self.cleaned_data = {}
+                self.cleaned_data[name] = form.cleaned_data
+            else:
+                if form.errors:
+                    self._errors[name] = form.errors
+                if isinstance(form, BaseFormSet) and form.non_form_errors():
+                    self.errors.setdefault(NON_FIELD_ERRORS, {})
+                    self.errors[NON_FIELD_ERRORS].update({name: form.non_form_errors()})
+
+        try:
+            self.clean()
+        except ValidationError as e:
+            self.add_non_field_error(None, e)
+
+    def clean(self):
+        pass
+
+    @property
+    def media(self):
+        return accumulate((form.media for form in self), initial=Media())
+
+
+class BaseModelMultiForm(BaseMultiForm, AltersData):
+    def __init__(
+        self,
+        data=None,
+        files=None,
+        auto_id="id_%s",
+        prefix=None,
+        querysets: None | dict[str, QuerySet] = None,
+        initial=None,
+        error_class=ErrorList,
+        form_kwargs=None,
+        renderer=None,
+    ):
+        self.querysets = querysets or {}
+        super().__init__(
+            data, files, auto_id, prefix, initial, error_class, form_kwargs, renderer
+        )
+
+    def get_queryset(self, name) -> QuerySet:
+        return self.querysets.get(name, None)
+
+    def get_form_kwargs(self, name, form_class):
+        kwargs = super().get_form_kwargs(name, form_class)
+        queryset = self.get_queryset(name)
+        if (
+            "queryset" not in kwargs
+            and queryset is not None
+            and issubclass(self.form_classes[name], ModelFormLike)
+        ):
+            kwargs["queryset"] = queryset
+        return kwargs
+
+    @property
+    def model_forms(self):
+        for form in self:
+            if isinstance(form, ModelFormLike):
+                yield form
+
+    def save(self, commit=True):
+        if self.errors:
+            raise ValueError(
+                ngettext(
+                    "The form %s could not be saved because it has errors.",
+                    "The forms %s could not be saved because it has errors.",
+                    len(self.errors),
+                )
+                % (
+                    list(self.errors.keys())[0]
+                    if len(self.errors) == 1
+                    else ", ".join(self.errors.keys())
+                ),
+            )
+
+        for form in self.model_forms:
+            form.save(commit)

--- a/aidants_connect_common/tests/test_forms.py
+++ b/aidants_connect_common/tests/test_forms.py
@@ -1,0 +1,398 @@
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from django import forms
+from django.core.exceptions import ValidationError
+from django.forms.formsets import (
+    INITIAL_FORM_COUNT,
+    MAX_NUM_FORM_COUNT,
+    MIN_NUM_FORM_COUNT,
+    TOTAL_FORM_COUNT,
+    BaseFormSet,
+)
+from django.test import TestCase, tag
+
+from dsfr.forms import DsfrDjangoTemplates
+
+from aidants_connect_common.forms import BaseModelMultiForm, BaseMultiForm
+from aidants_connect_web.models import Aidant, Organisation
+from aidants_connect_web.tests.factories import AidantFactory, OrganisationFactory
+
+
+class _TestForm(forms.Form):
+    test = forms.IntegerField()
+
+
+_TestFormset = forms.formset_factory(_TestForm)
+
+
+class _TestMultiForm(BaseMultiForm):
+    test = _TestForm
+    tests = _TestFormset
+
+
+_TestModelFormset = forms.modelformset_factory(
+    Aidant,
+    fields=(
+        "id",
+        "email",
+        "last_name",
+        "first_name",
+        "profession",
+        "phone",
+        "organisation",
+        "username",
+    ),
+    extra=0,
+)
+
+
+class _TestModelMultiForm(BaseModelMultiForm):
+    test = _TestForm
+    tests = _TestModelFormset
+
+
+@tag("forms")
+class TestBaseMultiForm(TestCase):
+    def test_instanciate(self):
+        form = _TestMultiForm()
+        self.assertFalse(form.errors)
+
+    def test_instanciate_with_params(self):
+        renderer = DsfrDjangoTemplates()
+        form = _TestMultiForm(
+            auto_id="id-%s",
+            prefix="metaform",
+            initial={"test": "test"},
+            error_class=None,
+            form_kwargs={
+                "test": {"prefix": "the_test"},
+                "tests": {"prefix": "the_tests"},
+            },
+            renderer=renderer,
+        )
+        self.assertFalse(form.errors)
+        self.assertEqual("the_test", form["test"].prefix)
+        self.assertEqual("the_tests", form["tests"].prefix)
+        self.assertEqual(renderer, form["test"].renderer)
+        self.assertEqual(renderer, form["tests"].renderer)
+
+    def test_valid(self):
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): 6,
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 100,
+                form["tests"].forms[0].add_prefix("test"): 12,
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            {
+                "test": {"test": 6},
+                "tests": [{"test": 12}],
+            },
+            form.cleaned_data,
+        )
+
+    def test_invalid(self):
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): "NaN",
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): object(),
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): object(),
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): object(),
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): object(),
+                form["tests"].forms[0].add_prefix("test"): "NaN",
+            }
+        )
+        form.is_valid()
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            {
+                "__all__": {
+                    "tests": [
+                        "Des données du formulaire ManagementForm sont manquantes ou "
+                        "ont été manipulées. Champs manquants : "
+                        "multiform-tests-TOTAL_FORMS, "
+                        "multiform-tests-INITIAL_FORMS, "
+                        "multiform-tests-MIN_NUM_FORMS, "
+                        "multiform-tests-MAX_NUM_FORMS. "
+                        "Vous pourriez créer un rapport de "
+                        "bogue si le problème persiste."
+                    ]
+                },
+                "test": {"test": ["Saisissez un nombre entier."]},
+            },
+            form.errors,
+        )
+        self.assertRaises(AttributeError, getattr, form, "cleaned_data")
+
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): "NaN",
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 0,
+                form["tests"].forms[0].add_prefix("test"): "NaN",
+            }
+        )
+        form.is_valid()
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            {
+                "test": {"test": ["Saisissez un nombre entier."]},
+                "tests": [{"test": ["Saisissez un nombre entier."]}],
+            },
+            form.errors,
+        )
+        self.assertRaises(AttributeError, getattr, form, "cleaned_data")
+
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): 6,
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 0,
+                form["tests"].forms[0].add_prefix("test"): "NaN",
+            }
+        )
+        form.is_valid()
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            {"tests": [{"test": ["Saisissez un nombre entier."]}]},
+            form.errors,
+        )
+        self.assertEqual({"test": {"test": 6}}, form.cleaned_data)
+
+    def test_clean_raises_validation_error(self):
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): 6,
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 0,
+                form["tests"].forms[0].add_prefix("test"): "NaN",
+            }
+        )
+
+        form.clean = MagicMock(side_effect=ValidationError("Woops"))
+        self.assertEqual(
+            {
+                "__all__": {"__all__": ["Woops"]},
+                "tests": [{"test": ["Saisissez un nombre entier."]}],
+            },
+            form.errors,
+        )
+
+    def test_add_non_field_error(self):
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): 6,
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 0,
+                form["tests"].forms[0].add_prefix("test"): 12,
+            }
+        )
+
+        self.assertTrue(form.is_valid())
+
+        form.add_non_field_error(None, "1")
+        form.add_non_field_error(None, ValidationError("2"))
+        form.add_non_field_error("test", "1")
+        form.add_non_field_error("test", ValidationError("2"))
+        form.add_non_field_error("tests", "1")
+        form.add_non_field_error("tests", ValidationError("2"))
+        self.assertRaises(
+            ValueError, form.add_non_field_error, "non_existant_form", "1"
+        )
+        self.assertRaises(
+            ValueError,
+            form.add_non_field_error,
+            "non_existant_form",
+            ValidationError("2"),
+        )
+        self.assertEqual(
+            {
+                "__all__": {"__all__": ["1", "2"], "tests": ["1", "2"]},
+                "test": {"__all__": ["1", "2"]},
+            },
+            form.errors,
+        )
+
+    def test_repr(self):
+        self.assertEqual(
+            "<_TestMultiForm bound=False, valid=Unknown, "
+            f"form_classes={{'test': {_TestForm}, 'tests': {_TestFormset}}}>",
+            str(_TestMultiForm()),
+        )
+        form = _TestMultiForm()
+        form = _TestMultiForm(
+            {
+                form["test"].add_prefix("test"): 6,
+                form["tests"].management_form.add_prefix(TOTAL_FORM_COUNT): 1,
+                form["tests"].management_form.add_prefix(INITIAL_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MIN_NUM_FORM_COUNT): 0,
+                form["tests"].management_form.add_prefix(MAX_NUM_FORM_COUNT): 100,
+                form["tests"].forms[0].add_prefix("test"): 12,
+            }
+        )
+        self.assertTrue(form.is_valid())
+        self.assertEqual(
+            "<_TestMultiForm bound=True, valid=True, "
+            f"form_classes={{'test': {_TestForm}, 'tests': {_TestFormset}}}>",
+            str(form),
+        )
+
+    def test_extend(self):
+        class _TestMultiForm2(_TestMultiForm):
+            test2 = _TestForm
+
+        form = _TestMultiForm2()
+        self.assertEqual({"test", "tests", "test2"}, set(form.forms.keys()))
+        self.assertIsInstance(form["test"], _TestForm)
+        self.assertIsInstance(form["tests"], BaseFormSet)
+        self.assertIsInstance(form["test2"], _TestForm)
+
+
+@tag("forms")
+class TestBaseModelMultiForm(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org1: Organisation = OrganisationFactory()
+        cls.aidants1: list[Aidant] = [
+            AidantFactory(organisation=cls.org1) for _ in range(3)
+        ]
+        cls.org2: Organisation = OrganisationFactory()
+        cls.aidants2: list[Aidant] = [
+            AidantFactory(organisation=cls.org2) for _ in range(3)
+        ]
+
+    def test_instanciate_with_params(self):
+        renderer = DsfrDjangoTemplates()
+        form = _TestModelMultiForm(
+            auto_id="id-%s",
+            prefix="metaform",
+            initial={"test": "test"},
+            error_class=None,
+            form_kwargs={
+                # Testing 'queryset argument is not passed to BaseForm or BaseFormSet
+                "test": {"prefix": "the_test"},
+                "tests": {"prefix": "the_tests"},
+            },
+            querysets={"test": Aidant.objects.none(), "tests": self.org1.aidants},
+            renderer=renderer,
+        )
+        self.assertFalse(form.errors)
+        self.assertEqual("the_test", form["test"].prefix)
+        self.assertEqual("the_tests", form["tests"].prefix)
+        self.assertEqual(renderer, form["test"].renderer)
+        self.assertEqual(renderer, form["tests"].renderer)
+
+    def test_queryset(self):
+        form = _TestModelMultiForm(
+            querysets={"test": Aidant.objects.none(), "tests": self.org1.aidants.all()}
+        )
+        self.assertEqual(3, len(form["tests"].forms))
+        self.assertEqual(self.aidants1[0], form["tests"].forms[0].instance)
+        self.assertEqual(self.aidants1[1], form["tests"].forms[1].instance)
+        self.assertEqual(self.aidants1[2], form["tests"].forms[2].instance)
+
+    def test_save(self):
+        names = ["e", "j", "v"]
+        additionnal_aidant = AidantFactory.build()
+        data = {
+            "multiform-test-test": 6,
+            "multiform-tests-TOTAL_FORMS": 4,
+            "multiform-tests-INITIAL_FORMS": 3,
+            "multiform-tests-MIN_NUM_FORMS": 0,
+            "multiform-tests-MAX_NUM_FORMS": 1000,
+            "multiform-tests-0-id": self.aidants1[0].pk,
+            "multiform-tests-0-username": self.aidants1[0].username,
+            "multiform-tests-0-first_name": self.aidants1[0].first_name,
+            "multiform-tests-0-last_name": names[0],
+            "multiform-tests-0-email": self.aidants1[0].email,
+            "multiform-tests-0-profession": self.aidants1[0].profession,
+            "multiform-tests-0-phone": f"{self.aidants1[0].phone}",
+            "multiform-tests-0-organisation": self.org1.pk,
+            "multiform-tests-1-id": self.aidants1[1].pk,
+            "multiform-tests-1-username": self.aidants1[1].username,
+            "multiform-tests-1-first_name": self.aidants1[1].first_name,
+            "multiform-tests-1-last_name": names[1],
+            "multiform-tests-1-email": self.aidants1[1].email,
+            "multiform-tests-1-profession": self.aidants1[1].profession,
+            "multiform-tests-1-phone": f"{self.aidants1[1].phone}",
+            "multiform-tests-1-organisation": self.org1.pk,
+            "multiform-tests-2-id": self.aidants1[2].pk,
+            "multiform-tests-2-username": self.aidants1[2].username,
+            "multiform-tests-2-first_name": self.aidants1[2].first_name,
+            "multiform-tests-2-last_name": names[2],
+            "multiform-tests-2-email": self.aidants1[2].email,
+            "multiform-tests-2-profession": self.aidants1[2].profession,
+            "multiform-tests-2-phone": f"{self.aidants1[2].phone}",
+            "multiform-tests-2-organisation": self.org1.pk,
+            "multiform-tests-3-id": None,
+            "multiform-tests-3-username": additionnal_aidant.username,
+            "multiform-tests-3-first_name": additionnal_aidant.first_name,
+            "multiform-tests-3-last_name": additionnal_aidant.last_name,
+            "multiform-tests-3-email": additionnal_aidant.email,
+            "multiform-tests-3-profession": additionnal_aidant.profession,
+            "multiform-tests-3-phone": f"{additionnal_aidant.phone}",
+            "multiform-tests-3-organisation": self.org1.pk,
+        }
+
+        form = _TestModelMultiForm(
+            data,
+            querysets={"test": Aidant.objects.none(), "tests": self.org1.aidants.all()},
+        )
+        self.assertEqual(3, len(self.org1.aidants.all()))
+
+        form.save()
+
+        self.org1.refresh_from_db()
+        self.assertEqual(4, len(self.org1.aidants.all()))
+        self.assertEqual(
+            {*names, additionnal_aidant.last_name},
+            set(self.org1.aidants.all().values_list("last_name", flat=True)),
+        )
+        added_aidant = self.org1.aidants.last()
+        self.assertEqual(
+            {
+                "id": added_aidant.pk,  # not important
+                "username": additionnal_aidant.username,
+                "first_name": additionnal_aidant.first_name,
+                "last_name": additionnal_aidant.last_name,
+                "email": additionnal_aidant.email,
+                "profession": additionnal_aidant.profession,
+                "phone": f"{additionnal_aidant.phone}",
+                "organisation": self.org1,
+            },
+            {k: getattr(added_aidant, k) for k in form["tests"].forms[0].fields.keys()},
+        )
+
+        # Test raising error
+        with patch(
+            "aidants_connect_common.tests.test_forms._TestModelMultiForm.errors",
+            new_callable=PropertyMock,
+        ) as mock_errors:
+            mock_errors.return_value = {"test": ValidationError("Woops!")}
+            form = _TestModelMultiForm(
+                data,
+                querysets={
+                    "test": Aidant.objects.none(),
+                    "tests": self.org1.aidants.all(),
+                },
+            )
+            self.assertRaises(ValueError, form.save)

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -78,10 +78,9 @@ class AidantCreationForm(forms.ModelForm):
         self.fields["organisation"].required = True
 
     def clean(self):
-        super().clean()
-        cleaned_data = self.cleaned_data
+        cleaned_data = super().clean()
         aidant_email = cleaned_data.get("email")
-        if aidant_email in Aidant.objects.all().values_list("username", flat=True):
+        if Aidant.objects.filter(email__iexact=aidant_email).exists():
             self.add_error(
                 "email", forms.ValidationError("This email is already taken")
             )


### PR DESCRIPTION
## 🌮 Objectif

Ces classes permettent de créer des méta-`Form`, des Form qui contiennent des Forms. [J'ai déjà rencontré le cas sur Aidants Connect d'une page qui utilise des `ModelFormSet`s + d'autres données communes](https://github.com/betagouv/Aidants_Connect/blob/main/aidants_connect_habilitation/forms.py#L579). À l'époque, j'ai écrit une classe à l'arrache. Mais j'ai à nouveau le cas sur la page d'habilitation P2P et un cas c'est du hasard, 2 cas, c'est un tendance. Donc autant développer un truc propre.