### PR TITLE
Utiliser des emails différents pour la validation d'inscription d'un aidant conum ou non conum

### DIFF
--- a/aidants_connect_habilitation/signals.py
+++ b/aidants_connect_habilitation/signals.py
@@ -71,6 +71,31 @@ def notify_issuer_draft_request_saved(
     )
 
 
+def get_email_messages_for_inscription_validation(
+    person, formation, str_contact_emails
+):
+    if person.conseiller_numerique:
+        text_message, html_message = render_email(
+            "email/formation-aidant-conum.mjml",
+            {
+                "person": person,
+                "formation": formation,
+                "formation_contacts": str_contact_emails,
+            },
+        )
+
+    else:
+        text_message, html_message = render_email(
+            "email/formation-aidant.mjml",
+            {
+                "person": person,
+                "formation": formation,
+                "formation_contacts": str_contact_emails,
+            },
+        )
+    return text_message, html_message
+
+
 @receiver(post_save, sender=FormationAttendant)
 def formation_aidant(instance: FormationAttendant, created: bool, **_):
     if not created:
@@ -96,15 +121,10 @@ def formation_aidant(instance: FormationAttendant, created: bool, **_):
     organisation = instance.formation.organisation
 
     str_contact_emails = ", ".join(organisation.private_contacts)
-    text_message, html_message = render_email(
-        "email/formation-aidant.mjml",
-        {
-            "person": person,
-            "formation": instance.formation,
-            "formation_contacts": str_contact_emails,
-        },
-    )
 
+    text_message, html_message = get_email_messages_for_inscription_validation(
+        person, instance.formation, str_contact_emails
+    )
     send_mail(
         from_email=settings.SUPPORT_EMAIL,
         recipient_list=[*emails],

--- a/aidants_connect_habilitation/templates/email/formation-aidant-conum.mjml
+++ b/aidants_connect_habilitation/templates/email/formation-aidant-conum.mjml
@@ -1,0 +1,29 @@
+{% extends "layouts/email-base.mjml" %}
+
+{% block email_body %}
+  <mj-section>
+    <mj-column>
+      <mj-text>Madame, Monsieur,</mj-text>
+      <mj-text>
+        <p>
+          Nous vous confirmons que {{ person.get_full_name }} a été inscrit(e) à la formation : {{ formation.organisation.name }} / {{ formation.type.label }},
+          {{ formation.date_range_str|lower }}. L’organisme en charge de cette formation prendra prochainement contact avec vous.
+        </p>
+        <p>
+         Pour toute demande complémentaire, merci de vous rapprocher de l’organisme de formation à cette adresse :  {{ formation_contacts }}
+        </p>
+        <p>Financée dans le cadre du Plan France Relance jusqu’en 2023, la formation à Aidants Connect est dorénavant
+        financée selon différentes modalités. Pour les conseillers numériques, la formation est financée dans
+        le cadre du dispositif Conseiller numérique, si elle fait partie des 2 modules thématiques choisis par le conseiller
+         lors de la formation initiale ou qu’elle correspond au module annuel choisi dans le cadre de la formation continue.
+         </p>
+      </mj-text>
+    <mj-text>
+    <em>L'organisme de formation se réserve le droit d’annuler une session si le nombre de participants est insuffisant.</em>
+    </mj-text>
+      <mj-text>
+        Nous nous tenons à votre disposition et vous remercions de votre intérêt pour Aidants Connect.
+      </mj-text>
+    </mj-column>
+  </mj-section>
+{% endblock email_body %}

--- a/aidants_connect_habilitation/templates/email/formation-aidant-conum.txt
+++ b/aidants_connect_habilitation/templates/email/formation-aidant-conum.txt
@@ -1,0 +1,20 @@
+Bonjour,
+
+Nous vous confirmons que {{ person.get_full_name }} a été inscrit à la formation : {{ formation.organisation.name }} / {{ formation.type.label }}, {{ formation.date_range_str|lower }}.
+
+L’organisme en charge de cette formation prendra prochainement contact avec vous.
+
+Pour toute demande complémentaire, merci de vous rapprocher de l’organisme de formation à cette adresse :  {{ formation_contacts }}
+
+Financée dans le cadre du Plan France Relance jusqu’en 2023, la formation à Aidants Connect est dorénavant financée selon différentes modalités.
+Pour les conseillers numériques, la formation est financée dans  le cadre du dispositif Conseiller numérique,
+si elle fait partie des 2 modules thématiques choisis par le conseiller lors de la formation initiale ou qu’elle correspond au module annuel choisi dans le cadre de la formation continue.
+
+L'organisme de formation se réserve le droit d’annuler une session si le nombre de participants est insuffisant.
+
+Nous nous tenons à votre disposition et vous remercions de votre intérêt pour Aidants Connect.
+
+À bientôt sur Aidants Connect !
+L’équipe Aidants Connect
+Accompagnez vos usagers en toute sécurité
+Pour toute demande : contact@aidantsconnect.beta.gouv.fr

--- a/aidants_connect_habilitation/templates/email/formation-aidant.mjml
+++ b/aidants_connect_habilitation/templates/email/formation-aidant.mjml
@@ -6,17 +6,18 @@
       <mj-text>Madame, Monsieur,</mj-text>
       <mj-text>
         <p>
-          Nous vous confirmons que {{ person.get_full_name }} a été inscrit(e) à la formation : {{ formation.organisation.name }} / {{ formation.type.label }},
-          {{ formation.date_range_str|lower }}.L’organisme en charge de cette formation prendra prochainement contact avec vous.
+          Nous vous confirmons que {{ person.get_full_name }} a été pré-inscrit(e)  à la formation : {{ formation.organisation.name }} / {{ formation.type.label }},
+          {{ formation.date_range_str|lower }}.
         </p>
         <p>
-          Si vous souhaitez modifier ou annuler votre demande, merci de vous rapprocher de l’organisme de formation à cette adresse : {{ formation_contacts }}</p>
-        <p>La formation à Aidants Connect a été exceptionnellement financée dans le cadre du Plan France Relance jusqu’en 2023. Cette formation est dorénavant financée selon différentes modalités.</p>
-        <p>Nous vous invitons à vous rendre sur <a href="https://tally.so/r/mO0Xkg">ce simulateur de financement</a> pour découvrir comment la financer.</p>
-        <p><strong>Attention :</strong> il peut arriver que dans certains cas (structures non adhérentes à l'OPCO Uniformation, conseillers numériques ayant consommés leurs modules annuels, etc.) la formation doive être financée par la structure.</p>
+        L’organisme de formation vous adressera un devis à lui retourner signé pour valider l’inscription définitive. Pour toute demande complémentaire, merci de vous rapprocher de l’organisme de formation à cette adresse :  {{ formation_contacts }}
+        </p>
+        <p>Financée dans le cadre du Plan France Relance jusqu’en 2023, la formation à Aidants Connect est dorénavant financée selon différentes modalités.
+        Nous vous invitons à vous rendre sur <a href="https://tally.so/r/mO0Xkg">ce simulateur</a> pour connaître les modalités de financement
+        propres à votre structure et au profil des aidants à habiliter. Il peut arriver que dans certains cas la formation doive être financée par la structure.</p>
       </mj-text>
     <mj-text>
-    <em>L'organisme de formation se réserve le droit d’annuler une session si le nombre de participants est insuffisant.</em>
+    <em>L’organisme de formation se réserve le droit d’annuler ou de reporter une session si le nombre de participants est insuffisant.</em>
     </mj-text>
       <mj-text>
         Nous nous tenons à votre disposition et vous remercions de votre intérêt pour Aidants Connect.

--- a/aidants_connect_habilitation/templates/email/formation-aidant.txt
+++ b/aidants_connect_habilitation/templates/email/formation-aidant.txt
@@ -1,18 +1,14 @@
 Bonjour,
 
-Nous vous confirmons que {{person.get_full_name}} a été inscrit à la formation : {{formation.organisation.name}} / {{formation.type.label}}, {{formation.date_range_str|lower}}. L’organisme en charge de cette formation prendra prochainement contact avec vous.
+Nous vous confirmons que {{ person.get_full_name }} a été pré-inscrit(e) à la formation : {{ formation.organisation.name }} / {{ formation.type.label }}, {{ formation.date_range_str|lower }}.
 
-Si vous souhaitez modifier ou annuler votre demande, merci de vous rapprocher de l’organisme de formation à cette adresse : {{formation_contacts}}
+L’organisme de formation vous adressera un devis à lui retourner signé pour valider l’inscription définitive. Pour toute demande complémentaire, merci de vous rapprocher de l’organisme de formation à cette adresse :  : {{ formation_contacts }}
 
-La formation à Aidants Connect a été exceptionnellement financée dans le cadre du Plan France Relance jusqu’en 2023. Cette formation est dorénavant financée selon differentes modalités.
+Financée dans le cadre du Plan France Relance jusqu’en 2023, la formation à Aidants Connect est dorénavant financée selon différentes modalités.
 
-Nous vous invitons à vous rendre sur le simulateur de financement sur ce lien https://tally.so/r/mO0Xkg pour découvrir comment la financer.
+Nous vous invitons à vous rendre sur ce simulateur (https://tally.so/r/mO0Xkg) pour connaître les modalités de financement propres à votre structure et au profil des aidants à habiliter. Il peut arriver que dans certains cas la formation doive être financée par la structure.
 
-Attention : il peut arriver que dans certains cas (structures non adhérentes à l'OPCO uniformation, conseillers numériques ayant consommés leurs modules annuels, etc.) la formation doive être financée par la structure.
-
-L'organisme de formation se réserve le droit d’annuler une session si le nombre de participants est insuffisant.
-
-Nous nous tenons à votre disposition et vous remercions de votre intérêt pour Aidants Connect.
+L’organisme de formation se réserve le droit d’annuler ou de reporter une session si le nombre de participants est insuffisant.
 
 À bientôt sur Aidants Connect !
 L’équipe Aidants Connect

--- a/aidants_connect_habilitation/tests/test_signals.py
+++ b/aidants_connect_habilitation/tests/test_signals.py
@@ -1,0 +1,40 @@
+from django.test import TestCase, tag
+
+from aidants_connect_common.tests.factories import FormationFactory
+from aidants_connect_web.tests.factories import HabilitationRequestFactory
+
+from ..signals import get_email_messages_for_inscription_validation
+
+
+@tag("signal")
+class UtilsSignalFormationEmailSendingTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.hr_not_conum = HabilitationRequestFactory(
+            first_name="JeanNotConum", conseiller_numerique=False
+        )
+        cls.hr_conum = HabilitationRequestFactory(
+            first_name="JeanConum", conseiller_numerique=True
+        )
+
+        cls.formation = FormationFactory()
+
+    def test_use_email_not_conum_for_person_not_conum(self):
+        text_message, html_message = get_email_messages_for_inscription_validation(
+            self.hr_not_conum, self.formation, "str_emails_contact"
+        )
+        self.assertTrue("ce simulateur" in text_message)
+        self.assertTrue(
+            'https://tally.so/r/mO0Xkg">ce simulateur</a> pour' in html_message
+        )
+        self.assertTrue("str_emails_contact" in html_message)
+        self.assertTrue("str_emails_contact" in text_message)
+
+    def test_use_email_not_conum_for_person_conum(self):
+        text_message, html_message = get_email_messages_for_inscription_validation(
+            self.hr_conum, self.formation, "str_emails_contact"
+        )
+        self.assertTrue("Pour les conseillers numériques" in text_message)
+        self.assertTrue("Pour les conseillers numériques" in html_message)
+        self.assertTrue("str_emails_contact" in text_message)
+        self.assertTrue("str_emails_contact" in html_message)

--- a/aidants_connect_web/tests/test_commands.py
+++ b/aidants_connect_web/tests/test_commands.py
@@ -168,8 +168,11 @@ class CreateSuperUserTests(TestCase):
         def input_mock(*_):
             return "Proletaires_de_tous_les_pays"
 
-        with patch("getpass.getpass", input_mock), patch.dict(
-            os.environ, {ORGANISATION_NAME_ENV: "L'Internationale des travailleurs"}
+        with (
+            patch("getpass.getpass", input_mock),
+            patch.dict(
+                os.environ, {ORGANISATION_NAME_ENV: "L'Internationale des travailleurs"}
+            ),
         ):
             call_command(
                 "createsuperuser",


### PR DESCRIPTION
## 🌮 Objectif

Utiliser des emails différents pour la validation d'inscription d'un aidant conum ou non conum

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
