### PR TITLE
Run : script bash pour trouver les assets inutilisés

### DIFF
--- a/aidants_connect/run/find-unused-assets.sh
+++ b/aidants_connect/run/find-unused-assets.sh
@@ -1,0 +1,10 @@
+while IFS= read -r -d '' file; do
+  TARGET="$file"
+  if [[ "$file" == *scss ]]; then
+    TARGET=$(echo "$file" | sed -E 's/\.scss/\.css/g')
+  fi
+
+  if ! grep "$TARGET" -rqI . --exclude-dir=".git" --exclude-dir="*__pycache__" --exclude-dir="*staticfiles" --exclude="**/*.map"; then
+    echo "$file"
+  fi
+done < <(find . -wholename "*/static/*" -type f -print0 | xargs -0 basename -a -z)


### PR DESCRIPTION
## 🌮 Objectif

Run : script bash pour trouver les assets inutilisés

La liste des assets trouvés par le script :

```
Evolventa-BoldOblique.ttf
Evolventa-Oblique.ttf
gpl.txt
SIL Open Font License.txt
Aidants Connect _ FranceConnect-c_est-quoi _ Impression noir et blanc.pdf
Aidants Connect _ FranceConnect-c_est-quoi.pdf
Franceconnect_3.pdf
Franceconnect_3_N_B.pdf
cnil_guide_securite_des_donnees_personnelles-2023.pdf
browserconfig.xml
arrow.svg
header-newsletter.svg
step1.svg
step2.svg
step3.svg
step4.svg
step5.svg
structure.svg
header-newsletter.png
Papier.svg
SMS.svg
remote-methode-checked.svg
remote-methode-unchecked.svg
help.svg
key.svg
play.svg
solidarite-numerique-phoneheart.svg
solidarite-numerique-illu_home.svg
AC_CarteOTP_Recto.svg
AC_CarteOTP_Verso.svg
build.svg
cycle.svg
document.svg
kitinterventionrimage.png
solidaritenumerique.png
ie-deprecation.css
_boxes.scss
_colors.scss
_utils.scss
```

J'ai raffiné le script pour traiter spécialement le cas des `.scss`. En revanche, le script ne 