### PR TITLE
don't send email to inactive managers

### DIFF
--- a/aidants_connect_web/models/organisation.py
+++ b/aidants_connect_web/models/organisation.py
@@ -174,6 +174,10 @@ class Organisation(models.Model):
         return self.aidants.exclude(responsable_de=self)
 
     @cached_property
+    def responsables_is_active(self) -> QuerySet:
+        return self.responsables.exclude(is_active=False)
+
+    @cached_property
     def num_usagers(self):
         return self.mandats.distinct("usager").count()
 

--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -829,7 +829,7 @@ def notifiy_organisation_having_formation_unregistered_habilitation_requests():
         send_mail(
             from_email=settings.SUPPORT_EMAIL,
             subject="Sessions de formation à Aidants Connect",
-            recipient_list=org.responsables.values_list("email", flat=True),
+            recipient_list=org.responsables_is_active.values_list("email", flat=True),
             message=text_message,
             html_message=html_message,
         )

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -985,6 +985,18 @@ class OrganisationModelTests(TestCase):
         )
         self.assertEqual({has_unregistered_hab}, set(actual))
 
+    def test_responsables_is_active(self):
+        orga = OrganisationFactory()
+        aid1 = AidantFactory()
+        aid2 = AidantFactory()
+        aid1.responsable_de.add(orga)
+        aid2.responsable_de.add(orga)
+        self.assertEqual(2, orga.responsables_is_active.count())
+        aid2.is_active = False
+        aid2.save()
+        self.assertEqual(1, orga.responsables_is_active.count())
+        self.assertFalse(aid2 in orga.responsables_is_active)
+
 
 @tag("models", "aidant")
 class AidantModelTests(TestCase):


### PR DESCRIPTION
## 🌮 Objectif

Ne pas envoyer d'email aux managers qui ne sont plus actifs

## 🔍 Implémentation

filter sur is_active

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
