### PR TITLE
Renforcement de la sécurité sur la page organisation référent

### DIFF
--- a/aidants_connect_web/decorators.py
+++ b/aidants_connect_web/decorators.py
@@ -56,7 +56,16 @@ def user_is_responsable_structure(view=None, redirect_field_name="next"):
     """
 
     def test(user):
-        return user.is_responsable_structure()
+        from aidants_connect_web.models import Organisation
+
+        organisation = getattr(user, "organisation", None)
+        if not isinstance(organisation, Organisation):
+            return False
+
+        return (
+            Organisation.objects.filter(pk=organisation.pk, responsables=user).count()
+            > 0
+        )
 
     decorator = user_passes_test(
         test,

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -82,18 +82,18 @@ class OrganisationView(DetailView, FormView):
     def dispatch(self, request, *args, **kwargs):
         self.referent: Aidant = request.user
         # Needed when following the FormView path
-        self.object = self.get_object()
+        self.organisation = self.get_object()
         return super().dispatch(request, *args, **kwargs)
 
     def get_object(self, queryset=None):
-        self.organisation: Organisation = self.referent.organisation
-
-        if not self.organisation:
-            django_messages.error(
-                self.request, "Vous n'êtes pas rattaché à une organisation."
+        if not hasattr(self, "object"):
+            self.object = get_object_or_404(
+                Organisation,
+                pk=self.referent.organisation.pk,
+                responsables=self.referent,
             )
-            return redirect("espace_aidant_home")
-        return self.organisation
+
+        return self.object
 
     def get_context_data(self, **kwargs):
         return {


### PR DESCRIPTION
## 🌮 Objectif

Empêche les utilisateurs qui ne sont pas référents pour cette organisation qui sont référents pour une autre organisation de gérer cette organisation.