### PR TITLE
Ajouter le nom de l'organisme de formation en plus de son type dans la liste des formations

### DIFF
--- a/aidants_connect_common/templates/formation/formation-registration.html
+++ b/aidants_connect_common/templates/formation/formation-registration.html
@@ -46,7 +46,7 @@
           <tbody>
           {% for formation_widget in form.formations.subwidgets %}
             <tr>
-              <td>{{ formation_widget.data.value.instance.type.label }}</td>
+              <td>{{ formation_widget.data.value.instance.type.label }} ({{ formation_widget.data.value.instance.organisation.name }})</td>
               <td>
                 {{ formation_widget.data.value.instance.date_range_str }} <br />
                 {{ formation_widget.data.value.instance.description|linebreaksbr }}

--- a/aidants_connect_habilitation/tests/test_views.py
+++ b/aidants_connect_habilitation/tests/test_views.py
@@ -23,7 +23,10 @@ from aidants_connect_common.constants import (
     RequestStatusConstants,
 )
 from aidants_connect_common.models import Formation
-from aidants_connect_common.tests.factories import FormationFactory
+from aidants_connect_common.tests.factories import (
+    FormationFactory,
+    FormationOrganizationFactory,
+)
 from aidants_connect_habilitation.forms import (
     AidantRequestFormSet,
     EmailOrganisationValidationError,
@@ -1495,6 +1498,7 @@ class TestFormationRegistrationView(TestCase):
         cls.formation_ok: Formation = FormationFactory(
             type_label="Des formations et des Hommes",
             start_datetime=now() + timedelta(days=50),
+            organisation=FormationOrganizationFactory(name="Organisation_Formation_OK"),
         )
 
         cls.formation_too_close: Formation = FormationFactory(
@@ -1636,6 +1640,7 @@ class TestFormationRegistrationView(TestCase):
         )
 
         self.assertIn(self.formation_ok.type.label, response.content.decode())
+        self.assertIn(self.formation_ok.organisation.name, response.content.decode())
         self.assertNotIn(self.formation_too_close.type.label, response.content.decode())
         self.assertNotIn(self.formation_full.type.label, response.content.decode())
 


### PR DESCRIPTION
## 🌮 Objectif

Ajouter le nom de l'organisme de formation en plus de son type.

## 🔍 Implémentation

- Ajout de l'affichage du champs
- Ajout d'un test pour vérifier qu'il est bien présent

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
