### PR TITLE
Ajouter le nom de l'OF en plus du type de formation dans l'email de pré inscription

### DIFF
--- a/aidants_connect_habilitation/templates/email/formation-aidant.mjml
+++ b/aidants_connect_habilitation/templates/email/formation-aidant.mjml
@@ -6,7 +6,7 @@
       <mj-text>Madame, Monsieur,</mj-text>
       <mj-text>
         <p>
-          Nous vous confirmons que {{person.get_full_name}} a été inscrit(e) à la formation : {{formation.type.label}},
+          Nous vous confirmons que {{person.get_full_name}} a été inscrit(e) à la formation : {{formation.organisation.name}} / {{formation.type.label}},
           {{formation.date_range_str|lower}}.L’organisme en charge de cette formation prendra prochainement contact avec vous.
         </p>
         <p>

--- a/aidants_connect_habilitation/templates/email/formation-aidant.txt
+++ b/aidants_connect_habilitation/templates/email/formation-aidant.txt
@@ -1,6 +1,6 @@
 Bonjour,
 
-Nous vous confirmons que {{person.get_full_name}} a été inscrit à la formation : {{formation.type.label}}, {{formation.date_range_str|lower}}. L’organisme en charge de cette formation prendra prochainement contact avec vous.
+Nous vous confirmons que {{person.get_full_name}} a été inscrit à la formation : {{formation.organisation.name}} / {{formation.type.label}}, {{formation.date_range_str|lower}}. L’organisme en charge de cette formation prendra prochainement contact avec vous.
 
 Si vous souhaitez modifier ou annuler votre demande, merci de vous rapprocher de l’organisme de formation à cette adresse : {{formation_contacts}}
 


### PR DESCRIPTION
## 🌮 Objectif

Ajouter le nom de l'OF en plus du type de formation dans l'email de pré inscription

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
