### PR TITLE
Ne plus utiliser les adresses spéciales conseiller numérique

### DIFF
--- a/aidants_connect_common/forms.py
+++ b/aidants_connect_common/forms.py
@@ -186,15 +186,16 @@ class ConseillerNumerique(Form):
         result = super().clean()
         result.setdefault("conseiller_numerique", None)
         result.setdefault("email", "")
-        if result["conseiller_numerique"] is True and not result["email"].endswith(
+        if result["conseiller_numerique"] is True and result["email"].endswith(
             settings.CONSEILLER_NUMERIQUE_EMAIL
         ):
             self.add_error(
                 "email",
                 (
-                    "Si la personne fait partie du dispositif conseiller numérique, "
-                    "elle doit s'inscrire avec son email "
+                    "Suite à l'annonce de l'arrêt des adresses emails "
                     f"{settings.CONSEILLER_NUMERIQUE_EMAIL}"
+                    " le 15 novembre 2024, nous vous invitons à renseigner"
+                    " une autre adresse email nominative et professionnelle."
                 ),
             )
 

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -482,13 +482,7 @@ class TestManagerForm(TestCase):
             email="test@test.test",
         )
 
-        self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form.errors["email"][0],
-            "Si la personne fait partie du dispositif conseiller numérique, "
-            "elle doit s'inscrire avec son email "
-            f"{settings.CONSEILLER_NUMERIQUE_EMAIL}",
-        )
+        self.assertTrue(form.is_valid())
 
 
 class TestAidantRequestForm(TestCase):
@@ -590,12 +584,31 @@ class TestAidantRequestForm(TestCase):
             email="test@test.test",
         )
 
+        self.assertTrue(form.is_valid())
+        # self.assertEqual(
+        #     form.errors["email"][0],
+        #     "Si la personne fait partie du dispositif conseiller numérique, "
+        #     "elle doit s'inscrire avec son email "
+        #     f"{settings.CONSEILLER_NUMERIQUE_EMAIL}",
+        # )
+
+    def test_email_conseiller_numerique_with_deprecated_email(self):
+        organisation = OrganisationRequestFactory()
+        form = get_form(
+            AidantRequestForm,
+            ignore_errors=True,
+            form_init_kwargs={"organisation": organisation},
+            conseiller_numerique=True,
+            email="test@conseiller-numerique.fr",
+        )
+
         self.assertFalse(form.is_valid())
         self.assertEqual(
             form.errors["email"][0],
-            "Si la personne fait partie du dispositif conseiller numérique, "
-            "elle doit s'inscrire avec son email "
-            f"{settings.CONSEILLER_NUMERIQUE_EMAIL}",
+            "Suite à l'annonce de l'arrêt des adresses emails "
+            f"{settings.CONSEILLER_NUMERIQUE_EMAIL}"
+            " le 15 novembre 2024, nous vous invitons à renseigner"
+            " une autre adresse email nominative et professionnelle.",
         )
 
 


### PR DESCRIPTION
## 🌮 Objectif

Ne plus utiliser les adresses spéciales conseiller numérique

On n'oblige plus leur utilisation et on met un message d'erreur quand elles sont utilisées.

## 🔍 Implémentation

- suppression de la vérification au clean du formulaire que l'on remplace par une vérification de non utilisation
## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
