### PR TITLE
Afficher un message d'erreur générique en cas d'erreur de connexion

### DIFF
--- a/aidants_connect/settings.py
+++ b/aidants_connect/settings.py
@@ -374,6 +374,11 @@ MAGICAUTH_EMAIL_HTML_TEMPLATE = "login/email_template.mjml"
 MAGICAUTH_EMAIL_TEXT_TEMPLATE = "login/email_template.txt"
 MAGICAUTH_WAIT_VIEW_TEMPLATE = "login/wait.html"
 MAGICAUTH_ENABLE_2FA = True
+# Use the same generic error message as for invalid OTP / inactive account to
+# avoid user enumeration and keep a single consistent wording.
+MAGICAUTH_EMAIL_UNKNOWN_MESSAGE = (
+    "Les informations saisies ne permettent pas de vous identifier."
+)
 
 # https://github.com/betagouv/django-magicauth/blob/8a8143388bb15fad2823528201e22a31817da243/magicauth/settings.py  # NOQA
 MAGICAUTH_TOKEN_DURATION_SECONDS = int(

--- a/aidants_connect_web/forms.py
+++ b/aidants_connect_web/forms.py
@@ -171,6 +171,11 @@ class AidantChangeForm(forms.ModelForm):
         return cleaned_data
 
 
+LOGIN_GENERIC_ERROR_MESSAGE = (
+    "Les informations saisies ne permettent pas de vous identifier."
+)
+
+
 class LoginEmailForm(MagicAuthEmailForm, DsfrBaseForm):
     email = forms.EmailField(
         label="Adresse e-mail", help_text="Format attendu : prenom-nom@exemple.fr"
@@ -179,11 +184,7 @@ class LoginEmailForm(MagicAuthEmailForm, DsfrBaseForm):
     def clean_email(self):
         user_email = super().clean_email()
         if not Aidant.objects.filter(email__iexact=user_email, is_active=True).exists():
-            raise ValidationError(
-                "Les informations saisies ne "
-                "permettent pas de vous identifier. Si vous pensez"
-                " que c’est une erreur, prenez contact avec Aidants Connect."
-            )
+            raise ValidationError(LOGIN_GENERIC_ERROR_MESSAGE)
         return user_email
 
 
@@ -259,6 +260,15 @@ class DsfrOtpForm(OTPForm, DsfrBaseForm):
 
     def __init__(self, user, *args, **kwargs):
         super().__init__(user, *args, **kwargs)
+
+    def clean_otp_token(self):
+        # Replace magicauth's OTP-specific error messages with the same
+        # generic message used for an unknown email, so that the user cannot
+        # tell whether the email or the OTP is at fault.
+        try:
+            return super().clean_otp_token()
+        except ValidationError as err:
+            raise ValidationError(LOGIN_GENERIC_ERROR_MESSAGE) from err
 
 
 def get_choices_for_remote_method():

--- a/aidants_connect_web/tests/test_views/test_login.py
+++ b/aidants_connect_web/tests/test_views/test_login.py
@@ -42,9 +42,37 @@ class LoginTests(TestCase):
         self.assertEqual(response.status_code, 200)
         # Check explicit message is displayed
         self.assertContains(
-            response, "permettent pas de vous identifier. Si vous pensez"
+            response, "Les informations saisies ne permettent pas de vous identifier."
         )
         # Check no email was sent
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_unknown_email_shows_generic_error_and_no_otp_error(self):
+        response = self.client.post(
+            reverse("login"),
+            {"email": "unknown@example.com", "otp_token": "123456"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Les informations saisies ne permettent pas de vous identifier."
+        )
+        # Specific magicauth messages must not leak
+        self.assertNotContains(response, "Aucun utilisateur trouvé")
+        self.assertNotContains(response, "est pas valide")
+        self.assertNotContains(response, "n'a pas trouvé d&#x27;appareil")
+        self.assertEqual(len(mail.outbox), 0)
+
+    def test_invalid_otp_shows_same_generic_error(self):
+        response = self.client.post(
+            reverse("login"),
+            {"email": self.aidant_with_totp_card.email, "otp_token": "000000"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "Les informations saisies ne permettent pas de vous identifier."
+        )
+        # The OTP-specific error message must not be displayed
+        self.assertNotContains(response, "est pas valide")
         self.assertEqual(len(mail.outbox), 0)
 
     def test_magicauth_login_redirects(self):


### PR DESCRIPTION
## 🌮 Objectif

Le même message dans tous les cas d'erreur

## 🔍 Implémentation

- surcharge du message Magicauth via les settings
- catch and raise pour  forcer le message d'erreur sur l'otp

## 🖼️ Images

<img width="551" height="697" alt="image" src="https://github.com/user-attachments/assets/32e6ed55-ef15-4296-819d-0c8ccfbb69ea" />