### PR TITLE
Ne pas envoyer les emails de formation aux référents inactifs

### DIFF
--- a/aidants_connect_habilitation/signals.py
+++ b/aidants_connect_habilitation/signals.py
@@ -105,7 +105,11 @@ def formation_aidant(instance: FormationAttendant, created: bool, **_):
 
     emails = set()
     if isinstance(person, HabilitationRequest):
-        emails |= set(person.organisation.responsables.values_list("email", flat=True))
+        emails |= set(
+            person.organisation.responsables.filter(is_active=True).values_list(
+                "email", flat=True
+            )
+        )
         try:
             person = person.manger_request or person.aidant_request
             emails.add(person.organisation.issuer.email)


### PR DESCRIPTION
## 🌮 Objectif

Ne pas envoyer les emails de formation aux référents inactifs

## 🔍 Implémentation

- _Une liste des modifications_

## 🏕 Amélioration continue

- _(optionnel) Une liste d'autres modifications pas en lien direct avec la PR_

## ⚠️ Informations supplémentaires

_(optionnel) Documentation, commandes à lancer, variables d'environment, etc_

## 🖼️ Images

_(optionnel) Une ou plusieurs captures d'écran_
