### PR TITLE
Ne pas envoyer d'email inscription en formation aux managers FNE

### DIFF
--- a/aidants_connect_web/tasks.py
+++ b/aidants_connect_web/tasks.py
@@ -826,13 +826,16 @@ def notifiy_organisation_having_formation_unregistered_habilitation_requests():
             },
         )
 
-        send_mail(
-            from_email=settings.SUPPORT_EMAIL,
-            subject="Sessions de formation à Aidants Connect",
-            recipient_list=org.responsables_is_active.values_list("email", flat=True),
-            message=text_message,
-            html_message=html_message,
-        )
+        if org.responsables_is_active.filter(created_by_fne=False).exists():
+            send_mail(
+                from_email=settings.SUPPORT_EMAIL,
+                subject="Sessions de formation à Aidants Connect",
+                recipient_list=org.responsables_is_active.filter(
+                    created_by_fne=False
+                ).values_list("email", flat=True),
+                message=text_message,
+                html_message=html_message,
+            )
 
 
 @shared_task


### PR DESCRIPTION
## 🌮 Objectif

Ne pas envoyer d'email inscription en formation aux managers FNE

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
