### PR TITLE
Ajout action admin "permettre à un référent de s'inscrire en formation Aidant"

### DIFF
--- a/aidants_connect_common/tests/testcases.py
+++ b/aidants_connect_common/tests/testcases.py
@@ -56,7 +56,7 @@ class FunctionalTestCase(StaticLiveServerTestCase):
             log_output="./geckodriver.log", service_args=["--log", "debug"]
         )
         cls.selenium = WebDriver(options=firefox_options, service=service)
-        cls.selenium.implicitly_wait(0.5)
+        cls.selenium.implicitly_wait(2)
         cls.wait = WebDriverWait(cls.selenium, 10)
 
         # In some rare cases, the first connection to the Django LiveServer

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -89,6 +89,34 @@ class TestAidantInPreDesactivationZoneFilter(TestCase):
 
 
 @tag("admin")
+class TestAidantAdmin(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organisation1 = OrganisationFactory()
+        cls.aidant_marge = AidantFactory(
+            first_name="Marge",
+            organisation=cls.organisation1,
+            can_create_mandats=False,
+            email="marge@simpson.com",
+        )
+        cls.aidant_marge.responsable_de.add(cls.organisation1)
+        cls.aidant_homer = AidantFactory(
+            first_name="Homer",
+            organisation=cls.organisation1,
+            can_create_mandats=True,
+            email="homer@simpson.com",
+        )
+
+    def test_add_habilitationrequest_to_manager(self):
+        self.assertEqual(0, HabilitationRequest.objects.count())
+        AidantAdmin._add_habilitationrequest_to_manager(Aidant.objects.all())
+        self.assertEqual(1, HabilitationRequest.objects.count())
+        self.assertEqual(
+            1, HabilitationRequest.objects.filter(email="marge@simpson.com").count()
+        )
+
+
+@tag("admin")
 class TestAidantWithMandatsFilter(TestCase):
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
## 🌮 Objectif

Ajouter une action d'admin "permettre à un référent de s'inscrire en formation Aidant"

## 🔍 Implémentation

- Ajout d'une action admin pour créer une Habilitation Request pour un référent. L'habilitation request n'est créée que si elle n'existe pas déjà

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
