### PR TITLE
ne pas envoyer l'email d'activation pour des référents non aidant qui deviennent aidant

### DIFF
--- a/aidants_connect_web/models/other_models.py
+++ b/aidants_connect_web/models/other_models.py
@@ -147,15 +147,15 @@ class HabilitationRequest(models.Model):
             if Aidant.objects.filter(username__iexact=self.email).count() > 0:
                 aidant: Aidant = Aidant.objects.get(username__iexact=self.email)
                 aidant.organisations.add(self.organisation)
-                aidant.is_active = True
+                # aidant.is_active = True
                 aidant.referent_non_aidant = False
                 aidant.can_create_mandats = True
                 aidant.save()
                 self.status = ReferentRequestStatuses.STATUS_VALIDATED
                 self.save()
-                from aidants_connect_web.signals import aidant_activated
-
-                aidant_activated.send(self.__class__, aidant=aidant, hrequest=self)
+                # from aidants_connect_web.signals import aidant_activated
+                #
+                # aidant_activated.send(self.__class__, aidant=aidant, hrequest=self)
                 return True
 
             aidant = Aidant.objects.create(

--- a/aidants_connect_web/tests/test_models.py
+++ b/aidants_connect_web/tests/test_models.py
@@ -2140,7 +2140,7 @@ class HabilitationRequestTests(TestCase):
         aidant.refresh_from_db()
         self.assertIn(habilitation_request.organisation, aidant.organisations.all())
 
-    def test_validate_if_inactive_aidant_already_exists(self):
+    def test_do_not_validate_if_inactive_aidant_already_exists(self):
         aidant = AidantFactory(is_active=False)
         self.assertFalse(aidant.is_active)
         habilitation_request = HabilitationRequestFactory(
@@ -2157,7 +2157,7 @@ class HabilitationRequestTests(TestCase):
             ReferentRequestStatuses.STATUS_VALIDATED.value,
         )
         aidant.refresh_from_db()
-        self.assertTrue(aidant.is_active)
+        self.assertFalse(aidant.is_active)
         self.assertIn(habilitation_request.organisation, aidant.organisations.all())
 
     def test_do_not_validate_if_invalid_status(self):


### PR DESCRIPTION
## 🌮 Objectif

On ne veut pas envoyer l'email d'activation aidant pour des référents non aidant que l'on transforme en référent aidant.

## 🔍 Implémentation

- envoie de l'email d'activation aidant uniquement si l'activation génére une création d'objet Aidant en base de données

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
