### PR TITLE
1136 accessibilite heading order invalid

### DIFF
--- a/aidants_connect_common/templates/layouts/_header.html
+++ b/aidants_connect_common/templates/layouts/_header.html
@@ -1,7 +1,5 @@
 {% load ac_common static %}
 
-{% include 'layouts/_skip-links.html' %}
-
 <header role="banner" class="fr-header">
   {% with view_name=request.resolver_match.view_name %}
     <div class="fr-header__body">

--- a/aidants_connect_common/templates/layouts/_header.html
+++ b/aidants_connect_common/templates/layouts/_header.html
@@ -30,6 +30,7 @@
               <ul class="fr-btns-group">
                 {% if user_is_authenticated %}
                   {% if user_is_responsable_structure %}
+                  <li>
                     <a
                       class="fr-btn fr-icon-arrow-right-line"
                       href="{% url 'espace_responsable' %}"
@@ -37,6 +38,7 @@
                     >
                       Espace référent
                     </a>
+                  </li>
                   {% endif %}
                   {% if user_can_create_mandats %}
                   <li>

--- a/aidants_connect_common/templates/layouts/_skip-links-no-footer.html
+++ b/aidants_connect_common/templates/layouts/_skip-links-no-footer.html
@@ -1,0 +1,9 @@
+<div class="fr-skiplinks">
+    <nav role="navigation" aria-label="Accès rapide" class="fr-container">
+        <ul class="fr-skiplinks__list">
+            <li>
+                <a class="fr-link" href="#main">Contenu principal</a>
+            </li>
+        </ul>
+    </nav>
+</div>

--- a/aidants_connect_common/templates/layouts/main.html
+++ b/aidants_connect_common/templates/layouts/main.html
@@ -57,6 +57,11 @@
 </head>
 
 <body class="{% block body_class %}{% endblock %}">
+
+{% block skiplinks %}
+  {% include 'layouts/_skip-links.html' %}
+{% endblock skiplinks %}
+
 {% block nav %}
   {% if request.resolver_match.view_name|startswith:"habilitation" %}
     {% comment %}

--- a/aidants_connect_habilitation/templates/aidants_connect_habilitation/validation-request-form-view.html
+++ b/aidants_connect_habilitation/templates/aidants_connect_habilitation/validation-request-form-view.html
@@ -46,7 +46,7 @@
             <div class="fr-alert fr-alert--info fr-mb-6w">
           {% endif %}
       {% endif %}
-        <h3 class="fr-alert__title fr-mb-0">Statut : {{ organisation.status_enum.label }}</h3>
+        <h2 class="fr-alert__title fr-mb-0">Statut : {{ organisation.status_enum.label }}</h2>
         {% if organisation.status_enum.description %}
           <section>{{ organisation.status_enum.description }}</section>
         {% endif %}

--- a/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
+++ b/aidants_connect_habilitation/tests/test_functionnal/test_modify_request_form.py
@@ -43,8 +43,7 @@ class AddAidantsRequestViewTests(FunctionalTestCase):
                     status=status
                 )
                 self.__open_readonly_view_url(organisation)
-                self.check_accessibility("habilitation_organisation_view", strict=False)
-
+                self.check_accessibility("habilitation_organisation_view", strict=True)
                 self.selenium.find_element(By.CSS_SELECTOR, self.add_aidant_css).click()
 
                 self.wait.until(

--- a/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
@@ -8,6 +8,10 @@
   <link href="{% static 'css/attestation-translation.css' %}" rel="stylesheet">
 {% endblock extracss %}
 
+{% block skiplinks %}
+  {% include 'layouts/_skip-links-no-footer.html' %}
+{% endblock skiplinks %}
+
 {% block content %}
   <div
     class="fr-container"

--- a/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/attestation_translation.html
@@ -35,7 +35,7 @@
     </div>
 
     <header class="mandate-translation-row no-print">
-      <h3 class="mandate-translation-column">Version française</h3>
+      <h2 class="mandate-translation-column fr-h3">Version française</h2>
       <section class="mandate-translation-column">
         <label class="fr-h4 fr-col-6 fr-mb-0" for="mandate-translation-lang">Traduire le mandat en :</label>
         <select class="fr-select"
@@ -74,7 +74,7 @@
       <div class="fr-mt-6w empty-translation-container">
         <div class="fr-background-alt--grey fr-p-4w fr-text--center">
           <span class="fr-icon-translate-2 fr-text-title--blue-france fr-icon--lg"></span>
-          <h4>D’autres langues sont disponibles</h4>
+          <h3 class="fr-h4">D’autres langues sont disponibles</h3>
           <p>
             Retrouvez ici le mandat type en version traduite.
             Sélectionnez une langue dans la liste déroulante ci-dessus.

--- a/aidants_connect_web/templates/aidants_connect_web/common/resources-block.html
+++ b/aidants_connect_web/templates/aidants_connect_web/common/resources-block.html
@@ -59,15 +59,14 @@
             </p>
             <ul class="fr-btns-group fr-btns-group--inline-lg fr-col-12 fr-mt-2w flex-right">
               <li>
-                <button class="fr-btn fr-btn--secondary fr-text--sm">
-                  <a
-                    href="https://www.etsijaccompagnais.fr/ressources-des-aidants"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Version française
-                  </a>
-                </button>
+                <a
+                  href="https://www.etsijaccompagnais.fr/ressources-des-aidants"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="fr-btn fr-btn--secondary fr-text--sm"
+                >
+                  Version française
+                </a>
               </li>
               <li>
                 <details class="fr-btn fr-btn--secondary fr-text--sm fr-mr-0">

--- a/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
+++ b/aidants_connect_web/templates/aidants_connect_web/new_mandat/new_mandat.html
@@ -78,7 +78,7 @@
           {% dsfr_form_field form.duree %}
          </div>
 
-        <h4 class="fr-h6 fr-mt-2w">Signature à distance</h4>
+        <h3 class="fr-h6 fr-mt-2w">Signature à distance</h3>
 
         <fieldset class="is-remote-section fr-fieldset">
           <section class="fr-checkbox-group">

--- a/aidants_connect_web/templates/login/email_sent.html
+++ b/aidants_connect_web/templates/login/email_sent.html
@@ -12,7 +12,7 @@
         <p class="fr-text--xl fr-mb-16v">Un email vous a été envoyé pour vous connecter.</p>
 
         <div class="fr-alert fr-alert--info">
-          <h3 class="fr-alert__title fr-m-0">Vous n’avez pas reçu votre email de connexion ?</h3>
+          <h2 class="fr-alert__title fr-m-0">Vous n’avez pas reçu votre email de connexion ?</h2>
           <p><a href="{% url 'magicauth-login' %}" class="fr-link">Cliquez ici</a> pour réessayer de vous connecter.</p>
         </div>
       </div>

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -25,10 +25,10 @@
                   id="login-1760-fieldset"
                   aria-labelledby="login-1760-fieldset-legend"
                 >
-                  <div class="flex width-100">
+                  <legend class="flex width-100 fr-h1 fr-m-0 fr-p-0" id="login-1760-fieldset-legend">
                     <h1 class="fr-m-0 fr-p-0">Connectez-vous</h1>
                     <div class="spacer"></div>
-                  </div>
+                  </legend>
 
                   <div class="fr-fieldset__element fr-my-6v">
                     <fieldset class="fr-fieldset fr-my-0" id="credentials">

--- a/aidants_connect_web/templates/login/login.html
+++ b/aidants_connect_web/templates/login/login.html
@@ -62,7 +62,7 @@
 
                 <div class="flex width-100">
 
-                    <h4 class="fr-m-0 fr-p-0 fr-mt-3w">Première connexion référent</h4  >
+                    <h2 class="fr-h4 fr-m-0 fr-p-0 fr-mt-3w">Première connexion référent</h2  >
                     <div class="spacer"></div>
                 </div>
 

--- a/aidants_connect_web/templates/public_website/formation.html
+++ b/aidants_connect_web/templates/public_website/formation.html
@@ -28,7 +28,7 @@
     Si ma structure n’est pas encore habilitée, l’inscription se fait suite à la <a class="fr-link" href="{% url 'habilitation_new' %}">demande d’habilitation</a> de la structure. Après vérification de l’éligibilité par Aidants Connect, un mail est envoyé au demandeur et au référent avec un lien vers le formulaire d’inscription aux sessions.</p>
     <p>Si ma structure est déjà habilitée, le référent peut ajouter des aidants depuis son <a class="fr-link" href="{% url 'espace_responsable_organisation' %}">espace référent</a> et les inscrire à une session après vérification de l’éligibilité par Aidants Connect.
   </p>
-  <h4>Les formations à Aidants Connect</h4>
+  <h2 class="fr-h4 fr-mb-3w">Les formations à Aidants Connect</h2>
   <div class="fr-tabs right-grey-background">
     <ul class="fr-tabs__list" role="tablist" aria-label="formations_tabs">
       <li role="presentation">
@@ -55,7 +55,7 @@
             <li>Comprendre les enjeux liés à la manipulation de données personnelles d'usagers</li>
             <li>Connaître le cadre réglementaire de la fonction d'aidant numérique</li>
           </ul>
-          <h5 class="fr-mt-4w">Méthodes pédagogiques</h5>
+          <h3 class="fr-h5">Méthodes pédagogiques</h3>
           <ul class="fr-pl-3w">
             <li>Mises en situation</li>
             <li>Réflexion sur les problématiques rencontrées</li>

--- a/aidants_connect_web/tests/test_functional/test_create_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_create_mandat.py
@@ -54,7 +54,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.selenium.find_element(By.ID, "add_usager").click()
         self.wait.until(self.path_matches("new_mandat"))
 
-        self.check_accessibility("new_mandat", strict=False)
+        self.check_accessibility("new_mandat", strict=True)
 
         # Check accessibility of the form page
         demarches_section = self.selenium.find_element(
@@ -80,7 +80,6 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.wait.until(url_matches(r"https://.+franceconnect\.fr/api/v1/authorize.+"))
         fc_title = self.selenium.title
         self.assertEqual("Connexion - choix du compte", fc_title)
-        self.check_accessibility("fc_authorize", strict=False)
 
         # Click on the 'Démonstration' identity provider
         demonstration_hex = self.selenium.find_element(
@@ -88,7 +87,6 @@ class CreateNewMandatTests(FunctionalTestCase):
         )
         demonstration_hex.click()
         self.wait.until(url_matches(r"https://.+franceconnect\.fr/interaction/.+"))
-        self.check_accessibility("fc_callback", strict=False)
 
         # FC - Use the Mélaine_trois credentials
         demo_title = self.selenium.find_element(By.TAG_NAME, "h3").text
@@ -112,7 +110,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.assertIn("Angela Claire Louise DUBOIS ", recap_text)
         checkboxes = self.selenium.find_elements(By.TAG_NAME, "input")
 
-        self.check_accessibility("logout_callback", strict=False)
+        self.check_accessibility("logout_callback", strict=True)
 
         self.selenium.find_element(By.CSS_SELECTOR, "#id_personal_data ~ label").click()
         id_otp_token = checkboxes[-2]
@@ -134,10 +132,10 @@ class CreateNewMandatTests(FunctionalTestCase):
         mandat_qs = Mandat.objects.filter(organisation=self.aidant.organisation)
         self.assertEqual(1, mandat_qs.count())
         self.assertEqual(2, mandat_qs[0].autorisations.count())
-        self.check_accessibility("new_attestation_final", strict=False)
+        self.check_accessibility("new_attestation_final", strict=True)
 
         self.open_live_url("/usagers/")
-        self.check_accessibility("usagers", strict=False)
+        self.check_accessibility("usagers", strict=True)
 
     def test_create_new_remote_mandat_with_legacy_consent(self):
         self.open_live_url("/usagers/")
@@ -341,7 +339,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         # # Send recap mandate and go to second step
         self.selenium.find_element(By.CSS_SELECTOR, ".fr-connect").click()
         self.wait.until(self.path_matches("new_mandat_remote_second_step"))
-        self.check_accessibility("new_mandat_remote_second_step", strict=False)
+        self.check_accessibility("new_mandat_remote_second_step", strict=True)
 
         # # Send user consent request
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
@@ -365,7 +363,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.open_live_url(reverse("new_mandat_recap"))
 
         self.wait.until(self.path_matches("new_mandat_waiting_room"))
-        self.check_accessibility("new_mandat_waiting_room", strict=False)
+        self.check_accessibility("new_mandat_waiting_room", strict=True)
 
         # Simulate user content
         self._user_consents("0 800 840 800")
@@ -410,7 +408,7 @@ class CreateNewMandatTests(FunctionalTestCase):
         self.wait.until(
             self.path_matches("logout_callback", query_params={"state": ".+"})
         )
-        self.check_accessibility("logout_callback", strict=False)
+        self.check_accessibility("logout_callback", strict=True)
 
         # Recap all the information for the Mandat
         recap_title = self.selenium.find_element(By.TAG_NAME, "h1").text

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -29,7 +29,7 @@ class CancelAutorisationTests(FunctionalTestCase):
         email_sent_title = self.selenium.find_element(By.TAG_NAME, "h1").text
         self.assertEqual("Confirmation de connexion", email_sent_title)
         self.assertEqual(len(mail.outbox), 1)
-        self.check_accessibility("confirmation_connexion", strict=False)
+        self.check_accessibility("confirmation_connexion", strict=True)
         url = re.findall(r"https?://\S+", mail.outbox[0].body, flags=re.M)[0].replace(
             "https", "http", 1
         )

--- a/aidants_connect_web/tests/test_functional/test_login.py
+++ b/aidants_connect_web/tests/test_functional/test_login.py
@@ -20,6 +20,7 @@ class CancelAutorisationTests(FunctionalTestCase):
 
     def test_aidant_can_login(self):
         self.open_live_url("/accounts/login/")
+        self.check_accessibility("login", strict=True)
         login_field = self.selenium.find_element(By.ID, "id_email")
         login_field.send_keys(self.aidant_thierry.email)
         otp_field = self.selenium.find_element(By.ID, "id_otp_token")

--- a/aidants_connect_web/tests/test_functional/test_renew_mandat.py
+++ b/aidants_connect_web/tests/test_functional/test_renew_mandat.py
@@ -52,7 +52,7 @@ class RenewMandatTests(FunctionalTestCase):
 
         self.login_aidant(self.aidant)
 
-        self.check_accessibility("renew_mandat", strict=False)
+        self.check_accessibility("renew_mandat", strict=True)
 
         demarches_section = self.selenium.find_element(
             By.CSS_SELECTOR, ".demarches-section"
@@ -268,13 +268,13 @@ class RenewMandatTests(FunctionalTestCase):
         self.selenium.find_element(By.ID, "submit_renew_button").click()
         self.wait.until(self.path_matches("renew_remote_second_step"))
 
-        self.check_accessibility("renew_remote_second_step", strict=False)
+        self.check_accessibility("renew_remote_second_step", strict=True)
 
         # # Send user consent request
         self.selenium.find_element(By.CSS_SELECTOR, '[type="submit"]').click()
         self.wait.until(self.path_matches("renew_mandat_waiting_room"))
 
-        self.check_accessibility("renew_mandat_waiting_room", strict=False)
+        self.check_accessibility("renew_mandat_waiting_room", strict=True)
 
         # # Test the message is correctly logged
         consent_request_log: Journal = Journal.objects.find_sms_consent_requests(

--- a/aidants_connect_web/tests/test_functional/test_translation.py
+++ b/aidants_connect_web/tests/test_functional/test_translation.py
@@ -37,7 +37,7 @@ class DisplayTranslationTests(FunctionalTestCase):
         time.sleep(2)
 
         self.wait.until(self.path_matches("mandate_translation"))
-        self.check_accessibility("mandate_translation", strict=False)
+        self.check_accessibility("mandate_translation", strict=True)
 
         self.wait.until(
             expected_conditions.text_to_be_present_in_element(

--- a/aidants_connect_web/tests/test_functional/test_validate_cgu.py
+++ b/aidants_connect_web/tests/test_functional/test_validate_cgu.py
@@ -25,14 +25,14 @@ class ValidateCGUTests(FunctionalTestCase):
         self.login_aidant(self.aidant)
 
         self.assertIsNone(self.aidant.validated_cgu_version)
-        self.check_accessibility("espace_aidant_cgu", strict=False)
+        self.check_accessibility("espace_aidant_cgu", strict=True)
 
         # Espace Aidant home
         self.selenium.find_element(By.CSS_SELECTOR, 'label[for="id_agree"]').click()
         self.selenium.find_element(By.CSS_SELECTOR, 'button[type="submit"]').click()
 
         self.wait.until(self.path_matches("espace_aidant_home"))
-        self.check_accessibility("espace_aidant_home", strict=False)
+        self.check_accessibility("espace_aidant_home", strict=True)
 
         el = self.selenium.find_element(
             By.XPATH, "//*[contains(@class, 'fr-alert') and contains(., 'CGU')]"

--- a/aidants_connect_web/views/espace_aidant.py
+++ b/aidants_connect_web/views/espace_aidant.py
@@ -54,7 +54,7 @@ class Home(TemplateView):
 
         common_infos = {
             "extra_classes": "fr-tile--horizontal fr-tile--sm",
-            "heading_tag": self.tiles_heading_tag,
+            "heading_tag": "h2",
         }
 
         return [


### PR DESCRIPTION
## 🌮 Objectif

Fix warnings accessibilité levés par axe-core sur l'ordre des heading (il est préférable d'éviter les saut de hiérarchie, même si c'est toléré depuis RGAA 4.1) : [ticket](https://trello.com/c/humbZ2DY/1136-accessibilite-heading-order-invalid
).

## 🔍 Implémentation

Remplace les balises h{x} par celles attendues si pas de saut de hiérarchie, en conservant le style (grâce à la classe dsfr fr-h{x}).

## 🏕 Amélioration continue

Correction d'autres warnings axe-core / lighthouse sur les pages croisées :

- page login aria-valid-attr-value : la propriété `aria-labelledby="login-1760-fieldset-legend"` n'avait pas de balise html avec `id="login-1760-fieldset-legend"` correspondant. Ajout d'une balise `<legend class="flex width-100 fr-h1 fr-m-0 fr-p-0" id="login-1760-fieldset-legend">`
- page mandate_translation : les skip-links faisaient référence au footer alors que la page n'en a pas. Erreur repérée par lighthouse mais pas axe-core. Correction apportée : restructuration de `main.html` et `_header.html`, ajout d'un block `skiplinks` qui peut être facilement personnalisable dans les pages. Personnalisation dans la page `mandate_translation` avec `_skip-links-no-footer.html`.
- page espace_aidant_home insufficient touch target : repéré par lighthouse (pas axe-core) : encore une `<a>`dans un `<button>`: suppression de `<button>` et ajout de la classe `fr-btn`dsfr pour conserver le style.
- page espace_aidant_home ul does not contains only li elements : il manquait une balise <li> autour du lien `espace_referent`
