### PR TITLE
accessibility - plan du site

### DIFF
--- a/aidants_connect_common/templates/layouts/_footer.html
+++ b/aidants_connect_common/templates/layouts/_footer.html
@@ -97,6 +97,9 @@
     <div class="fr-footer__bottom">
       <ul class="fr-footer__bottom-list">
         <li class="fr-footer__bottom-item">
+          <a class="fr-footer__bottom-link" href="/plan-du-site">Plan du site</a>
+        </li>
+        <li class="fr-footer__bottom-item">
           <a class="fr-footer__bottom-link" href="/cgu">Conditions générales d'utilisation</a>
         </li>
         <li class="fr-footer__bottom-item">
@@ -106,7 +109,7 @@
           <a class="fr-footer__bottom-link" href="/mentions-legales">Mentions légales</a>
         </li>
         <li class="fr-footer__bottom-item">
-          <a class="fr-footer__bottom-link" href="/faq">Foire aux questions</a>
+          <a class="fr-footer__bottom-link" href="/faq">Aide</a>
         </li>
         <li class="fr-footer__bottom-item">
           <a class="fr-footer__bottom-link" href="/stats">Statistiques</a>

--- a/aidants_connect_common/templates/public_website/layout/_menu-legal.html
+++ b/aidants_connect_common/templates/public_website/layout/_menu-legal.html
@@ -55,6 +55,15 @@
             >Budget</a
           >
         </li>
+        <li class="fr-sidemenu__item{% if request.resolver_match.url_name == 'budget' %} fr-sidemenu__item--active{% endif %}">
+          <a
+            class="fr-sidemenu__link"
+            target="_self"
+            href="{% url 'sitemap' %}"
+            {% if request.resolver_match.url_name == 'sitemap' %}aria-current="page"{% endif %}
+            >Plan du site</a
+          >
+        </li>
       </ul>
     </div>
   </div>

--- a/aidants_connect_web/templates/layouts/footer.html
+++ b/aidants_connect_web/templates/layouts/footer.html
@@ -21,7 +21,7 @@
       <ul class="footer__links">
         <li><a href="/cgu">Conditions d’utilisation</a></li>
         <li><a href="/mentions-legales">Mentions légales</a></li>
-        <li><a href="/faq">Foire aux questions</a></li>
+        <li><a href="/faq">Aide</a></li>
         <li><a href="/stats">Statistiques</a></li>
         <li><a href="/budget">Budget</a></li>
         <li><a href="/accessibilite">Accessibilité</a> (non conforme)</li>

--- a/aidants_connect_web/templates/public_website/plan_site.html
+++ b/aidants_connect_web/templates/public_website/plan_site.html
@@ -1,0 +1,58 @@
+{% extends 'layouts/main.html' %}
+
+{% load ac_common static %}
+
+{% block title %}Plan du site - Aidants Connect{% endblock %}
+
+{% block extracss %}
+<link href="{% static 'css/dashboard.css' %}" rel="stylesheet">
+{% endblock extracss %}
+
+{% block content %}
+<section class="section">
+  <div class="fr-container">
+    <h1 class="fr-mb-4w">Plan du site</h1>
+
+    <ul class="fr-mb-4w">
+      <li><a href="{% url 'home_page' %}" class="fr-link">Accueil</a></li>
+      <li>Habilitation et formation :</li>
+      <ul class="fr-ml-2w">
+        <li><a href="{% url 'habilitation_faq_habilitation' %}" class="fr-link">Habilitation</a></li>
+        <li><a href="{% url 'habilitation_faq_formation' %}" class="fr-link">Formation</a></li>
+        <li><a href="{% url 'habilitation_new' %}" class="fr-link">Nouvelle demande d'habilitation</a></li>
+      </ul>
+      <li><a href="{% url 'temoignages' %}" class="fr-link">Témoignages</a></li>
+      <li><a href="{% url 'ressources' %}" class="fr-link">Ressources</a></li>
+      <li><a href="{% url 'statistiques' %}" class="fr-link">Statistiques</a></li>
+      <li><a href="{% url 'faq_generale' %}" class="fr-link">Aide</a></li>
+      <li><a href="{% url 'sandbox_presentation' %}" class="fr-link">Site bac à sable</a></li>
+      <li><a href="{% url 'guide_utilisation' %}" class="fr-link">Guide d'utilisation</a></li>
+    </ul>
+
+    {% if user.is_authenticated and user.can_create_mandats %}
+    <ul class="fr-mb-4w">
+      <li>Espace aidant :</li>
+      <ul class="fr-ml-2w">
+        <li><a href="{% url 'espace_aidant_home' %}" class="fr-link">Accueil</a></li>
+        <li><a href="{% url 'usagers' %}" class="fr-link">Mandats</a></li>
+        <li><a href="{% url 'new_mandat' %}" class="fr-link">Créer un mandat</a></li>
+      </ul>
+    </ul>
+    {% endif %}
+
+    {% if user.is_authenticated and user.is_responsable_structure %}
+    <ul class="fr-mb-4w">
+      <li>Espace référent :</li>
+      <ul class="fr-ml-2w">
+        <li><a href="{% url 'espace_responsable' %}" class="fr-link">Accueil</a></li>
+        <li><a href="{% url 'espace_responsable_aidants' %}" class="fr-link">Aidants</a></li>
+        <li><a href="{% url 'espace_responsable_referents' %}" class="fr-link">Référents</a></li>
+        <li><a href="{% url 'espace_responsable_demandes' %}" class="fr-link">Demandes en cours</a></li>
+        <li><a href="{% url 'espace_responsable_organisation' %}" class="fr-link">Mon organisation</a></li>
+      </ul>
+    </ul>
+    {% endif %}
+
+  </div>
+</section>
+{% endblock content %}

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -342,6 +342,7 @@ urlpatterns = [
         formations.FormationsListing.as_view(),
         name="listing_formations",
     ),
+    path("plan-du-site/", service.SitemapView.as_view(), name="sitemap"),
 ]
 
 urlpatterns.extend(magicauth_urls)

--- a/aidants_connect_web/views/service.py
+++ b/aidants_connect_web/views/service.py
@@ -203,6 +203,10 @@ def budget(request):
     return render(request, "public_website/budget.html")
 
 
+class SitemapView(TemplateView):
+    template_name = "public_website/plan_site.html"
+
+
 class AccessibiliteView(TemplateView):
     template_name = "public_website/accessibilite.html"
 


### PR DESCRIPTION
## 🌮 Objectif

Accessibilité => ajouter un plan du site (cf. [ticket](https://trello.com/c/o9oujWhn/1165-footer))

## 🔍 Implémentation

Un plan pour chaque partie : publique / espace aidant / espace référent, qui s'affiche conditionnement aux droits du user (pas loggé, loggé aidant, loggé référent, loggé référent-aidant)

Les liens des navigations secondaires sont montrées (comme dans https://www.service-public.fr/P10003)

## 🏕 Amélioration continue

Ajout des pages bac à sable et guide dans le plan site publique

## ⚠️ Informations supplémentaires

Si les navigations secondaires sont fausses (par exemple Site bac à sable, Ressources, Aide dans espace aidant), les liens présentés dans le plan du site sont correct (site bac à sable, Ressources  et Aide ne sont affichés que dans la partie site public, pas espace aidant).
A revoir si les navigations secondaires ne sont pas seulement corrigées mais modifiées

## 🖼️ Images

<img width="1217" height="786" alt="Screenshot 2025-09-11 at 18 55 15" src="https://github.com/user-attachments/assets/1dd7860a-b3da-445b-8005-fa7ea3a762b7" />
