### PR TITLE
fix accessibility warning skip-links

### DIFF
--- a/aidants_connect_common/templates/layouts/_header.html
+++ b/aidants_connect_common/templates/layouts/_header.html
@@ -1,5 +1,9 @@
 {% load ac_common static %}
 
+{% block skip_links %}
+  {% include 'layouts/_skip-links.html' %}
+{% endblock skip_links %}
+
 <header role="banner" class="fr-header">
   {% with view_name=request.resolver_match.view_name %}
     <div class="fr-header__body">

--- a/aidants_connect_common/templates/layouts/main.html
+++ b/aidants_connect_common/templates/layouts/main.html
@@ -58,10 +58,6 @@
 
 <body class="{% block body_class %}{% endblock %}">
 {% block nav %}
-  {% include 'layouts/_skip-links.html' %}
-{% endblock nav %}
-
-{% block header %}
   {% if request.resolver_match.view_name|startswith:"habilitation" %}
     {% comment %}
       This block is a bit weird. Habilitation is part of the public webstite so it should display the nav
@@ -74,7 +70,7 @@
   {% else %}
     {% include 'layouts/_header.html' %}
   {% endif %}
-{% endblock header %}
+{% endblock nav %}
 
 <main id="main" tabindex="-1">
   {% block content %}

--- a/aidants_connect_web/templates/aidants_connect_web/attestation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation.html
@@ -10,11 +10,19 @@
 
 {# Display navigation only on final mandate #}
 
-{% block nav %}
+{% block skip_links %}
   {% if final %}
     <nav class="skip-links sr-only" aria-label="Accès rapide">
       <a href="#main">Contenu principal</a>
     </nav>
+  {% endif %}
+{% endblock skip_links %}
+
+{% block nav %}
+  {% if final %}
+    <div class="no-print">
+      {{ block.super }}
+    </div>
   {% endif %}
 {% endblock nav %}
 

--- a/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
@@ -8,11 +8,11 @@
   <link href="{% static 'css/attestation-translation.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
-{% block nav %}
+{% block skip_links %}
   <nav class="skip-links sr-only" aria-label="Accès rapide">
     <a href="#main">Contenu principal</a>
   </nav>
-{% endblock nav %}
+{% endblock skip_links %}
 
 {% block content %}
   <div


### PR DESCRIPTION
## 🌮 Objectif

Les pages mandate_translation et new_attestation_final affichent un warning axe-core skip-link:
- Rule Violated:
> skip-link - Ensure all skip links have a focusable target
URL: https://dequeuniversity.com/rules/axe/3.1/skip-link?application=axeAPI
Impact Level: moderate
Tags: cat.keyboard best-practice
Elements Affected:
Target: a[href$="#footer"]
No skip link target

- Origine de l'erreur:
> ces pages n'ont pas de footer (c'est volontaire, elles ont vocation à être imprimées).

## 🔍 Implémentation

Override du composant skiplinks pour ces deux pages.