### PR TITLE
1140 accessibilite header nav dialog footer

### DIFF
--- a/aidants_connect_common/templates/layouts/main.html
+++ b/aidants_connect_common/templates/layouts/main.html
@@ -83,7 +83,6 @@
       id="main-modal"
       class="fr-modal"
       aria-labelledby="fr-modal-title"
-      role="dialog"
       data-main-modal-target="dialog"
       data-action="dsfr.conceal->main-modal#onConceal"
     >

--- a/aidants_connect_common/tests/testcases.py
+++ b/aidants_connect_common/tests/testcases.py
@@ -330,7 +330,21 @@ class FunctionalTestCase(StaticLiveServerTestCase):
             re.sub(r"\s+", " ", f"{second}", flags=re.M).strip(),
         )
 
-    def check_accessibility(self, page_name="page", strict=False, options=None):
+    # Selon la doc dsfr, les composants fr-skiplinks, header, nav et footer doivent
+    # déclarer les roles. axe-core considère que c'est redondant: on privilégie le dsfr
+    def check_accessibility(
+        self,
+        page_name="page",
+        strict=False,
+        options={
+            "exclude": [
+                ["nav[aria-label='Accès rapide']"],
+                ["header[role='banner']"],
+                ["nav[role='navigation']"],
+                ["footer[role='contentinfo']"],
+            ]
+        },
+    ):
         """
         Check accessibility of the current page using axe-core
 


### PR DESCRIPTION
## 🌮 Objectif

Fixer les warnings axe-core sur les balises du layout (header, nav, dialog, footer) :

Rule Violated:
aria-allowed-role - Ensures role attribute has an appropriate value for the element
URL: https://dequeuniversity.com/rules/axe/3.1/aria-allowed-role?application=axeAPI
Impact Level: minor
Tags: cat.aria best-practice
Elements Affected:

Target: header
role banner  is not allowed for given element

Target: #navigation-494
role navigation  is not allowed for given element

Target: #footer
role contentinfo  is not allowed for given element

Faux positifs pour [header](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/en-tete/accessibilite-de-l-en-tete), [nav](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/navigation-principale/accessibilite-de-la-navigation-principale) et [footer](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/pied-de-page/accessibilite-du-pied-de-page) : le dsfr indique explicitement qu'il faut ajouter les roles dans les balises, axe-core considère que c'est redondant. 

Erreur pertinente pour la [modale](https://www.systeme-de-design.gouv.fr/version-courante/fr/composants/modale/accessibilite-de-la-modale) dsfr: il n'est pas indiqué d'ajouter le role "dialog".

## 🔍 Implémentation
- les warnings sont rendus silencieux pour les faux-positifs
- on enlève le role "dialog" redondant à la modale dsfr