### PR TITLE
fix accessibility page habilitation

### DIFF
--- a/aidants_connect_web/templates/public_website/habilitation.html
+++ b/aidants_connect_web/templates/public_website/habilitation.html
@@ -96,7 +96,7 @@
         <p class="fr-text-default--grey">Vous avez pris connaissance de toutes les informations concernant l’habilitation et l’inscription à Aidants Connect.<br/>
         Vous pouvez démarrer votre demande d’habilitation en suivant le bouton ci-dessous.</p>
         <div class="fr-mt-4w">
-          <button class="fr-btn"><a href="https://tally.so/r/31BYqb">Remplir une demande d'habilitation <span class="fr-icon-arrow-right-line fr-ml-1w"></span></a></button>
+          <a href="https://tally.so/r/31BYqb" class="fr-btn">Remplir une demande d'habilitation <span class="fr-icon-arrow-right-line fr-ml-1w"></span></a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 🌮 Objectif

Résoudre le warning lighthouse "touch target does not have sufficient space" sur la page /habilitation 
https://trello.com/c/qRm63GvO/1132-accessibilite-touch-target

## 🔍 Implémentation

Avant : html incorrect : `<button class="fr-button"><a href=...>...</a></button>`
Après : `<a class="fr-button" href=...>...</a>`
