### PR TITLE
Changer le label du champ listant totu les utilisateurs (aidants et référents) de la page d'administration d'une structure

### DIFF
--- a/aidants_connect_web/admin/organisation.py
+++ b/aidants_connect_web/admin/organisation.py
@@ -356,7 +356,9 @@ class OrganisationAdmin(
     def display_aidants(self, obj):
         return self.format_list_of_aidants(obj.aidants.order_by("last_name").all())
 
-    display_aidants.short_description = "Aidants"
+    display_aidants.short_description = (
+        "Utilisateurs pouvant se connecter (aidants et autre)"
+    )
 
     def format_list_of_aidants(self, aidants_list):
         return mark_safe(


### PR DESCRIPTION
## 🌮 Objectif

Changer le label du champ listant totu les utilisateurs (aidants et référents) de la page d'administration d'une structure

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
