### PR TITLE
Ajouter d'un bouton pour les référents pour télécharger l'attestation de formation des aidants

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
@@ -6,92 +6,94 @@
 
 {% block content %}
   <div class="fr-container">
-
-    <div class="fr-grid-row flex-between" >
+    <div class="fr-grid-row flex-between">
       <h1>{{ aidant.get_full_name }}</h1>
-
       <div>
         <div class="fr-btns-group fr-btns-group--inline fr-btns-group--md fr-btns-group--icon-left">
-        {% if aidant.can_create_mandats %}
-          <a
-            href="{% url 'espace_responsable_aidant_formation_attestation' aidant_id=aidant.id %}"
-            class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left"
-            id="download-formation-attestation-{{ aidant.id }}"
-          >
-            Télécharger l'attestation de formation
-          </a>
-        {% endif %}
-        {% if aidant.is_active and not is_aidant_referent_of_current_org %}
-          <form method="post" action="{% url 'espace_responsable_aidants' %}">
-            {% csrf_token %}
-            <input type="hidden" name="candidate" value="{{ aidant.pk }}">
-            <button type="submit" class="fr-btn fr-btn--secondary">
-              Désigner comme référent
-            </button>
-          </form>
-        {% endif %}
+          {% if aidant.can_create_mandats %}
+            <a
+              href="{% url 'espace_responsable_aidant_formation_attestation' aidant_id=aidant.id %}"
+              class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left"
+              id="download-formation-attestation-{{ aidant.id }}"
+            >
+              Télécharger l'attestation de formation
+            </a>
+          {% endif %}
+          {% if aidant.is_active and not is_aidant_referent_of_current_org %}
+            <form method="post" action="{% url 'espace_responsable_aidants' %}">
+              {% csrf_token %}
+              <input type="hidden" name="candidate" value="{{ aidant.pk }}">
+              <button type="submit" class="fr-btn fr-btn--secondary">
+                Désigner comme référent
+              </button>
+            </form>
+          {% endif %}
 
-        {% if aidant.is_active and aidant != responsable %}
-          <a href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
+          {% if aidant.is_active and aidant != responsable %}
+            <a
+              href="{% url 'espace_responsable_remove_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
               class="fr-btn fr-btn--secondary"
-              id="remove-aidant-{{ aidant.id }}-from-organisation">
-          Désactiver
-          </a>
-        {% elif not aidant.is_active and aidant != responsable %}
-          <a href="{% url 'espace_responsable_reactivate_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
+              id="remove-aidant-{{ aidant.id }}-from-organisation"
+            >
+              Désactiver
+            </a>
+          {% elif not aidant.is_active and aidant != responsable %}
+            <a
+              href="{% url 'espace_responsable_reactivate_aidant_from_organisation' aidant_id=aidant.id organisation_id=organisation.id %}"
               class="fr-btn fr-btn--secondary"
-              id="reactivate-aidant-{{ aidant.id }}-from-organisation">
-          Réactiver
-          </a>
-        {% endif %}
+              id="reactivate-aidant-{{ aidant.id }}-from-organisation"
+            >
+              Réactiver
+            </a>
+          {% endif %}
         </div>
       </div>
     </div>
 
     {% dsfr_django_messages %}
     <div class="fr-col-12 fr-col-md-8">
-
-    <section class="fr-mt-8v">
-      <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-user-line">
-        Informations
-      </h2>
-      <div class="fr-card">
-        <div class="fr-card__body">
-          <div class="fr-card__content ">
-            <div class="fr-grid-row fr-grid-row--gutters">
-              <div class="fr-col-12 fr-col-md-6">
-                <h3 class="fr-h6">Profession</h3>
-                <p class="fr-text">
-                  {{ aidant.profession }}
-                </p>
-              </div>
-              <div class="fr-col-12 fr-col-md-6">
-                <h3 class="fr-h6">Adresse e-mail</h3>
-                <p class="fr-text">{{ aidant.email }}</p>
+      <section class="fr-mt-8v">
+        <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-user-line">
+          Informations
+        </h2>
+        <div class="fr-card">
+          <div class="fr-card__body">
+            <div class="fr-card__content">
+              <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-md-6">
+                  <h3 class="fr-h6">Profession</h3>
+                  <p class="fr-text">
+                    {{ aidant.profession }}
+                  </p>
+                </div>
+                <div class="fr-col-12 fr-col-md-6">
+                  <h3 class="fr-h6">Adresse e-mail</h3>
+                  <p class="fr-text">{{ aidant.email }}</p>
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
         <div class="fr-card fr-mt-2w">
           <div class="fr-card__body">
             <div class="fr-card__content">
-                <h3 class="fr-h6">
-                  Organisation{% if common_organisations|length > 1 %}s{% endif %}
-                </h3>
-                {% for org in common_organisations %}
-                  <p class="fr-text">{{ org.name }}
-                      {% if aidant in org.responsables.all %}
-                        {% if aidant.referent_non_aidant %}
-                          <span id="badge-referent" class="fr-badge fr-badge--purple-glycine fr-ml-2v">REFERENT</span>
-                        {% else %}
-                          <span id="badge-referent-aidant" class="fr-badge fr-badge--no-icon fr-badge--info fr-ml-2v">REFERENT-AIDANT</span>
-                        {% endif %}
-                      {% endif %}
-                  </p>
-                {% endfor %}
-                {% if referent_orgs|length > 1 %}
-                 <button
+              <h3 class="fr-h6">
+                Organisation{% if common_organisations|length > 1 %}s{% endif %}
+              </h3>
+              {% for org in common_organisations %}
+                <p class="fr-text">
+                  {{ org.name }}
+                  {% if aidant in org.responsables.all %}
+                    {% if aidant.referent_non_aidant %}
+                      <span id="badge-referent" class="fr-badge fr-badge--purple-glycine fr-ml-2v">REFERENT</span>
+                    {% else %}
+                      <span id="badge-referent-aidant" class="fr-badge fr-badge--no-icon fr-badge--info fr-ml-2v">REFERENT-AIDANT</span>
+                    {% endif %}
+                  {% endif %}
+                </p>
+              {% endfor %}
+              {% if referent_orgs|length > 1 %}
+                <button
                   class="fr-btn fr-btn--secondary"
                   data-fr-opened="false"
                   aria-controls="modal-change-organisations-{{ aidant.id }}"
@@ -99,140 +101,144 @@
                 >
                   Modifier l'organisation
                 </button>
-                {% endif %}
+              {% endif %}
             </div>
           </div>
         </div>
-      {% include "aidants_connect_web/espace_responsable/_modale_change_aidant_organisations.html" %}
-    </section>
+        {% include "aidants_connect_web/espace_responsable/_modale_change_aidant_organisations.html" %}
+      </section>
 
-    {% if formation.info_available %}
+      {% if formation.info_available %}
+        <section class="fr-mt-8v">
+          <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-book-2-line">
+            Formation
+          </h2>
+          <div class="fr-card fr-mt-2w">
+            <div class="fr-card__body">
+              <div class="fr-card__content">
+                {% if formation.status.value == "formation_attendance" %}
+                  {% if formation.type.value == "p2p" %}
+                    <p class="fr-text">Inscrit à une formation pair à pair</p>
+                  {% elif formation.type.value == "fne" %}
+                    <p class="fr-text">Inscrit à une formation FNE</p>
+                  {% else %}
+                    <p class="fr-text">
+                      Inscrit à la formation du {{ formation.date_formation }}
+                      par {{ formation.organisation_name }}
+                    </p>
+                    <div class="fr-alert fr-alert--info">
+                      <p class="fr-text">
+                        Information : si vous souhaitez modifier ou annuler l'inscription, rapprochez-vous de l'organisme en charge de la formation :
+                        <a class="fr-link" href="mailto:{{ formation_attendant.formation.organisation_email }}">
+                          {{ formation.organisation_email }}
+                        </a>
+                      </p>
+                    </div>
+                  {% endif %}
+                {% elif formation.status.value == "formation_completed" %}
+                  {% if formation.type.value == "classic" %}
+                    <p class="fr-text">
+                      Formation classique réalisée
+                      {% if formation.date_formation %}
+                        le {{ formation.date_formation }}
+                      {% endif %}
+                      {% if formation.organisation_name %}
+                        par {{ formation.organisation_name }}
+                      {% endif %}
+                    </p>
+                  {% elif formation.type.value == "fne" %}
+                    <p class="fr-text">
+                      Formation FNE réalisée
+                      {% if formation.date_formation %}
+                        le {{ formation.date_formation }}
+                      {% endif %}
+                    </p>
+                  {% else %}
+                    <p class="fr-text">Formation pair à pair</p>
+                  {% endif %}
+                  {% if formation.date_test_pix %}
+                    <p class="fr-text">Test PIX réalisé le {{ formation.date_test_pix }}</p>
+                  {% endif %}
+                {% endif %}
+              </div>
+            </div>
+          </div>
+        </section>
+      {% endif %}
+
       <section class="fr-mt-8v">
-        <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-book-2-line">
-          Formation
+        <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-device-line">
+          Moyen de connexion
         </h2>
+
         <div class="fr-card fr-mt-2w">
           <div class="fr-card__body">
             <div class="fr-card__content">
-              {% if formation.status.value == "formation_attendance" %}
-                {% if formation.type.value == "p2p" %}
-                  <p class="fr-text">Inscrit à une formation pair à pair</p>
-                {% elif formation.type.value == "fne" %}
-                  <p class="fr-text">Inscrit à une formation FNE</p>
-                {% else %}
-                  <p class="fr-text">Inscrit à la formation du {{ formation.date_formation }}
-                      par {{ formation.organisation_name }}
-                  </p>
-                   <div class="fr-alert fr-alert--info">
-                    <p class="fr-text">Information : si vous souhaitez modifier ou annuler l'inscription, rapprochez-vous de l'organisme en charge de la formation :
-                      <a class="fr-link" href="mailto:{{ formation_attendant.formation.organisation_email }}">
-                        {{ formation.organisation_email }}
-                      </a>
-                    </p>
-                  </div>
-                {% endif %}
-              {% elif formation.status.value == "formation_completed" %}
-                {% if formation.type.value == "classic" %}
-                  <p class="fr-text">Formation classique réalisée
-                    {% if formation.date_formation %}
-                      le {{ formation.date_formation }}
-                    {% endif %}
-                    {% if formation.organisation_name %}
-                      par {{ formation.organisation_name }}
-                    {% endif %}
-                  </p>
-                {% elif formation.type.value == "fne" %}
-                  <p class="fr-text">Formation FNE réalisée
-                    {% if formation.date_formation %}
-                      le {{ formation.date_formation }}
-                    {% endif %}
-                  </p>
-                {% else %}
-                  <p class="fr-text">Formation pair à pair</p>
-                {% endif %}
-                {% if formation.date_test_pix %}
-                  <p class="fr-text">Test PIX réalisé le {{ formation.date_test_pix }}</p>
-                {% endif %}
+              <div class="fr-grid-row" id="section-otp-card">
+                <h3 class="fr-h6">Carte OTP</h3>
+                <div class="fr-mb-8v fr-ml-4v">
+                  {% if aidant.has_a_carte_totp %}
+                    <span class="fr-badge fr-badge--success">ASSOCIÉ</span>
+                  {% else %}
+                    <span class="fr-badge fr-badge--warning">INACTIF</span>
+                  {% endif %}
+                </div>
+              </div>
+              {% if aidant.has_a_carte_totp %}
+                <h3 class="fr-h6">Référence : <span class="fr-text--regular">{{ aidant.carte_totp.serial_number }}</span></h3>
+                <a
+                  id="remove-totp-card-from-aidant-{{ aidant.id }}"
+                  href="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}"
+                  class="fr-btn fr-btn--secondary"
+                >
+                  Délier la carte
+                </a>
+              {% elif aidant.is_active %}
+                <a
+                  id="manage-totp-cards-for-aidant-{{ aidant.id }}"
+                  href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}"
+                  class="fr-btn fr-btn--secondary"
+                >
+                  Associer un moyen de connexion
+                </a>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+        <div class="fr-card fr-mt-2w">
+          <div class="fr-card__body">
+            <div class="fr-card__content">
+              <div class="fr-grid-row" id="section-mobile-app">
+                <h3 class="fr-h6">Application mobile</h3>
+                <div class="fr-mb-8v fr-ml-4v">
+                  {% if aidant.has_otp_app %}
+                    <span class="fr-badge fr-badge--success">ASSOCIÉ</span>
+                  {% else %}
+                    <span class="fr-badge fr-badge--warning">INACTIF</span>
+                  {% endif %}
+                </div>
+              </div>
+              {% if aidant.has_otp_app %}
+                <a
+                  id="manage-totp-cards-for-aidant-{{ aidant.id }}"
+                  href="{% url 'espace_responsable_aidant_remove_app_otp' aidant_id=aidant.id %}"
+                  class="fr-btn fr-btn--secondary fr-mt-8v"
+                >
+                  Délier l'application mobile
+                </a>
+              {% elif aidant.is_active %}
+                <a
+                  id="manage-totp-cards-for-aidant-{{ aidant.id }}"
+                  href="{% url 'espace_responsable_aidant_add_app_otp' aidant_id=aidant.id %}"
+                  class="fr-btn fr-btn--secondary"
+                >
+                  Associer une application mobile
+                </a>
               {% endif %}
             </div>
           </div>
         </div>
       </section>
-    {% endif %}
-
-
-    <section class="fr-mt-8v">
-      <h2 class="fr-h3 fr-mb-4 fr-title-icon-left fr-icon-device-line">
-        Moyen de connexion
-      </h2>
-
-      <div class="fr-card fr-mt-2w">
-        <div class="fr-card__body">
-          <div class="fr-card__content">
-            <div class="fr-grid-row" id="section-otp-card">
-              <h3 class="fr-h6">Carte OTP</h3>
-              <div class="fr-mb-8v fr-ml-4v">
-                {% if aidant.has_a_carte_totp %}
-                  <span class="fr-badge fr-badge--success">ASSOCIÉ</span>
-                {% else %}
-                  <span class="fr-badge fr-badge--warning">INACTIF</span>
-                {% endif %}
-              </div>
-            </div>
-            {% if aidant.has_a_carte_totp %}
-              <h3 class="fr-h6">Référence : <span class="fr-text--regular">{{ aidant.carte_totp.serial_number }}</span></h3>
-              <a
-                id="remove-totp-card-from-aidant-{{ aidant.id }}"
-                href="{% url "espace_responsable_aidant_remove_card" aidant_id=aidant.id %}"
-                class="fr-btn fr-btn--secondary"
-              >
-                Délier la carte
-              </a>
-            {% elif aidant.is_active %}
-              <a
-                id="manage-totp-cards-for-aidant-{{ aidant.id }}"
-                href="{% url "espace_responsable_associate_totp" aidant_id=aidant.id %}"
-                class="fr-btn fr-btn--secondary"
-              >
-                Associer un moyen de connexion
-              </a>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-      <div class="fr-card fr-mt-2w">
-        <div class="fr-card__body">
-          <div class="fr-card__content">
-            <div class="fr-grid-row" id="section-mobile-app">
-              <h3 class="fr-h6">Application mobile</h3>
-              <div class="fr-mb-8v fr-ml-4v">
-                {% if aidant.has_otp_app %}
-                  <span class="fr-badge fr-badge--success">ASSOCIÉ</span>
-                {% else %}
-                  <span class="fr-badge fr-badge--warning">INACTIF</span>
-                {% endif %}
-              </div>
-            </div>
-            {% if aidant.has_otp_app %}
-              <a
-                id="manage-totp-cards-for-aidant-{{ aidant.id }}"
-                href="{% url 'espace_responsable_aidant_remove_app_otp' aidant_id=aidant.id %}"
-                class="fr-btn fr-btn--secondary fr-mt-8v"
-              >
-                Délier l'application mobile
-              </a>
-            {% elif aidant.is_active %}
-              <a
-                id="manage-totp-cards-for-aidant-{{ aidant.id }}"
-                href="{% url 'espace_responsable_aidant_add_app_otp' aidant_id=aidant.id %}"
-                class="fr-btn fr-btn--secondary"
-              >
-                Associer une application mobile
-              </a>
-            {% endif %}
-          </div>
-        </div>
-      </div>
-    </section>
+    </div>
   </div>
 {% endblock content %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/aidant.html
@@ -11,7 +11,16 @@
       <h1>{{ aidant.get_full_name }}</h1>
 
       <div>
-        <div class="fr-btns-group fr-btns-group--inline fr-btns-group--md">
+        <div class="fr-btns-group fr-btns-group--inline fr-btns-group--md fr-btns-group--icon-left">
+        {% if aidant.can_create_mandats %}
+          <a
+            href="{% url 'espace_responsable_aidant_formation_attestation' aidant_id=aidant.id %}"
+            class="fr-btn fr-btn--secondary fr-icon-download-line fr-btn--icon-left"
+            id="download-formation-attestation-{{ aidant.id }}"
+          >
+            Télécharger l'attestation de formation
+          </a>
+        {% endif %}
         {% if aidant.is_active and not is_aidant_referent_of_current_org %}
           <form method="post" action="{% url 'espace_responsable_aidants' %}">
             {% csrf_token %}

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -36,7 +36,7 @@ class EspaceResponsableOrganisationPage(TestCase):
         self.assertEqual(
             response.status_code,
             200,
-            "trying to get " "/espace-responsable/organisation/",
+            "trying to get /espace-responsable/organisation/",
         )
         self.assertTemplateUsed(
             response, "aidants_connect_web/espace_responsable/organisation.html"

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -181,6 +181,32 @@ class EspaceResponsableAidantPage(TestCase):
             response, "aidants_connect_web/espace_responsable/aidant.html"
         )
 
+    def test_referent_can_download_managed_aidant_formation_attestation(self):
+        self.client.force_login(self.responsable_tom)
+        url = reverse(
+            "espace_responsable_aidant_formation_attestation",
+            kwargs={"aidant_id": self.aidant_tim.id},
+        )
+        found = resolve(url)
+        self.assertEqual(
+            found.func.view_class,
+            espace_responsable.GenerateAidantFormationAttestation,
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/pdf")
+
+    def test_responsable_cannot_download_formation_attestation_for_unmanaged_aidant(
+        self,
+    ):
+        self.client.force_login(self.responsable_tom)
+        url = reverse(
+            "espace_responsable_aidant_formation_attestation",
+            kwargs={"aidant_id": self.autre_aidant.id},
+        )
+        response = self.client.get(url)
+        self.assertRedirects(response, reverse("espace_responsable_organisation"))
+
     def test_responsable_cannot_see_an_aidant_they_are_not_responsible_for(self):
         self.client.force_login(self.responsable_tom)
         response = self.client.get(

--- a/aidants_connect_web/urls.py
+++ b/aidants_connect_web/urls.py
@@ -228,6 +228,11 @@ urlpatterns = [
         name="espace_responsable_aidant",
     ),
     path(
+        "espace-responsable/aidant/<int:aidant_id>/attestation-formation/",
+        espace_responsable.GenerateAidantFormationAttestation.as_view(),
+        name="espace_responsable_aidant_formation_attestation",
+    ),
+    path(
         "espace-responsable/aidant/ajouter/",
         espace_responsable.NewHabilitationRequest.as_view(),
         name="espace_responsable_aidant_new",

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -7,12 +7,12 @@ from itertools import chain
 from django.contrib import messages as django_messages
 from django.db import transaction
 from django.forms import model_to_dict
-from django.http import HttpRequest, HttpResponseRedirect
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect
 from django.urls import reverse, reverse_lazy
 from django.utils.decorators import method_decorator
 from django.utils.translation import ngettext
-from django.views.generic import DeleteView, DetailView, FormView, TemplateView
+from django.views.generic import DeleteView, DetailView, FormView, TemplateView, View
 
 import qrcode
 from django_otp.plugins.otp_totp.models import TOTPDevice
@@ -412,6 +412,44 @@ class AidantView(ReferentCannotManageAidantResponseMixin, TemplateView):
             }
         )
         return super().get_context_data(**kwargs)
+
+
+@responsable_logged_with_activity_required
+class GenerateAidantFormationAttestation(ReferentCannotManageAidantResponseMixin, View):
+    """
+    Lets a structure referent download the formation
+    attestation PDF for a managed aidant.
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        self.referent: Aidant = request.user
+        if not self.referent.can_manage_aidant(kwargs["aidant_id"]):
+            return self.referent_cannot_manage_aidant_response()
+        self.aidant: Aidant = Aidant.objects.get(pk=kwargs["aidant_id"])
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        if not self.aidant.can_create_mandats:
+            django_messages.error(
+                request,
+                (
+                    "Cet aidant ne peut pas recevoir dʼattestation "
+                    "de formation Aidants Connect.",
+                ),
+            )
+            return redirect(
+                "espace_responsable_aidant", kwargs={"aidant_id": self.aidant.pk}
+            )
+        self.aidant.generate_attestation()
+        return HttpResponse(
+            self.aidant.attestation.read(),
+            content_type="application/pdf",
+            headers={
+                "Content-Disposition": (
+                    f'attachment; filename="{self.aidant.attestation.name}"'
+                )
+            },
+        )
 
 
 @responsable_logged_with_activity_required


### PR DESCRIPTION
## 🌮 Objectif

Permettre aux référents de télécharger les attestations de formation de leurs aidants.

## 🔍 Implémentation

- une vue pour la génération et le téléchargement de l'attestation par un référent
- bouton sur la fiche aidant

## 🖼️ Images

<img width="1533" height="1075" alt="Capture d’écran du 2026-04-21 17-27-53" src="https://github.com/user-attachments/assets/7799c01d-0b3f-47fb-a073-f2572b6e8839" />
