### PR TITLE
1147 accessibilite composant checkbox recap mandat

### DIFF
--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -1,4 +1,3 @@
-import time
 from distutils.util import strtobool
 from random import randint
 from unittest import mock
@@ -343,7 +342,6 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.selenium.find_element(By.CSS_SELECTOR, ".fr-connect").click()
         self.wait.until(self.path_matches("new_mandat_remote_second_step"))
         self.check_accessibility("new_mandat_remote_second_step", strict=False)
-        time.sleep(1000)
 
         # # Send user consent request
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()


### PR DESCRIPTION
## 🌮 Objectif
Correction des warnings axe-core (accessibilité) sur le composant aidants_connect_web/templates/aidants_connect_web/new_mandat/_mandate-elements.html

1. Rule Violated: aria-valid-attr-value - Ensures all ARIA attributes have valid values
> URL: https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI
Impact Level: critical
Tags: cat.aria wcag2a wcag412
Elements Affected:
Target: #checkboxes-disabled-Famille\ -\ Scolarité
Invalid ARIA attribute value: aria-describedby="checkboxes-disabled-messages"
- Origine de l'erreur
> Dans le composant, on référence l’ID checkboxes-disabled-messages via l’attribut aria-describedby, mais il n’y a aucun élément HTML avec l’ID checkboxes-disabled-messages.
Règle sur aria-describedby
> Pour être valide, la valeur de aria-describedby doit référencer un ou plusieurs IDs d’éléments présents dans la même page qui fournissent une description supplémentaire.
Si l’ID n’existe pas, l’attribut est considéré comme non valide et axe-core remonte donc une erreur critique.
‌
3. Rule Violated: checkboxgroup - Ensures related <input type="checkbox"> elements have a group and that the group designation is consistent
> URL: https://dequeuniversity.com/rules/axe/3.1/checkboxgroup?application=axeAPI
Impact Level: critical
Tags: cat.forms best-practice
Elements Affected:
> Target: #checkboxes-disabled-Famille\ -\ Scolarité
All elements with the name "checkboxes-disabled" do not reference the same element with aria-labelledby
Element does not have a containing fieldset or ARIA group

- Origine de l'erreur : les cases à cocher associées (ayant généralement le même name) doivent être regroupées sémantiquement et programmatiquement
> Soit dans un `<fieldset>` avec `<legend>` qui donne un label de groupe.
> Soit dans une structure avec role="group" et un attribué aria-label ou aria-labelledby qui lie chaque checkbox à ce même label.

3. Rule Violated: label-title-only - Ensures that every form element is not solely labeled using the title or aria-describedby attributes
> URL: https://dequeuniversity.com/rules/axe/3.1/label-title-only?application=axeAPI
Impact Level: serious
Tags: cat.forms best-practice
Elements Affected:
> Target: #checkboxes-disabled-Famille\ -\ Scolarité
Only title used to generate label for form element
Target: #checkboxes-disabled-Argent\ -\ Impôts\ -\ Consommation
Only title used to generate label for form element

- Origine de l’erreur
> dans l'intégration
```
<input checked="" disabled="" ...>
<label class="fr-label" for="..."></label>
<div class="fr-text--lead fr-mb-1w"><strong>Famille - Scolarité</strong></div>
```
> Le `<label>` est vide : il ne contient pas de texte. Les technologies d’assistance ne peuvent pas associer le texte visible au checkbox, d’où la violation.

4. Rule Violated: label - Ensures every form element has a label
> URL: https://dequeuniversity.com/rules/axe/3.1/label?application=axeAPI
Impact Level: critical
Tags: cat.forms wcag2a wcag332 wcag131 section508 section508.22.n
Elements Affected:
> Target: #checkboxes-disabled-Famille\ -\ Scolarité
> aria-label attribute does not exist or is empty
aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
Form element does not have an implicit (wrapped) <label>
Form element does not have an explicit <label>
Element has no title attribute or the title attribute is empty
> Target: #checkboxes-disabled-Argent\ -\ Impôts\ -\ Consommation
aria-label attribute does not exist or is empty
aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
Form element does not have an implicit (wrapped) <label>
Form element does not have an explicit <label>
Element has no title attribute or the title attribute is empty

- Origine de l'erreur :
> Le `<input type="checkbox">` n’a pas de label associé. Le label visible (“Famille - Scolarité” ou “Argent - Impôts - Consommation”) n’est pas relié au checkbox, donc invisible pour l’accessibilité.
> Sans association programmatique, impossible pour un utilisateur de comprendre la fonction de la case à cocher (lecteur d’écran, activation vocale, navigation clavier, etc.).
> DSFR n’impose pas le label : c’est à l’intégrateur de positionner le bon texte dans le <label> ou via ARIA.

## 🔍 Implémentation
- suppression de l'attribut aria-describedby="checkboxes-disabled-messages" qui n'a pas de div avec id "checkboxes-disabled-messages" et une description correspondante
- regroupement des checkboxes dans une <div role="group" aria-label="Eléments du mandat">
- déplacement du texte {{title}} dans la balise <label>

## 🖼️ Images
Visuel légèrement modifié car les textes title et description sont eux aussi avec un format texte "disabled" (légèrement plus grisés.
<img width="773" height="292" alt="Screenshot 2025-08-14 at 11 47 12" src="https://github.com/user-attachments/assets/c7193e54-b3ba-49c1-a056-b2254eae0ae9" />
