### PR TITLE
Faire en sorte que le menu aidant ne soit pas visible par les référents qui ne sont pas aidants

### DIFF
--- a/aidants_connect_common/context_processors.py
+++ b/aidants_connect_common/context_processors.py
@@ -10,6 +10,9 @@ def settings_variables(request):
         "user_is_responsable_structure": (
             isinstance(request.user, Aidant) and request.user.is_responsable_structure
         ),
+        "user_can_create_mandats": (
+            isinstance(request.user, Aidant) and request.user.can_create_mandats
+        ),
         "testimonies_count": Testimony.objects.for_display().count(),
         "SUPPORT_EMAIL": settings.SUPPORT_EMAIL,
         "AC_CONTACT_EMAIL": settings.AC_CONTACT_EMAIL,

--- a/aidants_connect_common/templates/layouts/_header.html
+++ b/aidants_connect_common/templates/layouts/_header.html
@@ -40,6 +40,7 @@
                       Espace référent
                     </a>
                   {% endif %}
+                  {% if user_can_create_mandats %}
                   <li>
                     <a
                       class="fr-btn fr-icon-arrow-right-line"
@@ -49,6 +50,7 @@
                       Espace aidant
                     </a>
                   </li>
+                  {% endif %}
                 {% endif %}
                 <li>
                   {% if user_is_authenticated %}


### PR DESCRIPTION
## 🌮 Objectif

Faire en sorte que le menu aidant ne soit pas visible par les référents qui ne sont pas aidants

## 🔍 Implémentation

- 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
