### PR TITLE
Met à jour l’en-tête et le pied de page pour indiquer clairement qu’Aidants Connect s’adresse aux professionnels

### DIFF
--- a/aidants_connect_common/templates/layouts/_footer.html
+++ b/aidants_connect_common/templates/layouts/_footer.html
@@ -17,7 +17,7 @@
       </div>
       <div class="fr-footer__content">
         <p class="fr-footer__content-desc">
-          Aidants Connect est une plateforme visant à sécuriser l’accompagnement aux démarches administratives en ligne.
+          Aidants Connect est une plateforme visant à sécuriser l’accompagnement aux démarches administratives en ligne pour les professionnels.
         </p>
         <ul class="fr-footer__content-list">
           <li class="fr-footer__content-item">

--- a/aidants_connect_common/templates/layouts/_header.html
+++ b/aidants_connect_common/templates/layouts/_header.html
@@ -23,6 +23,7 @@
               <a href="{% url 'home_page' %}" title="Accueil Aidants Connect">
                 <img width="100" src="{% static 'images/aidants-connect_logo.png' %}" alt="Aidants Connect" />
               </a>
+              <p class="fr-header__service-tagline">Sécuriser les professionnels dans l'accompagnement aux démarches</p>
             </div>
           </div>
           <div class="fr-header__tools">


### PR DESCRIPTION
## 🌮 Objectif

 Indiquer clairement qu’Aidants Connect s’adresse aux professionnels

## 🔍 Implémentation

- ajout du "slogan" dans l'entête
- mise à jour de la phrase du pied de page

## 🖼️ Images

<img width="1548" height="467" alt="image" src="https://github.com/user-attachments/assets/d9b5354d-6a17-472f-9bbb-b966677b4465" />

<img width="1548" height="467" alt="image" src="https://github.com/user-attachments/assets/808538da-f0cc-4ff9-95cc-cdad6ff696f0" />
