### PR TITLE
Supprimer le mail to de la page de connexion et remplacer par lien vers la FAQ

### DIFF
--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -91,11 +91,8 @@
         </div>
 
         <div class="fr-alert fr-alert--warning fr-mt-6v">
-          <h5>Un problème avec votre carte ou votre téléphone ?</h5>
-          <p>
-            Contactez-nous par courriel à l'adresse {% mailto "contact@aidantsconnect.beta.gouv.fr" %} en précisant
-            votre nom, structure, et la nature du problème.
-          </p>
+          <h3 class="fr-alert__title fr-mb-1v">Un problème avec votre carte ou votre téléphone ?</h3>
+          <p><a href="{% url 'faq_category_detail' slug='utiliser-aidants-connect' %}" class="fr-link">Consultez notre FAQ</a></p>
         </div>
       </div>
       <div class="fr-col-12 fr-col-md-6 otp-app-panel">


### PR DESCRIPTION
## 🌮 Objectif

Supprimer le mail to de la page de connexion et remplacer par lien vers la FAQ