### PR TITLE
1134 accessibilite fix liens evitement

### DIFF
--- a/aidants_connect_common/templates/layouts/_skip-links.html
+++ b/aidants_connect_common/templates/layouts/_skip-links.html
@@ -1,4 +1,12 @@
-<nav class="skip-links sr-only" aria-label="Accès rapide">
-  <a href="#main">Contenu principal</a>
-  <a href="#footer">Pied de page</a>
-</nav>
+<div class="fr-skiplinks">
+    <nav role="navigation" aria-label="Accès rapide" class="fr-container">
+        <ul class="fr-skiplinks__list">
+            <li>
+                <a class="fr-link" href="#main">Contenu principal</a>
+            </li>
+            <li>
+                <a class="fr-link" href="#footer">Pied de page</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/aidants_connect_common/tests/testcases.py
+++ b/aidants_connect_common/tests/testcases.py
@@ -330,7 +330,14 @@ class FunctionalTestCase(StaticLiveServerTestCase):
             re.sub(r"\s+", " ", f"{second}", flags=re.M).strip(),
         )
 
-    def check_accessibility(self, page_name="page", strict=False, options=None):
+    # on exclue le warning aria-allowed-role sur les balises nav des skips-links car
+    # role="navigation" explicitement demandé dans le composant skip link DSFR
+    def check_accessibility(
+        self,
+        page_name="page",
+        strict=False,
+        options={"exclude": [["nav[aria-label='Accès rapide']"]]},
+    ):
         """
         Check accessibility of the current page using axe-core
 


### PR DESCRIPTION
## 🌮 Objectif

Les liens d'évitement n'apparaissent pas lors de la navigation au clavier. 

## 🔍 Implémentation

Utilisation du composant [Liens d'évitement](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/liens-d-evitement/code-des-liens-d-evitement) dans aidants_connect_common/templates/layouts/_skip-links.html