### PR TITLE
Incite les référents à configurer les thématiques administratives de leur organisation avec un badge

### DIFF
--- a/aidants_connect_web/migrations/0093_organisation_demarches_configured_at.py
+++ b/aidants_connect_web/migrations/0093_organisation_demarches_configured_at.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.db import migrations, models
+from django.utils import timezone
+
+
+def set_demarches_configured_at_for_customised_organisations(apps, schema_editor):
+    Organisation = apps.get_model("aidants_connect_web", "Organisation")
+    all_demarches = set(settings.DEMARCHES.keys())
+    configured_at = timezone.now()
+
+    for organisation in Organisation.objects.iterator():
+        if set(organisation.allowed_demarches) != all_demarches:
+            organisation.demarches_configured_at = configured_at
+            organisation.save(update_fields=["demarches_configured_at"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("aidants_connect_web", "0092_habilitationrequest_pix_score"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="organisation",
+            name="demarches_configured_at",
+            field=models.DateTimeField(
+                blank=True,
+                default=None,
+                null=True,
+                verbose_name="Thématiques configurées le",
+            ),
+        ),
+        migrations.RunPython(
+            set_demarches_configured_at_for_customised_organisations,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/aidants_connect_web/migrations/0096_organisation_demarches_configured_at.py
+++ b/aidants_connect_web/migrations/0096_organisation_demarches_configured_at.py
@@ -15,9 +15,8 @@ def set_demarches_configured_at_for_customised_organisations(apps, schema_editor
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
-        ("aidants_connect_web", "0092_habilitationrequest_pix_score"),
+        ("aidants_connect_web", "0095_alter_organisation_city_and_more"),
     ]
 
     operations = [

--- a/aidants_connect_web/models/organisation.py
+++ b/aidants_connect_web/models/organisation.py
@@ -134,6 +134,12 @@ class Organisation(models.Model):
         ),
         default=organisation_allowed_demarches,
     )
+    demarches_configured_at = models.DateTimeField(
+        "Thématiques configurées le",
+        null=True,
+        blank=True,
+        default=None,
+    )
 
     is_active = models.BooleanField("Est active", default=True, editable=False)
 
@@ -149,6 +155,19 @@ class Organisation(models.Model):
 
     def __str__(self):
         return f"{self.name}"
+
+    def has_all_allowed_demarches(self) -> bool:
+        return set(self.allowed_demarches) == set(settings.DEMARCHES.keys())
+
+    @property
+    def demarches_need_configuration(self) -> bool:
+        return self.has_all_allowed_demarches() and self.demarches_configured_at is None
+
+    def update_allowed_demarches(self, demarches: list[str]) -> None:
+        self.allowed_demarches = demarches
+        if self.demarches_configured_at is None:
+            self.demarches_configured_at = timezone.now()
+        self.save(update_fields=("allowed_demarches", "demarches_configured_at"))
 
     class AlreadyExists(Exception):
         pass

--- a/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
+++ b/aidants_connect_web/templates/aidants_connect_web/espace_responsable/home.html
@@ -89,6 +89,9 @@
                 <p class="fr-tile__title">
                   <a href="{% url 'espace_referent:organisation' %}">Configurer les thématiques</a>
                 </p>
+                {% if organisation.demarches_need_configuration %}
+                  <p class="fr-badge fr-badge--pink-tuile fr-icon-flashlight-fill fr-badge--icon-left fr-mb-1w">À configurer</p>
+                {% endif %}
               </div>
             </div>
             <div class="fr-tile__header">

--- a/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
+++ b/aidants_connect_web/tests/test_views/test_espace_responsable/test_espace_responsable.py
@@ -2,6 +2,7 @@ from django.contrib import messages as django_messages
 from django.test import TestCase, tag
 from django.test.client import Client
 from django.urls import resolve, reverse
+from django.utils import timezone
 
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from faker import Faker
@@ -92,6 +93,7 @@ class EspaceResponsableOrganisationPage(TestCase):
             len(settings.DEMARCHES.keys()),
             len(self.responsable_tom.organisation.allowed_demarches),
         )
+        self.assertIsNone(self.responsable_tom.organisation.demarches_configured_at)
         self.client.force_login(self.responsable_tom)
         response = self.client.post(
             reverse("espace_referent:organisation"),
@@ -103,6 +105,34 @@ class EspaceResponsableOrganisationPage(TestCase):
             2,
             len(self.responsable_tom.organisation.allowed_demarches),
         )
+        self.assertIsNotNone(self.responsable_tom.organisation.demarches_configured_at)
+
+    def test_home_shows_demarches_to_configure_label_when_not_configured(self):
+        self.assertTrue(self.responsable_tom.organisation.demarches_need_configuration)
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get(reverse("espace_referent:home"))
+        self.assertContains(response, "À configurer")
+
+    def test_home_hides_demarches_to_configure_label_after_validation_with_all(self):
+        self.client.force_login(self.responsable_tom)
+        response = self.client.post(
+            reverse("espace_referent:organisation"),
+            data={"demarches": list(settings.DEMARCHES.keys())},
+        )
+        self.assertRedirects(response, reverse("espace_referent:organisation"))
+        response = self.client.get(reverse("espace_referent:home"))
+        self.assertNotContains(response, "À configurer")
+
+    def test_home_hides_demarches_to_configure_label_when_subset_selected(self):
+        organisation = self.responsable_tom.organisation
+        organisation.allowed_demarches = ["papiers", "logement"]
+        organisation.demarches_configured_at = timezone.now()
+        organisation.save(
+            update_fields=("allowed_demarches", "demarches_configured_at")
+        )
+        self.client.force_login(self.responsable_tom)
+        response = self.client.get(reverse("espace_referent:home"))
+        self.assertNotContains(response, "À configurer")
 
     def test_I_must_select_at_least_one_demarche(self):
         # All demarches are allowed

--- a/aidants_connect_web/views/espace_responsable.py
+++ b/aidants_connect_web/views/espace_responsable.py
@@ -145,8 +145,7 @@ class OrganisationView(DetailView, FormView):
         return {"demarches": self.referent.organisation.allowed_demarches}
 
     def form_valid(self, form):
-        self.organisation.allowed_demarches = form.cleaned_data["demarches"]
-        self.organisation.save(update_fields=("allowed_demarches",))
+        self.organisation.update_allowed_demarches(form.cleaned_data["demarches"])
         return super().form_valid(form)
 
 
@@ -249,8 +248,7 @@ class ReferentsView(DetailView, FormView):
         return {"demarches": self.referent.organisation.allowed_demarches}
 
     def form_valid(self, form):
-        self.organisation.allowed_demarches = form.cleaned_data["demarches"]
-        self.organisation.save(update_fields=("allowed_demarches",))
+        self.organisation.update_allowed_demarches(form.cleaned_data["demarches"])
         return super().form_valid(form)
 
 


### PR DESCRIPTION
## 🌮 Objectif

Inciter les référents à configurer les thématiques administratives via un badge « À configurer » sur la tuile dédiée

## 🔍 Implémentation

Par défaut, une organisation a toutes les démarches autorisées, ce qui ne permet pas de distinguer une configuration jamais validée d’un choix délibéré. Cette PR ajoute un suivi explicite de la première validation et un repère visuel sur la page d’accueil référent.

- Ajout du champ demarches_configured_at sur Organisation, renseigné lors de la première sauvegarde du formulaire de thématiques
- Affichage d’un badge « À configurer » sur la tuile « Configurer les thématiques » tant que l’organisation a toutes les démarches et n’a jamais validé le formulaire
- Migration de données : les organisations ayant déjà restreint leurs démarches sont considérées comme configurées
- Tests couvrant l’affichage/masquage du badge selon les cas (jamais validé, validé avec toutes les démarches, sous-ensemble choisi)

## Captures d'écrans

<img width="1239" height="302" alt="image" src="https://github.com/user-attachments/assets/e4082fe5-8d1a-4932-b6c1-566064f1c4f7" />

