### PR TITLE
Mettre un label de formulaire en français et non en anglais

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -220,6 +220,7 @@ class ReferentForm(
 
     phone = AcPhoneNumberField(
         initial="",
+        label="Téléphone",
         required=True,
     )
 


### PR DESCRIPTION
## 🌮 Objectif

Mettre un label de formulaire en français et non en anglais

## 🔍 Implémentation

- déclaration du label dans le FormField

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
