### PR TITLE
fix accessibility aria-valid-attr-value aria-labelledby

### DIFF
--- a/aidants_connect_common/templates/public_website/layout/_menu-legal.html
+++ b/aidants_connect_common/templates/public_website/layout/_menu-legal.html
@@ -8,6 +8,7 @@
     >Menu
     </button>
     <div class="fr-collapse" id="fr-sidemenu-wrapper">
+      <div class="fr-sidemenu__title" id="fr-sidemenu-title">Menu</div>
       <ul class="fr-sidemenu__list">
         <li class="fr-sidemenu__item{% if request.resolver_match.url_name == 'cgu' %} fr-sidemenu__item--active{% endif %}">
           <a


### PR DESCRIPTION

## 🌮 Objectif
Corriger le warning axe-core  sur la page espace aidant cgu

- aria-valid-attr-value - Ensures all ARIA attributes have valid values
>URL: [Axe Rules | Deque University | Deque Systems](https://dequeuniversity.com/rules/axe/3.1/aria-valid-attr-value?application=axeAPI)
Impact Level: critical
Tags: cat.aria wcag2a wcag412
Elements Affected:
>Target: .fr-sidemenu
>Invalid ARIA attribute value: aria-labelledby="fr-sidemenu-title"

- Origine de l'erreur
> La valeur d’un attribut ARIA comme aria-labelledby doit impérativement pointer vers un élément réel, présent dans la page, ayant le bon id.
> la div title avec id `fr-sidemenu-title` n'apparait pas dans le menu de l'espace aidant cgu (alors qu'il est présent dans les autres pages, cf. habilitation par exemple)

## 🔍 Implémentation

Ajout d'un titre "Menu" avec id `fr-sidemenu-title` dans le menu de la page espace aidant cgu (comme dans les autres pages ayant un menu latéral)

