### PR TITLE
Corriger le fait que les emails envoyés aux OF soit vide

### DIFF
--- a/aidants_connect_common/tasks.py
+++ b/aidants_connect_common/tasks.py
@@ -83,27 +83,40 @@ def clean_blocklist():
     call_command("clean_blocklist")
 
 
+def get_body_email_formation_organization_new_attendants(attendants):
+    text_message, html_message = render_email(
+        "email/formation_organization_new_attendants.mjml",
+        {
+            "attendants": attendants,
+            "detail_attendants": (
+                settings.EMAIL_ORGANISATION_FORMATION_NEW_ATTENDANT_GRIST_LINK
+            ),
+        },
+    )
+    return text_message, html_message
+
+
+def get_attendants_for_organization(organization):
+    attendants = (
+        FormationAttendant.objects.filter(
+            formation__organisation=organization, organization_warned_at__isnull=True
+        )
+        .prefetch_related("formation")
+        .order_by("formation")
+    )
+    return attendants
+
+
 @shared_task
 def email_formation_organization_new_attendants():
     orgs = FormationOrganization.objects.warnable_about_new_attendants()
 
     for org in orgs:
-        attendants = (
-            FormationAttendant.objects.filter(
-                formation__organisation=org, organization_warned_at__isnull=True
-            )
-            .prefetch_related("formation")
-            .order_by("formation")
-        )
 
-        text_message, html_message = render_email(
-            "email/formation_organization_new_attendants.mjml",
-            {
-                "attendants": attendants,
-                "detail_attendants": (
-                    settings.EMAIL_ORGANISATION_FORMATION_NEW_ATTENDANT_GRIST_LINK
-                ),
-            },
+        attendants = get_attendants_for_organization(org)
+
+        text_message, html_message = (
+            get_body_email_formation_organization_new_attendants(attendants)
         )
 
         send_mail(

--- a/aidants_connect_common/templates/email/formation_organization_new_attendants.mjml
+++ b/aidants_connect_common/templates/email/formation_organization_new_attendants.mjml
@@ -12,7 +12,7 @@
           {% else %}
             <p>Les personnes suivantes ont été inscrites à une session de formation :</p>
             <ul>{% for attendant in attendants %}
-              <li>{{ attendant.target.get_full_name }}, à la session du {{ attendant.formation.start_datetime|date:"d F Y à H:i" }}</li>
+              <li>{{ attendant.attendant.get_full_name }}, à la session du {{ attendant.formation.start_datetime|date:"d F Y à H:i" }}</li>
             {% endfor %}</ul>
           {% endif %}{% endwith %}
       </mj-text>

--- a/aidants_connect_common/templates/email/formation_organization_new_attendants.txt
+++ b/aidants_connect_common/templates/email/formation_organization_new_attendants.txt
@@ -1,4 +1,4 @@
-{% load i18n ac_common %}
+{% load ac_common i18n %}
 Bonjour,
 
 {% linebreakless %}
@@ -8,7 +8,7 @@ La personne {{ attendants.0.target.get_full_name }} a été inscrite à la sessi
 Les personnes suivantes on été inscrites à une session de formation :{% keeplinebreak %}
 {% keeplinebreak %}
 {% for attendant in attendants %}
-  - {{ attendant.target.get_full_name }}, à la session du {{ attendant.formation.start_datetime|date:"d F Y à H:i" }}{% keeplinebreak %}
+  - {{ attendant.attendant.get_full_name }}, à la session du {{ attendant.formation.start_datetime|date:"d F Y à H:i" }}{% keeplinebreak %}
 {% endfor %}
 {% endif %}
 {% endwith %}

--- a/aidants_connect_common/tests/test_models.py
+++ b/aidants_connect_common/tests/test_models.py
@@ -11,6 +11,10 @@ from aidants_connect_common.models import (
     FormationOrganization,
     FormationType,
 )
+from aidants_connect_common.tasks import (
+    get_attendants_for_organization,
+    get_body_email_formation_organization_new_attendants,
+)
 from aidants_connect_common.tests.factories import (
     FormationFactory,
     FormationOrganizationFactory,
@@ -199,9 +203,22 @@ class TestFormationOrganization(TestCase):
             formation=form,
             organization_warned_at=None,
         )
+        FormationFactory(organisation=cls.org_without_attendants)
 
     def test_warnable_about_new_attendants(self):
         self.assertEqual(
             {self.org_with_not_warned_attendants},
             set(FormationOrganization.objects.warnable_about_new_attendants()),
         )
+
+    def test_get_body_email_formation_organization_new_attendants(self):
+        attendants = get_attendants_for_organization(
+            self.org_with_not_warned_attendants
+        )
+
+        text_message, html_message = (
+            get_body_email_formation_organization_new_attendants(attendants)
+        )
+        last_name = attendants.first().attendant.last_name
+        self.assertTrue(last_name in text_message)
+        self.assertTrue(last_name in html_message)


### PR DESCRIPTION
## 🌮 Objectif

Corriger le fait que les emails envoyés aux OF soit vide

## 🔍 Implémentation

-  Correction de la typo qui bloquait l'affichage des noms des apprenants 
- Ajout d'un test 

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
