### PR TITLE
nouveaux templates pour les parcours de révocation de mandats ou d'autorisations

### DIFF
--- a/aidants_connect_web/static/css/espace-aidant.css
+++ b/aidants_connect_web/static/css/espace-aidant.css
@@ -12,3 +12,27 @@
 .fr-card__title {
   flex-grow: 10;
 }
+details[name="mandat-action"] {
+  position: relative;
+  width: fit-content;
+}
+details[name="mandat-action"] summary {
+  width: 32px;
+  height: 32px;
+  text-align: center;
+}
+details[name="mandat-action"] summary::marker {
+  content: '';
+}
+details[name="mandat-action"] .details-content {
+  width: fit-content;
+  border: solid 1px var(--grey-975-75-active);
+  position: absolute;
+  background-color: var(--background-default-grey);
+  right: 20px;
+  z-index: 1;
+  bottom: 8px;
+}
+details[name="mandat-action"] .details-content a {
+  background-image: none;
+}

--- a/aidants_connect_web/templates/aidants_connect_web/attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation.html
@@ -2,7 +2,7 @@
 
 {% load static %}
 
-{% block title %}Aidants Connect - Impression du mandat{% endblock %}
+{% block title %}Impression du mandat - Aidants Connect{% endblock %}
 
 {% block extracss %}
   <link href="{% static 'css/attestation.css' %}" rel="stylesheet">

--- a/aidants_connect_web/templates/aidants_connect_web/espace_aidant/formation_continue.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_aidant/formation_continue.html
@@ -6,12 +6,12 @@
         <div class="fr-card__content">
           {% if view|startswith:'referent' %}
             <h3 class="fr-card__title">
-              <a href="https://app.livestorm.co/aidants-connect/webinaire-referent">Prochains webinaires référents</a>
+              <a class="fr-text--lg" href="https://app.livestorm.co/aidants-connect/webinaire-referent">Prochains webinaires référents</a>
             </h3>
             <p class="fr-card__desc">L’équipe Aidants Connect vous présente le dispositif et le rôle de référent</p>
           {% else %}
             <h3 class="fr-card__title">
-              <a href="https://app.livestorm.co/aidants-connect/session-de-reembarquement-la-parole-aux-aidants">Prochains webinaires aidants</a>
+              <a class="fr-text--lg" href="https://app.livestorm.co/aidants-connect/session-de-reembarquement-la-parole-aux-aidants">Prochains webinaires aidants</a>
             </h3>
             <p class="fr-card__desc">L’équipe Aidants Connect et un aidant professionnel habilité répondent à vos questions</p>
           {% endif %}
@@ -27,7 +27,7 @@
       <div class="fr-card__body">
         <div class="fr-card__content">
           <h3 class="fr-card__title">
-            <a href="https://app.livestorm.co/aidants-connect/webinaire-juridique">Prochains webinaires juridiques</a>
+            <a class="fr-text--lg" href="https://app.livestorm.co/aidants-connect/webinaire-juridique">Prochains webinaires juridiques</a>
           </h3>
           <p class="fr-card__desc">Nos juristes répondent à vos questions (droit à l'erreur, gestion des données personnelles, etc.)</p>
         </div>
@@ -42,7 +42,7 @@
       <div class="fr-card__body">
         <div class="fr-card__content">
           <h3 class="fr-card__title">
-            <a href="#">Auto-formation</a>
+            <a class="fr-text--lg" href="#">Auto-formation</a>
           </h3>
           <p class="fr-card__desc">Description texte SM regular Lorem ipsum dolor sit amet, consectetur adipiscing elit,</p>
         </div>

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/authorization_cancellation_attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/authorization_cancellation_attestation.html
@@ -1,55 +1,55 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Impression du mandat{% endblock %}
+{% block title %}Impression de la révocation - Aidants Connect{% endblock %}
 
 {% block extracss %}
   <link href="{% static 'css/attestation.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
 {# Display navigation only on final mandate #}
-{% block nav %}<div class="no-print">{{ block.super }}</div>{% endblock nav %}
+{% block nav %}<div class="no-print">{{ block.super }}</div>{% endblock %}
 
 {% block content %}
-  <div class="fr-container clearfix">
-    <div class="fr-grid-row no-print margin-bottom-4rem">
-      <h1 class="full-width">Révocation d'une autorisation via le service « Aidants Connect »</h1>
-      <section class="fr-col-12 fr-col-md-7">
-        <p class="subtitle">
-          Lʼattestation a été révoquée avec succès.<br />
-          Veuillez l’imprimer afin de le faire signer par le mandant.
-        </p>
-      </section>
-      <section class="fr-col-12 fr-col-md-5">
-        {% include 'aidants_connect_web/_attestation-print.html' %}
-      </section>
-    </div>
-
-    <div class="attestation-content">
-      <header class="navbar fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-8">
-          {% include "layouts/_header_logos.html" %}
+  <div class="fr-container">
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <h1 class="no-print">Révocation d'une autorisation via le service « Aidants Connect »</h1>
+      <div class="fr-col-md-8 fr-col-12">
+        <div class="attestation-content">
+          <header class="navbar fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-8">
+              {% include "layouts/_header_logos.html" %}
+            </div>
+          </header>
+          <h1>Révocation d'une autorisation via le service « Aidants Connect »
+          </h1>
+          <p class="fr-my-8v">
+            Je soussigné(e), <strong>{{ user.get_full_name }}</strong> souhaite révoquer l'autorisation
+            « <strong>{{ authorization }}</strong> » créée le {{ creation_date }} avec
+            <strong>{{ organisation }}</strong>.
+          </p>
+          <p class="fr-my-8v">
+            Fait à
+            <strong {% if organisation.display_address == "" %}class="organisation-address"{% endif %}>{{ organisation.display_address }}</strong>,
+            le <strong>{{ revocation_date }}</strong>
+          </p>
+          <p class="fr-my-8v">Le mandant</p>
         </div>
-      </header>
-
-      <p class="fr-my-8v">
-        Je soussigné(e), <strong>{{ user.get_full_name }}</strong> souhaite révoquer l'autorisation
-        « <strong>{{ authorization }}</strong> » créée le {{ creation_date }} avec
-        <strong>{{ organisation }}</strong>.
-      </p>
-
-      <p class="fr-my-8v">
-        Fait à
-        <strong {% if organisation.display_address == "" %}class="organisation-address"{% endif %}>{{ organisation.display_address }}</strong>,
-        le <strong>{{ revocation_date }}</strong>
-      </p>
-
-      <p class="fr-my-8v">
-        <span>Le mandant</span>
-      </p>
+      </div>
+      <div class="fr-col-md-4 fr-col-12 no-print">
+        <div class="fr-callout">
+          <p class="fr-text">
+            Lʼautorisation a été révoquée avec succès.<br />
+            Veuillez l’imprimer afin de la faire signer par le mandant.
+          </p>
+          <div class="fr-mb-2w">
+            {% include 'aidants_connect_web/_attestation-print.html' %}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock content %}
 
-{% block footer %}{% endblock footer %}
+{% block footer %}{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/authorization_cancellation_success.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/authorization_cancellation_success.html
@@ -1,20 +1,28 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Mandat révoqué !{% endblock %}
+{% block title %}Autorisation révoquée ! - Aidants Connect{% endblock %}
 
 {% block content %}
   <div class="fr-container">
-    <h2 class="fr-my-8v">L'autorisation a été révoquée avec succès !</h2>
-
-    <p class="subtitle">
-      L'autorisation « <strong>{{ humanized_auth }}</strong> » créée le
-      <strong>{{ authorization.creation_date | date:"d F Y" }}</strong> et expirant le
-      <strong>{{ authorization.expiration_date | date:"d F Y" }}</strong>
-      a été révoquée avec succès !
-    </p>
-
+    <h1 class="fr-my-8v">L'autorisation a été révoquée avec succès !</h1>
+    <div class="fr-grid-row">
+      <div class="fr-col-12 fr-col-md-6 fr-background-alt--grey fr-p-4w fr-mb-6w">
+        <h2 class="fr-h6">Rappel de l'autorisation révoquée</h2>
+        <p>Usager : <strong>{{ usager.get_full_name }}</strong></p>
+        <p><strong>Thématique administrative : </strong></p>
+        <div class="remaining-autorisations fr-checkbox-group fr-mb-3w">
+          {% for autorisation in revoked_autorisation %}
+          <input checked disabled type="checkbox" id="checkboxes-disabled-{{ autorisation }}">
+          <label class="fr-label fr-text-default--grey" for="checkboxes-disabled-{{ autorisation }}"><strong>{{ autorisation.0 }}</strong></label>
+          <div class="fr-my-1w fr-ml-4w">{{ autorisation.1 }}</div>
+          {% endfor %}
+        </div>
+        <p>Date de l'autorisation : <strong>{{ authorization.creation_date|date:"d F Y" }}</strong></p>
+        <p>Expiration de l'autorisation : <strong>{{ authorization.expiration_date|date:"d F Y" }}</strong></p>
+      </div>
+    </div>
     <div class="fr-my-8v">
       <a
         class="fr-btn fr-btn--icon-left fr-icon-printer-fill"
@@ -23,11 +31,6 @@
         rel="noopener noreferrer"
       >
         Imprimer l'attestation de révocation
-      </a>
-    </div>
-    <div>
-      <a href="{% url 'usager_details' usager_id=usager.id %}" class="fr-link">
-        Voir le profil de {{ usager.get_full_name }}.
       </a>
     </div>
   </div>

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/confirm_autorisation_cancelation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/confirm_autorisation_cancelation.html
@@ -1,32 +1,41 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Confirmer la révocation de l'autorisation{% endblock %}
+{% block title %}Révocation de l'autorisation - Aidants Connect{% endblock %}
 
 {% block content %}
   <div class="fr-container">
-    <div class="fr-grid-row fr-grid-row--center fr-my-8v">
-      <h2>Confirmer la révocation de l'autorisation</h2>
-
+    <h1>Confirmer la révocation de l'autorisation</h1>
+    <p class="fr-text--xl fr-mb-6w">Merci de vérifier les informations ci-dessous avant de valider la révocation de l'autorisation</p>
+    <div class="fr-grid-row fr-my-8v">
       <form method="post" class="fr-col-12 fr-col-md-6">
         {% if error %}<div class="fr-alert fr-alert--error" role="alert">{{ error }}</div>{% endif %}
-
+        <div class="fr-background-alt--grey fr-p-4w fr-mb-6w">
+          <h2 class="fr-h6">Rappel de l'autorisation en cours de révocation</h2>
+          <p>Usager : <strong>{{ usager }}</strong></p>
+          <p><strong>Thématique administrative associée : </strong></p>
+          <div class="remaining-autorisations fr-checkbox-group fr-mb-3w">
+            {% for autorisation in revoked_autorisation %}
+              <input checked disabled type="checkbox" id="checkboxes-disabled-{{ autorisation }}">
+              <label class="fr-label fr-text-default--grey" for="checkboxes-disabled-{{ autorisation }}"><strong>{{ autorisation.0 }}</strong></label>
+              <div class="fr-my-1w fr-ml-4w">{{ autorisation.1 }}</div>
+            {% endfor %}
+          </div>
+          <p>Date de l'autorisation : <strong>{{ autorisation.creation_date|date:"d F Y" }}</strong></p>
+          <p>Expiration de l'autorisation : <strong>{{ autorisation.expiration_date|date:"d F Y" }}</strong></p>
+          </div>
         <p>
-          L'autorisation avec l'usager <strong>{{ usager }}</strong>,
-          pour la démarche <strong>{{ autorisation.demarche }}</strong>,
-          créé le <strong>{{ autorisation.creation_date | date:"d F Y" }}</strong> et expirant le
-          <strong>{{ autorisation.expiration_date | date:"d F Y" }}</strong>,
-          va être <strong>révoquée</strong>.
-        </p>
-        <p>
-          Cliquez sur le bouton "Je confirme" pour confirmer l'action.
+          Souhaitez-vous confirmer la révocation de cette autorisation ?
         </p>
 
         {% csrf_token %}
-        <a href="{% url 'espace_responsable_organisation' %}" class="fr-btn">Annuler</a>
-        <button class="warning fr-btn float-right" type="submit">Confirmer</button>
-      </form>
+        <div class="flex flex-between">
+
+          <a href="{% url 'espace_responsable_organisation' %}" class="fr-btn fr-btn--secondary">Annuler</a>
+          <button class="warning fr-btn float-right" type="submit">Révoquer l'autorisation</button>
+        </div>
+        </form>
     </div>
   </div>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/confirm_mandat_cancellation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/confirm_mandat_cancellation.html
@@ -1,39 +1,40 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Confirmer la révocation de l'autorisation{% endblock %}
+{% block title %} Révocation mandat - Aidants Connect{% endblock %}
 
 {% block content %}
   <div class="fr-container">
-    <div class="fr-grid-row fr-grid-row--center fr-my-8v">
-      <h2>Confirmer la révocation du mandat</h2>
-
+    <h1 class="fr-mb-2w">Confirmation de révocation</h1>
+    <p class="fr-text--xl fr-mb-6w">Merci de vérifier les informations ci-dessous avant de valider la révocation du mandat</p>
+    <div class="fr-grid-row fr-my-8v">
       <form method="post" class="fr-col-12 fr-col-md-6">
         {% if error %}<div class="fr-alert fr-alert--error" role="alert">{{ error }}</div>{% endif %}
-
-        <p>
-            Le mandat avec l'usager <strong>{{ usager_name }}</strong>,
-            concernant les démarches suivantes :
-          </p>
-          <ul class="remaining-autorisations">
-            {% for autorisation in remaining_autorisations %}
-              <li><strong>{{ autorisation }}</strong></li>
+        <div class="fr-background-alt--grey fr-p-4w fr-mb-6w">
+          <h2 class="fr-h6">Rappel du mandat en cours de révocation</h2>
+          <p>Usager : <strong>{{ usager_name }}</strong></p>
+          <p><strong>Thématiques administratives associées : </strong></p>
+          <div class="remaining-autorisations fr-checkbox-group fr-mb-3w">
+            {% for autorisation in revoked_autorisations %}
+              <input checked disabled type="checkbox" id="checkboxes-disabled-{{ autorisation }}">
+              <label class="fr-label fr-text-default--grey" for="checkboxes-disabled-{{ autorisation }}"><strong>{{ autorisation.0 }}</strong></label>
+              <div class="fr-my-1w fr-ml-4w">{{ autorisation.1 }}</div>
             {% endfor %}
-          </ul>
-          <p>
-            créé le <strong>{{ mandat.creation_date | date:"d F Y" }}</strong> et expirant le <strong>{{ mandat.expiration_date | date:"d F Y" }}</strong>,
-            va être <strong>révoquée</strong>.
-          </p>
+          </div>
+          <p>Date du mandat : <strong>{{ mandat.creation_date|date:"d F Y" }}</strong></p>
+          <p>Expiration du mandat : <strong>{{ mandat.expiration_date|date:"d F Y" }}</strong></p>
 
-          <p>
-            Cliquez sur le bouton "Je confirme" pour confirmer l'action.
-          </p>
+        </div>
+        <p class="fr-mb-6w">
+          Souhaitez-vous confirmer la révocation de ce mandat ?
+        </p>
 
         {% csrf_token %}
-        <a href="{% url 'usager_details' usager_id=usager_id %}" class="fr-btn">Annuler</a>
-        <button class="warning fr-btn float-right" type="submit">Confirmer</button>
+        <div class="flex flex-between">
+          <a href="{% url 'usager_details' usager_id=usager_id %}" class="fr-btn fr-btn--secondary">Annuler</a>
+          <button class="warning fr-btn float-right" type="submit">Révoquer le mandat</button>
+        </div>
       </form>
-    </div>
   </div>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/mandat_cancellation_attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/mandat_cancellation_attestation.html
@@ -1,8 +1,8 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Impression du mandat{% endblock %}
+{% block title %}Impression de la révocation - Aidants Connect{% endblock %}
 
 {% block extracss %}
   <link href="{% static 'css/attestation.css' %}" rel="stylesheet">
@@ -13,41 +13,43 @@
   <div class="no-print">{{ block.super }}</div>{% endblock nav %}
 
 {% block content %}
-  <div class="fr-container clearfix">
-    <div class="fr-grid-row no-print margin-bottom-4rem">
-      <h1 class="full-width">Révocation d'un mandat via le service « Aidants Connect »</h1>
-      <section class="fr-col-12 fr-col-md-7">
-        <p class="subtitle">
-          Le mandat a été révoqué avec succès.<br />
-          Veuillez l’imprimer afin de le faire signer par le mandant.
-        </p>
-      </section>
-      <section class="fr-col-12 fr-col-md-5">
-        {% include 'aidants_connect_web/_attestation-print.html' %}
-      </section>
-    </div>
-
-    <div class="attestation-content">
-      <header class="navbar fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-8">
-          {% include "layouts/_header_logos.html" %}
+  <div class="fr-container">
+    <div class="fr-grid-row fr-grid-row--gutters">
+      <h1 class="no-print">Révocation d'un mandat via le service Aidants Connect</h1>
+      <div class="fr-col-md-8 fr-col-12">
+        <div class="attestation-content">
+          <header class="navbar fr-grid-row fr-grid-row--gutters">
+            <div class="fr-col-8">
+              {% include "layouts/_header_logos.html" %}
+            </div>
+          </header>
+          <h1>Mandat pour réaliser des démarches en ligne avec le service « Aidants Connect »
+          </h1>
+          <p class="fr-my-8v">
+            Je soussigné(e), <strong>{{ usager_name }}</strong> souhaite révoquer le mandat « Aidants Connect » créé
+            le {{ creation_date }} avec <strong>{{ organisation }}</strong>.
+          </p>
+          <p class="fr-my-8v">
+            Fait à
+            <strong {% if organisation.display_address == "" %}class="organisation-address"{% endif %}>{{ organisation.display_address }}</strong>,
+            le <strong>{{ revocation_date }}</strong>
+          </p>
+          <p class="fr-my-8v">Le mandant</p>
         </div>
-      </header>
-
-      <p class="fr-my-8v">
-        Je soussigné(e), <strong>{{ usager_name }}</strong> souhaite révoquer le mandat « Aidants Connect » créé
-        le {{ creation_date }} avec <strong>{{ organisation }}</strong>.
-      </p>
-
-      <p class="fr-my-8v">
-        Fait à
-        <strong {% if organisation.display_address == "" %}class="organisation-address"{% endif %}>{{ organisation.display_address }}</strong>,
-        le <strong>{{ revocation_date }}</strong>
-      </p>
-
-      <p class="fr-my-8v">Le mandant</p>
+      </div>
+      <div class="fr-col-md-4 fr-col-12 no-print">
+        <div class="fr-callout">
+          <p class="fr-text">
+            Le mandat a été révoqué avec succès.<br />
+            Veuillez l’imprimer afin de le faire signer par le mandant.
+          </p>
+          <div class="fr-mb-2w">
+            {% include 'aidants_connect_web/_attestation-print.html' %}
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 {% endblock content %}
 
-{% block footer %}{% endblock footer %}
+{% block footer %}{% endblock %}

--- a/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/mandat_cancellation_success.html
+++ b/aidants_connect_web/templates/aidants_connect_web/mandat_auths_cancellation/mandat_cancellation_success.html
@@ -1,19 +1,28 @@
-{% extends 'layouts/main-habilitation.html' %}
+{% extends 'layouts/main.html' %}
 
 {% load static %}
 
-{% block title %}Aidants Connect - Mandat révoqué !{% endblock %}
+{% block title %}Mandat révoqué ! - Aidants Connect{% endblock %}
 
 {% block content %}
   <div class="fr-container">
-    <h2 class="fr-my-8v">Le mandat a été révoqué avec succès !</h2>
-
-    <p class="subtitle">
-      Le mandat créé le <strong>{{ mandat.creation_date | date:"d F Y" }}</strong>
-      et expirant le <strong>{{ mandat.expiration_date | date:"d F Y" }}</strong>
-      a été révoqué avec succès !
-    </p>
-
+    <h1 class="fr-my-8v">Le mandat a été révoqué avec succès !</h1>
+    <div class="fr-grid-row">
+      <div class="fr-col-12 fr-col-md-6 fr-background-alt--grey fr-p-4w fr-mb-6w">
+        <h2 class="fr-h6">Rappel du mandat révoqué</h2>
+        <p>Usager : <strong>{{ usager.get_full_name }}</strong></p>
+        <p><strong>Thématiques administratives associées : </strong></p>
+        <div class="remaining-autorisations fr-checkbox-group fr-mb-3w">
+          {% for autorisation in revoked_autorisations %}
+          <input checked disabled type="checkbox" id="checkboxes-disabled-{{ autorisation }}">
+          <label class="fr-label fr-text-default--grey" for="checkboxes-disabled-{{ autorisation }}"><strong>{{ autorisation.0 }}</strong></label>
+          <div class="fr-my-1w fr-ml-4w">{{ autorisation.1 }}</div>
+          {% endfor %}
+        </div>
+        <p>Date du mandat : <strong>{{ mandat.creation_date|date:"d F Y" }}</strong></p>
+        <p>Expiration du mandat : <strong>{{ mandat.expiration_date|date:"d F Y" }}</strong></p>
+      </div>
+    </div>
     <div class="fr-my-8v">
       <a
         class="fr-btn fr-btn--icon-left fr-icon-printer-fill"
@@ -22,11 +31,6 @@
         rel="noopener noreferrer"
       >
         Imprimer l'attestation de révocation
-      </a>
-    </div>
-    <div>
-      <a href="{% url 'usager_details' usager_id=usager.id %}" class="fr-link">
-        Voir le profil de {{ usager.get_full_name }}.
       </a>
     </div>
   </div>

--- a/aidants_connect_web/templates/aidants_connect_web/usager-details.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usager-details.html
@@ -150,7 +150,7 @@
           {% endif %}
         </section>
       {% empty %}
-        {% dsfr_alert content=group|lower|strfmt:"Vous n’avez pas de mandat {} avec cet usager." type="info" %}
+        {% dsfr_alert content=group|lower|strfmt:"Vous n’avez pas de {} avec cet usager." type="info" %}
       {% endfor %}
     {% endfor %}
   </div>

--- a/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
+++ b/aidants_connect_web/templates/aidants_connect_web/usagers/usager_row.html
@@ -45,7 +45,7 @@
       {% else %}
         <td>
           <details name="mandat-action">
-            <summary>
+            <summary class="fr-background-alt--grey">
               <span>…</span>
             </summary>
             <div class="details-content fr-p-2w">
@@ -95,7 +95,7 @@
         {% else %}
           <td>
             <details name="mandat-action">
-              <summary>
+              <summary class="fr-background-alt--grey">
                 <span>…</span>
               </summary>
               <div class="details-content fr-p-2w">

--- a/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_autorisation.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 from django.template.defaultfilters import date
 from django.test import tag
+from django.urls import reverse
 from django.utils import timezone
 
 from selenium.webdriver.common.by import By
@@ -92,10 +93,9 @@ class CancelAutorisationTests(FunctionalTestCase):
         self.selenium.switch_to.window(self.selenium.window_handles[0])
 
         # See again all mandats of usager page
-        user_link = self.selenium.find_element(
-            By.XPATH, f'.//a[@href="/usagers/{self.usager_josephine.id}/"]'
+        self.open_live_url(
+            reverse("usager_details", kwargs={"usager_id": self.usager_josephine.id})
         )
-        user_link.click()
 
         active_autorisations_after = self.selenium.find_elements(
             By.CLASS_NAME, "mandats-actifs"
@@ -140,11 +140,19 @@ class CancelAutorisationTests(FunctionalTestCase):
         submit_button = self.selenium.find_element(By.CSS_SELECTOR, "[type='submit']")
         submit_button.click()
 
-        # See again all mandats of usager page
-        user_link = self.selenium.find_element(
-            By.XPATH, f'.//a[@href="/usagers/{self.usager_josephine.id}/"]'
+        self.wait.until(
+            self.path_matches(
+                "autorisation_cancelation_success",
+                kwargs={
+                    "usager_id": self.mandat_thierry_josephine.pk,
+                    "autorisation_id": self.family_authorization.pk,
+                },
+            )
         )
-        user_link.click()
+
+        self.open_live_url(
+            reverse("usager_details", kwargs={"usager_id": self.usager_josephine.id})
+        )
 
         active_autorisations_after = self.selenium.find_elements(
             By.CSS_SELECTOR, ".mandats-actifs"

--- a/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_cancel_mandat.py
@@ -1,4 +1,5 @@
 from django.test import tag
+from django.urls import reverse
 
 from selenium.webdriver.common.by import By
 
@@ -42,12 +43,7 @@ class CancelAutorisationTests(FunctionalTestCase):
         ]
         self.assertEqual(
             remaining_autorisations,
-            [
-                "ARGENT - IMPÔTS - CONSOMMATION: Crédit immobilier, Impôts, "
-                "Consommation, Livret A, Assurance, Surendettement…",
-                "FAMILLE - SCOLARITÉ: Allocations familiales, Naissance, Mariage, "
-                "Pacs, Scolarité…",
-            ],
+            ["Argent - Impôts - Consommation", "Famille - Scolarité"],
         )
 
         # Confirm cancellation
@@ -66,7 +62,7 @@ class CancelAutorisationTests(FunctionalTestCase):
 
         recap_title = self.selenium.find_element(By.TAG_NAME, "h1").text
         self.assertEqual(
-            "révocation d'un mandat via le service « aidants connect »",
+            "révocation d'un mandat via le service aidants connect",
             recap_title.casefold(),
         )
 
@@ -75,10 +71,9 @@ class CancelAutorisationTests(FunctionalTestCase):
 
         # See again all mandats of usager page
 
-        user_link = self.selenium.find_element(
-            By.XPATH, f'.//a[@href="/usagers/{self.mandat.usager.id}/"]'
+        self.open_live_url(
+            reverse("usager_details", kwargs={"usager_id": self.mandat.usager.id})
         )
-        user_link.click()
 
         inactive_mandats = self.selenium.find_elements(By.ID, "mandats-revoques")
         self.assertEqual(len(inactive_mandats), 1)


### PR DESCRIPTION
## 🌮 Objectif

Passer au DSFR les parcours de révocations


## 🏕 Amélioration continue

- correction titres des pages => action en premier pour l'accessibilité
- correction coquille double mot "mandat" pour les tableaux sans mandat : exemple "vous n'avez pas de mandats mandats révoqués" => "vous n'avez pas de mandats révoqués"
- correction bouton actions page Mes mandats 
 
![boutons_mes_mandats](https://github.com/user-attachments/assets/fded45dc-35f4-46f2-a667-6ee6d2bff203)
- correction du bloc "formation continue" => ajustement de la taille de police du titre des cartes

## ⚠️ Informations supplémentaires

Dans `confirm_mandat_cancelation`, on n'utilise plus remaining_autorisations mais il a été conservé pour les tests

## 🖼️ Images

### Mandats
- Confirmation de révocation : 
![confirm_revoc_mandat](https://github.com/user-attachments/assets/8a4ab474-59af-4bc3-a15e-f88c90de0a2d)

- Mandat révoqué avec succès : 
![success_revoc_mandat](https://github.com/user-attachments/assets/8d39cfb4-1b0d-4ebd-b77d-7f520160c82a)

- Impression de la confirmation : 
![image](https://github.com/user-attachments/assets/db0cab3b-ce6a-4d0c-a553-307ac19c4b5d)

- Version imprimée : 
![image](https://github.com/user-attachments/assets/d74558a4-2d36-4315-936a-675c24febf5c)


### Autorisations
- Confirmation de révocation : 
![confirm_revoc_autorisation](https://github.com/user-attachments/assets/dbb3d56a-8fa0-4823-a70f-10901219eee9)

- Mandat révoqué avec succès : 
![success_revoc_autor](https://github.com/user-attachments/assets/764f85c4-e47a-4b6d-ba09-3d7563448929)

- Impression de la confirmation : 
![image](https://github.com/user-attachments/assets/8c314466-8264-44bd-8e0a-d6e896dc7c6c)

- Version imprimée : 
![image](https://github.com/user-attachments/assets/76377f91-79a7-4344-8f78-408ec25cb9c1)

