### PR TITLE
fix accessibility duplicate-id-active page fi_select_demarche

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
+++ b/aidants_connect_web/templates/aidants_connect_web/id_provider/fi_select_demarche.html
@@ -54,7 +54,7 @@
                   </h3>
                   <p class="fr-tile__desc">{{ demarche_info.description }}
                   </p>
-                  <button id="button-demarche" value="{{ demarche }}" name="chosen_demarche" class="fr-tile__detail fr-btn fr-btn--sm" type="submit">
+                  <button id="button-demarche-{{ demarche }}" value="{{ demarche }}" name="chosen_demarche" class="fr-tile__detail fr-btn fr-btn--sm" type="submit">
 
                     Sélectionner cette démarche
                   </button>

--- a/aidants_connect_web/tests/test_functional/test_use_autorisation.py
+++ b/aidants_connect_web/tests/test_functional/test_use_autorisation.py
@@ -116,7 +116,9 @@ class UseAutorisationTests(FunctionalTestCase):
         # Select Démarche
         step2_title = self.selenium.find_element(By.CSS_SELECTOR, ".instructions").text
         self.assertIn("En sélectionnant une démarche", step2_title)
-        demarches = self.selenium.find_elements(By.ID, "button-demarche")
+        demarches = self.selenium.find_elements(
+            By.CSS_SELECTOR, "[id*='button-demarche']"
+        )
         self.assertEqual(len(demarches), 2)
         last_demarche = demarches[-1]
 


### PR DESCRIPTION
## 🌮 Objectif
Fix le warning axe-core accessibilite duplicate-id-active sur la page fi_select_demarche.
Du au fait que les id des button des cartes démarches n'ont pas d'id unique

## 🔍 Implémentation

Ajout de l'identifiant `{{demarche}}` dans l'id button

