### PR TITLE
Ne pas afficher les heures 00:00 sur les formations

### DIFF
--- a/aidants_connect_common/models.py
+++ b/aidants_connect_common/models.py
@@ -250,7 +250,7 @@ class Formation(models.Model):
                 f"au {date(self.end_datetime, 'd F Y à H:i')}"
             )
         else:
-            if self.start_datetime.hour == 0:
+            if self.start_datetime.hour in (0, 1, 2):
                 return f"Début le {date(self.start_datetime, 'd F Y')} "
             return f"Début le {date(self.start_datetime, 'd F Y à H:i')} "
 


### PR DESCRIPTION
## 🌮 Objectif

Ne pas afficher les heures 00:00 sur les formations

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
