### PR TITLE
Correction d'une erreur de validation de formulaire dans le tunnel d'habilitation

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -475,6 +475,7 @@ CSP_SCRIPT_SRC = (
     COOKIE_BANNER_SERVICES_URL,
     "https://code.jquery.com/jquery-3.6.1.js",
     "https://code.jquery.com/ui/1.13.1/jquery-ui.js",
+    AUTOCOMPLETE_SCRIPT_SRC,
 )
 
 CSP_STYLE_SRC = (

--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -242,6 +242,46 @@ class ReferentForm(
         ),
     )
 
+    address = CharField(
+        label="Adresse",
+        widget=Textarea(
+            attrs={
+                "rows": 2,
+                "data-manager-form-target": "autcompleteInput",
+                "data-address-autocomplete-target": "autcompleteInput",
+                "data-action": "focus->address-autocomplete#onAutocompleteFocus",
+            }
+        ),
+    )
+
+    zipcode = CharField(
+        label="Code Postal",
+        max_length=10,
+        error_messages={
+            "required": "Le champ « code postal » est obligatoire.",
+        },
+        widget=CharField.widget(
+            attrs={
+                "data-address-autocomplete-target": "zipcodeInput",
+                "data-manager-form-target": "zipcodeInput",
+            }
+        ),
+    )
+
+    city = CharField(
+        label="Ville",
+        max_length=255,
+        error_messages={
+            "required": "Le champ « ville » est obligatoire.",
+        },
+        widget=CharField.widget(
+            attrs={
+                "data-address-autocomplete-target": "cityInput",
+                "data-manager-form-target": "cityInput",
+            }
+        ),
+    )
+
     @property
     def media(self):
         return super().media + Media(js=(JSModulePath("js/manager-form.mjs"),))

--- a/aidants_connect_habilitation/static/js/manager-form.mjs
+++ b/aidants_connect_habilitation/static/js/manager-form.mjs
@@ -3,10 +3,13 @@ import {BaseController, aidantsConnectApplicationReady} from "AidantsConnectAppl
 /**
  * @property {HTMLElement} addressContainerTarget
  * @property {HTMLInputElement} addressSameAsOrgRadioTarget
+ * @property {HTMLInputElement} autcompleteInputTarget
+ * @property {HTMLInputElement} zipcodeInputTarget
+ * @property {HTMLInputElement} cityInputTarget
  */
 class ManagerForm extends BaseController {
     static values = {issuerData: Object}
-    static targets = ["addressContainer", "addressSameAsOrgRadio"]
+    static targets = ["addressContainer", "addressSameAsOrgRadio", "autcompleteInput", "zipcodeInput", "cityInput"]
 
     connect() {
         const elt = document.querySelector("#issuer-data");
@@ -26,7 +29,11 @@ class ManagerForm extends BaseController {
     }
 
     onAddressSameAsOrgChanged({target: {value}}) {
-        this.mutateAddressContainer(JSON.parse(value.toLowerCase()))
+       this.mutateAddressContainer(JSON.parse(value.toLowerCase()))
+      //   this.mutateAddressContainer(0)
+        this.mutateRequirement(!JSON.parse(value.toLowerCase()), this.autcompleteInputTarget)
+        this.mutateRequirement(!JSON.parse(value.toLowerCase()), this.zipcodeInputTarget)
+        this.mutateRequirement(!JSON.parse(value.toLowerCase()), this.cityInputTarget)
     }
 
     mutateAddressContainer(value) {


### PR DESCRIPTION
## 🌮 Objectif

Le processus d'habilitation était bloqué a l'étape référent lorsque que l'on voulait utiliser la même adresse pour l'adresse d'intervention du référent que celle de la structure.

## 🔍 Implémentation

- rendre non obligatoire les informations quand on veut utiliser l'adresse déjà saisi

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
