### PR TITLE
Configuration de `coverage.py` dans le `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,18 @@ skip_glob = [
     "dist",
     "**/migrations",
 ]
+
+[tool.coverage.run]
+source = ["."]
+branch = true
+omit = [
+    "*/venv/*",
+    "*/aidants_connect/*",
+    "*/aidants_connect_web/migrations/*",
+    "*/aidants_connect_web/tests/*"
+]
+
+[tool.coverage.report]
+fail_under = 80
+show_missing = true
+skip_covered = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,13 +2,3 @@
 exclude = .git,*migrations*, venv, aidants_connect/settings.py
 max-line-length = 88
 ignore = E203, W503
-
-[coverage:run]
-source = .
-branch = True
-omit = */venv/*, */aidants_connect/*, */aidants_connect_web/migrations/*, */aidants_connect_web/tests/*
-
-[coverage:report]
-fail_under = 80
-show_missing = True
-skip_covered = True


### PR DESCRIPTION
## 🌮 Objectif

On utilise `pyproject.toml`, maintenant donc autant bouger le max de configuration ici pour éviter la fragmentation. `flake8` ne semble pas encore le prendre en charge.

On peut peut-être jeter un œil à [ruff](https://docs.astral.sh/ruff/) à un moment ?