### PR TITLE
Ajout d'un timer pour eviter qu'un tests echoue aleatoirement

### DIFF
--- a/aidants_connect_web/tests/test_functional/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_functional/test_espace_responsable.py
@@ -1,4 +1,5 @@
 import itertools
+import time
 
 from django.template.defaultfilters import yesno
 from django.test import tag
@@ -892,8 +893,10 @@ class NewHabilitationRequestTests(FunctionalTestCase):
         self.selenium.find_element(
             By.CSS_SELECTOR, '#empty-form input[id$="email"]'
         ).send_keys(req1.email)
+        time.sleep(2)
 
         self._try_open_modal(By.ID, "edit-button-0")
+        time.sleep(2)
 
         actual = self.selenium.execute_script(
             "return arguments[0].value",


### PR DESCRIPTION
## 🌮 Objectif

Ajout d'un timer pour eviter qu'un tests echoue aleatoirement

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
