### PR TITLE
Création automatique d'une habilitation request lors de la création d'une aidant request

### DIFF
--- a/aidants_connect_habilitation/forms.py
+++ b/aidants_connect_habilitation/forms.py
@@ -43,7 +43,8 @@ from aidants_connect_habilitation.models import (
     OrganisationRequest,
 )
 from aidants_connect_habilitation.presenters import ProfileCardAidantRequestPresenter2
-from aidants_connect_web.models import OrganisationType
+from aidants_connect_web.constants import ReferentRequestStatuses
+from aidants_connect_web.models import HabilitationRequest, OrganisationType
 
 
 class AddressValidatableForm(DsfrBaseForm):
@@ -415,6 +416,20 @@ class AidantRequestForm(
 
     def save(self, commit=True):
         self.instance.organisation = self.organisation
+        if self.organisation.organisation:
+            hr, _ = HabilitationRequest.objects.get_or_create(
+                email=self.instance.email,
+                organisation=self.instance.organisation.organisation,
+                defaults=dict(
+                    origin=HabilitationRequest.ORIGIN_HABILITATION,
+                    first_name=self.instance.first_name,
+                    last_name=self.instance.last_name,
+                    profession=self.instance.profession,
+                    conseiller_numerique=self.instance.conseiller_numerique,
+                    status=ReferentRequestStatuses.STATUS_PROCESSING,
+                ),
+            )
+            self.instance.habilitation_request = hr
         return super().save(commit)
 
     class Meta:

--- a/aidants_connect_habilitation/tests/test_forms.py
+++ b/aidants_connect_habilitation/tests/test_forms.py
@@ -21,7 +21,8 @@ from aidants_connect_habilitation.tests.factories import (
     OrganisationRequestFactory,
 )
 from aidants_connect_habilitation.tests.utils import get_form
-from aidants_connect_web.models import OrganisationType
+from aidants_connect_web.models import HabilitationRequest, OrganisationType
+from aidants_connect_web.tests.factories import OrganisationFactory
 
 
 class TestIssuerForm(TestCase):
@@ -395,6 +396,28 @@ class TestAidantRequestForm(TestCase):
             f"{settings.CONSEILLER_NUMERIQUE_EMAIL}"
             " le 15 novembre 2024, nous vous invitons à renseigner"
             " une autre adresse email nominative et professionnelle.",
+        )
+
+    def test_aidant_request_with_validated_organisation_create_habiliation_request(
+        self,
+    ):
+        real_organisation = OrganisationFactory(name="real Organisation")
+        organisation = OrganisationRequestFactory()
+        organisation.organisation = real_organisation
+        organisation.save()
+        form = get_form(
+            AidantRequestForm,
+            ignore_errors=True,
+            form_init_kwargs={"organisation": organisation},
+            conseiller_numerique=False,
+            email="aidant_with_hr@test.fr",
+        )
+        self.assertTrue(form.is_valid())
+        form.save()
+        self.assertTrue(
+            HabilitationRequest.objects.filter(
+                organisation=real_organisation, email="aidant_with_hr@test.fr"
+            ).exists()
         )
 
 


### PR DESCRIPTION
…abilitation Request

## 🌮 Objectif

On veut une création automatique d'une habilitation request lorsque l'on crée une aidant request pour une organisation qui a déjà été validé. 

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
