### PR TITLE
Le téléphone est maintenant obligatoire pour les référents dans une demande d'habilitation

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -361,6 +361,11 @@ class ManagerForm(
     AddressValidatableMixin,
     CleanZipCodeMixin,
 ):
+    phone = AcPhoneNumberField(
+        initial="",
+        required=True,
+    )
+
     zipcode = CharField(
         label="Code Postal",
         max_length=10,


### PR DESCRIPTION
## 🌮 Objectif

Le téléphone est maintenant obligatoire pour les référents dans une demande d'habilitation

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
