### PR TITLE
fix accessibility checkboxgroup

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -66,7 +66,9 @@
       {% csrf_token %}
 
       <section class="demarches-section">
+        <div role="group" aria-label="Sélectionnez la ou les démarches (obligatoire)">
         {% dsfr_form_field form.demarche %}
+        </div>
       </section>
 
       {% include "aidants_connect_web/new_mandat/_bdf-warning-notification.html" %}


### PR DESCRIPTION
## 🌮 Objectif
Corriger le warning accessibilité "checkboxgroup" levé par axe-core sur les pages new_mandat et renew_mandat

- Rule Violated:
> checkboxgroup - Ensures related <input type="checkbox"> elements have a group and that the group designation is consistent
URL: [Axe Rules | Deque University | Deque Systems](https://dequeuniversity.com/rules/axe/3.1/checkboxgroup?application=axeAPI)
Impact Level: critical
Tags: cat.forms best-practice
Elements Affected:
Target: #id_demarche_papiers
All elements with the name "demarche" do not reference the same element with aria-labelledby
Element does not have a containing fieldset or ARIA group

- Origine du problème :
Les checkboxes dsfr doivent etre regroupées programmatiquement.

## 🔍 Implémentation

Ajout d'une  `<div role="group" aria-label="Sélectionnez la ou les démarches (obligatoire)">` enfant de `<section class="demarches-section">` et parent du formulaire

