### PR TITLE
Parcours de changement de structure : petites modifications de formulation 

### DIFF
--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/add-aidant-wizard-confirmation.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/add-aidant-wizard-confirmation.html
@@ -44,7 +44,7 @@
               </ul>
             </p>
             <p class="fr-text">
-              Une fois la demande validée, vous pourrez associer un moyen de connexion aux aidants depuis l'onglet « Aidants actifs ».
+              Une fois la demande validée, les aidants seront liés à votre organisation. Si besoin, vous pourrez leur associer un nouveau moyen de connexion depuis l'onglet « Aidants actifs ».
             </p>
           {% endif %}
         {% elif wizard_profile_choice == AddAidantProfileChoice.NOT_YET_TRAINED %}

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/add-aidant-wizard-step2-trained.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/add-aidant-wizard-step2-trained.html
@@ -63,7 +63,7 @@
                     l'aidant n'aura plus accès aux mandats de l'autre structure et ne pourra créer des mandats
                     qu'au nom de la structure {{ form.email_lookup_data.current_org_name }}.
                     S'il est nécessaire que l'aidant ait toujours accès aux mandats de l'autre structure,
-                    <a href="mailto:support@aidantsconnect.beta.gouv.fr" class="fr-link">contactez le support</a> pour les ajouter.
+                    <a href="mailto:support@aidantsconnect.beta.gouv.fr" class="fr-link">contactez le support</a>.
                   </p>
                 </div>
                 <div class="fr-mb-4v" data-action="change->new-email-toggle#toggle">

--- a/aidants_connect_web/tests/test_functional/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_functional/test_espace_responsable.py
@@ -368,12 +368,13 @@ class NewHabilitationRequestTests(FunctionalTestCase):
         "inscrire les aidants en formation",
     ]
     NOT_YET_TRAINED_UNEXPECTED = [
-        "vous pourrez associer un moyen de connexion aux aidants",
+        "Une fois la demande validée, les aidants seront liés à votre organisation.",
+        "Aidants actifs",
     ]
 
     ALREADY_TRAINED_EXPECTED = [
         "La demande d'ajout, pour les aidants suivants, sera vérifiée par notre équipe",
-        "vous pourrez associer un moyen de connexion aux aidants",
+        "Une fois la demande validée, les aidants seront liés à votre organisation.",
     ]
     ALREADY_TRAINED_UNEXPECTED = [
         "L’éligibilité des aidants sera vérifée",


### PR DESCRIPTION
## 🌮 Objectif

Clarifier le message de confirmation

## 🔍 Implémentation

- suppression "pour les ajouter" sur l'étape 2
- changement du message de confirmation pour les demandes de changement d'organisation

## 🖼️ Images

<img width="840" height="939" alt="Capture d’écran du 2026-05-11 16-02-29" src="https://github.com/user-attachments/assets/79d169a8-5816-479a-9de2-f277fd5800ff" />

<img width="927" height="493" alt="Capture d’écran du 2026-05-11 16-01-58" src="https://github.com/user-attachments/assets/ec743a89-d69f-492a-980a-0d23eb5fd2b1" />
