### PR TITLE
Modification interface d'admin et fonctionnel du CardSending

### DIFF
--- a/aidants_connect_erp/admin.py
+++ b/aidants_connect_erp/admin.py
@@ -22,7 +22,7 @@ class CardSendingAdminForm(models.ModelForm):
         self.fields["referent"].queryset = get_bizdev_users()
 
 
-class AidantInCardSendingInlineAdmin(TabularInline):
+class AidantInCardSendingInlineAdmin(VisibleToAdminMetier, TabularInline):
     model = CardSending.aidants.through
     show_change_link = True
     can_delete = False

--- a/aidants_connect_erp/admin.py
+++ b/aidants_connect_erp/admin.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.contrib.admin import ModelAdmin
+from django.contrib.admin import ModelAdmin, TabularInline
 from django.forms import models
 
 from import_export.admin import ImportMixin
@@ -20,6 +20,34 @@ class CardSendingAdminForm(models.ModelForm):
     def __init__(self, *args, **kwargs):
         super(CardSendingAdminForm, self).__init__(*args, **kwargs)
         self.fields["referent"].queryset = get_bizdev_users()
+
+
+class AidantInCardSendingInlineAdmin(TabularInline):
+    model = CardSending.aidants.through
+    show_change_link = True
+    can_delete = False
+    extra = 0
+
+    def has_change_permission(self, request, obj):
+        return False
+
+    def first_name(self, instance):
+        return instance.aidant.first_name if instance.aidant else "-"
+
+    def last_name(self, instance):
+        return instance.aidant.last_name if instance.aidant else "-"
+
+    first_name.short_description = "Prénom"
+    last_name.short_description = "Nom de Famille"
+
+    def get_readonly_fields(self, request, obj=None):
+        return (
+            list(super().get_readonly_fields(request, obj))
+            + ["first_name"]
+            + ["last_name"]
+        )
+
+    raw_id_fields = ("aidant",)
 
 
 class CardSendingAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
@@ -45,7 +73,11 @@ class CardSendingAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         "get_sending_year",
         "command_number",
     )
-    raw_id_fields = ("organisation", "referent")
+    raw_id_fields = (
+        "organisation",
+        "referent",
+        "aidants",
+    )
     list_filter = ("status",)
 
     search_fields = (
@@ -55,7 +87,7 @@ class CardSendingAdmin(ImportMixin, VisibleToAdminMetier, ModelAdmin):
         "referent__last_name",
         "referent__email",
     )
-    raw_id_fields = ("aidants",)
+    inlines = (AidantInCardSendingInlineAdmin,)
 
 
 admin_site.register(CardSending, CardSendingAdmin)

--- a/aidants_connect_erp/signals.py
+++ b/aidants_connect_erp/signals.py
@@ -11,21 +11,21 @@ from .models import CardSending
 def update_card_sendings(
     sender, aidant: Aidant, hrequest: HabilitationRequest, **kwargs
 ):
-    if (
-        CardSending.objects.filter(
-            organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
-        ).count()
-        <= 1
-    ):
-        sending, _ = CardSending.objects.get_or_create(
-            organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
-        )
-    else:
-        sending = CardSending.objects.filter(
-            organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
-        ).first()
-
     if hrequest.connexion_mode == HabilitationRequest.CONNEXION_MODE_CARD:
+        if (
+            CardSending.objects.filter(
+                organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
+            ).count()
+            <= 1
+        ):
+            sending, _ = CardSending.objects.get_or_create(
+                organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
+            )
+        else:
+            sending = CardSending.objects.filter(
+                organisation=aidant.organisation, status=SendingStatusChoices.PREPARING
+            ).first()
+
         sending.estimated_quantity += 1
         sending.aidants.add(aidant)
         sending.save()

--- a/aidants_connect_web/admin/habilitation_request.py
+++ b/aidants_connect_web/admin/habilitation_request.py
@@ -274,15 +274,16 @@ class HabilitationRequestAdmin(ImportExportMixin, VisibleToAdminMetier, ModelAdm
     raw_id_fields = ("organisation",)
     actions = ("mark_validated", "mark_refused", "mark_processing")
     list_filter = (
-        HabilitationRequestRegionFilter,
-        HabilitationDepartmentFilter,
-        HabilitationRequestOrgaTypeFilter,
         "status",
         "origin",
+        "formation_done",
         "test_pix_passed",
         "connexion_mode",
         "course_type",
         "created_by_fne",
+        HabilitationRequestRegionFilter,
+        HabilitationDepartmentFilter,
+        HabilitationRequestOrgaTypeFilter,
     )
     search_fields = (
         "first_name",


### PR DESCRIPTION
## 🌮 Objectif

Modification des interface d'admin. Dans un cardsending on voit maintenant les aidants concernés par les cartes qui vont être envoyées.
On ne créé une instance de cardsending uniquement que si l'aidant veut une carte (on n'envoie plus les kit papier, plus besoin de créer des envoies "kit uniquement" sans cartes)

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
