### PR TITLE
Documentation de la variable d'env `DATABASE_URL` pour le cas user/pass dans le .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,8 @@ SSL=1
 TEST="Everything is awesome"
 APP_SECRET=this-is-a-very-secret-value
 
-DATABASE_URL=postgres://localhost:5432/aidants_connect
-# Use this for password-protected development DB
-# DATABASE_URL=postgres://user:password@localhost:5432/aidants_connect
+# Replace `<user>` and `<password>` on password-protected DB
+DATABASE_URL=postgres://<user>:<password>@localhost:5432/aidants_connect
 
 # These envars come from the public FranceConnect documentation : https://partenaires.franceconnect.gouv.fr/fcp/fournisseur-service
 FC_AS_FS_BASE_URL=https://fcp.integ01.dev-franceconnect.fr/api/v1


### PR DESCRIPTION
## 🌮 Objectif

Documentation de la variable d'env `DATABASE_URL` pour le cas user/pass dans le .env