### PR TITLE
Un referent aidant n'ayant pas encore accès à son espace doit pouvoir s'inscrire en formation aidant

### DIFF
--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/validation-request-form-view.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/validation-request-form-view.html
@@ -202,11 +202,11 @@
                     Inscrit à la formation aidant du {{ formation_attendant.formation.start_datetime|date:"d/m/y" }}
                   </p>
                 {% endfor %}
-                {% if organisation.manager.aidant.last_login %}
-                  {% url "espace_responsable_organisation" as formation_url %}
-                {% else %}
-                  {% url 'habilitation_manager_formation_registration' issuer_id=organisation.issuer.issuer_id uuid=organisation.uuid as formation_url %}
-                {% endif %}
+                  {% if organisation.manager.aidant.last_login %}
+                    {% url "espace_responsable_organisation" as formation_url %}
+                  {% else %}
+                    {% url 'habilitation_manager_formation_registration' issuer_id=organisation.issuer.issuer_id uuid=organisation.uuid as formation_url %}
+                  {% endif %}
                 <p class="fr-m-0">
                   <a
                     href="{{ formation_url }}"

--- a/aidants_connect_web/admin/aidant.py
+++ b/aidants_connect_web/admin/aidant.py
@@ -24,6 +24,7 @@ from aidants_connect.admin import VisibleToAdminMetier
 from aidants_connect.utils import strtobool
 from aidants_connect_common.admin import DepartmentFilter, RegionFilter
 from aidants_connect_common.constants import JournalActionKeywords
+from aidants_connect_habilitation.models import Manager
 from aidants_connect_web.constants import OTP_APP_DEVICE_NAME
 from aidants_connect_web.forms import (
     AidantChangeForm,
@@ -517,13 +518,17 @@ class AidantAdmin(ImportExportMixin, VisibleToAdminMetier, DjangoUserAdmin):
                     email=one_manager.email
                 ).exists()
             ):
-                HabilitationRequest.objects.create(
+                hr = HabilitationRequest.objects.create(
                     organisation=one_manager.organisation,
                     first_name=one_manager.first_name,
                     last_name=one_manager.last_name,
                     email=one_manager.email,
                     profession=one_manager.profession,
                 )
+                hab_manager = Manager.objects.filter(email=one_manager.email).first()
+                if hab_manager:
+                    hab_manager.habilitation_request = hr
+                    hab_manager.save()
 
     def add_habilitationrequest_to_manager(
         self, request: HttpRequest, queryset: QuerySet

--- a/aidants_connect_web/tests/test_admin.py
+++ b/aidants_connect_web/tests/test_admin.py
@@ -7,6 +7,7 @@ from django.utils.timezone import now
 from aidants_connect_common.admin import DepartmentFilter, RegionFilter
 from aidants_connect_common.constants import AuthorizationDurations
 from aidants_connect_common.models import Region
+from aidants_connect_habilitation.models import Manager
 from aidants_connect_web.admin import (
     AidantAdmin,
     HabilitationRequestAdmin,
@@ -114,6 +115,31 @@ class TestAidantAdmin(TestCase):
         self.assertEqual(
             1, HabilitationRequest.objects.filter(email="marge@simpson.com").count()
         )
+
+    def test_add_habilitationrequest_to_manager2(self):
+        self.assertEqual(0, HabilitationRequest.objects.count())
+        for one_aidant in Aidant.objects.all():
+            Manager.objects.create(
+                address="adr",
+                zipcode="ZIP",
+                city="City",
+                is_aidant=True,
+                phone="0112121212",
+                email=one_aidant.email,
+                first_name=one_aidant.first_name,
+                last_name=one_aidant.last_name,
+            )
+
+        AidantAdmin._add_habilitationrequest_to_manager(Aidant.objects.all())
+        self.assertEqual(1, HabilitationRequest.objects.count())
+        self.assertEqual(
+            1, HabilitationRequest.objects.filter(email="marge@simpson.com").count()
+        )
+        hr = HabilitationRequest.objects.filter(email="marge@simpson.com").first()
+        self.assertEqual(
+            1, Manager.objects.filter(habilitation_request__isnull=False).count()
+        )
+        self.assertTrue(Manager.objects.filter(habilitation_request=hr))
 
 
 @tag("admin")


### PR DESCRIPTION
## 🌮 Objectif

Un referent aidant n'ayant pas encore accès à son espace doit pouvoir s'inscrire en formation aidant

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
