### PR TITLE
Analyse et rattrapage des types d'organisation

### DIFF
--- a/aidants_connect_web/management/commands/export_organisation_types.py
+++ b/aidants_connect_web/management/commands/export_organisation_types.py
@@ -1,0 +1,37 @@
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+
+from aidants_connect_web.organisation_type_merge import write_organisation_types_csv
+
+
+class Command(BaseCommand):
+    help = (
+        "Exporte les types de structure dans un CSV pour préparer un remapping "
+        "(colonne target_id à compléter avant import)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "output",
+            nargs="?",
+            default="-",
+            help="Fichier CSV de sortie (défaut : stdout, utiliser '-' explicitement).",
+        )
+
+    def handle(self, *args, **options):
+        output_path = options["output"]
+
+        if output_path in ("-", ""):
+            write_organisation_types_csv(sys.stdout)
+            return
+
+        try:
+            with open(output_path, "w", newline="", encoding="utf-8") as output_file:
+                write_organisation_types_csv(output_file)
+        except OSError as exc:
+            raise CommandError(
+                f"Impossible d'écrire le fichier {output_path!r}."
+            ) from exc
+
+        self.stdout.write(self.style.SUCCESS(f"Export terminé : {output_path}"))

--- a/aidants_connect_web/management/commands/merge_organisation_types.py
+++ b/aidants_connect_web/management/commands/merge_organisation_types.py
@@ -1,0 +1,84 @@
+from django.core.management.base import BaseCommand, CommandError
+
+from aidants_connect_web.organisation_type_merge import (
+    apply_organisation_type_merge,
+    iter_merge_summary_lines,
+    parse_merge_mapping_from_csv,
+    preview_organisation_type_merge,
+)
+
+
+class Command(BaseCommand):
+    help = (
+        "Fusionne des types de structure à partir d'un CSV exporté "
+        "(colonnes id/source_id et target_id)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "mapping_file",
+            help="Fichier CSV contenant les colonnes id et target_id.",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Applique les fusions (par défaut : dry-run).",
+        )
+        parser.add_argument(
+            "--no-delete-orphans",
+            action="store_true",
+            help="Ne supprime pas les types sans référence après fusion.",
+        )
+
+    def handle(self, *args, **options):
+        mapping_file = options["mapping_file"]
+        apply_changes = options["apply"]
+        delete_orphans = not options["no_delete_orphans"]
+
+        try:
+            with open(mapping_file, newline="", encoding="utf-8") as input_file:
+                mapping = parse_merge_mapping_from_csv(input_file)
+        except OSError as exc:
+            raise CommandError(
+                f"Impossible de lire le fichier {mapping_file!r}."
+            ) from exc
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        if not mapping:
+            self.stdout.write("Aucune ligne avec target_id à traiter.")
+            return
+
+        try:
+            previews = preview_organisation_type_merge(mapping)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        mode = "APPLICATION" if apply_changes else "DRY-RUN"
+        self.stdout.write(f"Mode : {mode}")
+        for line in iter_merge_summary_lines(previews):
+            self.stdout.write(line)
+
+        if not apply_changes:
+            self.stdout.write(
+                "Aucune modification effectuée. Relancez avec --apply pour exécuter."
+            )
+            return
+
+        try:
+            result = apply_organisation_type_merge(
+                mapping,
+                delete_orphans=delete_orphans,
+            )
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        if delete_orphans and result.deleted_orphan_type_ids:
+            deleted_ids = ", ".join(
+                str(type_id) for type_id in result.deleted_orphan_type_ids
+            )
+            self.stdout.write(
+                self.style.SUCCESS(f"Types orphelins supprimés : {deleted_ids}")
+            )
+
+        self.stdout.write(self.style.SUCCESS("Fusions appliquées."))

--- a/aidants_connect_web/migrations/0093_merge_legacy_organisation_types.py
+++ b/aidants_connect_web/migrations/0093_merge_legacy_organisation_types.py
@@ -1,0 +1,85 @@
+from django.db import migrations
+
+# Legacy organisation types removed from RequestOriginConstants in
+# dc5ac400 ("New Choices for Organisation Type", 2024-11-18).
+LEGACY_ORGANISATION_TYPE_MERGE = {
+    4: 30,  # Secrétariats de mairie → Municipalités
+    7: 8,  # Autre guichet de SP de proximité → Guichet opérateur de SP
+    9: 13,  # Autres associations → Associations
+    11: 12,  # Indépendant → Autre
+    # TODO: 10 Structure médico-sociale (CSAPA, CHU, CMS) ?
+}
+
+
+def merge_legacy_organisation_types(apps, schema_editor):
+    Organisation = apps.get_model("aidants_connect_web", "Organisation")
+    OrganisationType = apps.get_model("aidants_connect_web", "OrganisationType")
+    OrganisationRequest = apps.get_model(
+        "aidants_connect_habilitation", "OrganisationRequest"
+    )
+    canonical_type_ids = {
+        1,
+        2,
+        3,
+        5,
+        6,
+        8,
+        12,
+        13,
+        20,
+        29,
+        30,
+        32,
+        35,
+        55,
+        60,
+        91,
+        94,
+        144,
+        202,
+        238,
+        242,
+        247,
+        255,
+        358,
+        393,
+        459,
+        557,
+        577,
+        578,
+    }
+
+    for old_type_id, new_type_id in LEGACY_ORGANISATION_TYPE_MERGE.items():
+        Organisation.objects.filter(type_id=old_type_id).update(type_id=new_type_id)
+        OrganisationRequest.objects.filter(type_id=old_type_id).update(
+            type_id=new_type_id
+        )
+
+    used_type_ids = set(
+        Organisation.objects.exclude(type_id=None).values_list("type_id", flat=True)
+    ) | set(
+        OrganisationRequest.objects.exclude(type_id=None).values_list(
+            "type_id", flat=True
+        )
+    )
+
+    OrganisationType.objects.exclude(id__in=used_type_ids).exclude(
+        id__in=canonical_type_ids
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("aidants_connect_web", "0092_habilitationrequest_pix_score"),
+        (
+            "aidants_connect_habilitation",
+            "0037_alter_organisationrequest_avg_nb_demarches_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            merge_legacy_organisation_types,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/aidants_connect_web/organisation_type_merge.py
+++ b/aidants_connect_web/organisation_type_merge.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import csv
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from io import TextIOBase
+
+from django.db.models import Count
+
+from aidants_connect_common.constants import RequestOriginConstants
+from aidants_connect_habilitation.models import OrganisationRequest
+from aidants_connect_web.models import Organisation, OrganisationType
+
+CANONICAL_ORGANISATION_TYPE_IDS = {choice.value for choice in RequestOriginConstants}
+
+EXPORT_FIELDNAMES = (
+    "id",
+    "name",
+    "nb_organisations",
+    "nb_organisation_requests",
+    "is_canonical",
+    "target_id",
+)
+
+
+@dataclass(frozen=True)
+class OrganisationTypeAuditRow:
+    id: int
+    name: str
+    nb_organisations: int
+    nb_organisation_requests: int
+    is_canonical: bool
+
+
+@dataclass(frozen=True)
+class OrganisationTypeMergePreview:
+    source_id: int
+    source_name: str
+    target_id: int
+    target_name: str
+    nb_organisations: int
+    nb_organisation_requests: int
+
+
+@dataclass(frozen=True)
+class ApplyOrganisationTypeMergeResult:
+    previews: tuple[OrganisationTypeMergePreview, ...]
+    deleted_orphan_type_ids: tuple[int, ...]
+
+
+def get_organisation_type_audit_rows() -> list[OrganisationTypeAuditRow]:
+    rows = []
+    organisation_types = (
+        OrganisationType.objects.annotate(
+            nb_organisations=Count("organisation", distinct=True),
+            nb_organisation_requests=Count("organisationrequest", distinct=True),
+        )
+        .order_by("name", "id")
+        .values(
+            "id",
+            "name",
+            "nb_organisations",
+            "nb_organisation_requests",
+        )
+    )
+
+    for organisation_type in organisation_types:
+        rows.append(
+            OrganisationTypeAuditRow(
+                id=organisation_type["id"],
+                name=organisation_type["name"],
+                nb_organisations=organisation_type["nb_organisations"],
+                nb_organisation_requests=organisation_type["nb_organisation_requests"],
+                is_canonical=organisation_type["id"] in CANONICAL_ORGANISATION_TYPE_IDS,
+            )
+        )
+
+    return rows
+
+
+def write_organisation_types_csv(output: TextIOBase) -> None:
+    writer = csv.DictWriter(output, fieldnames=EXPORT_FIELDNAMES)
+    writer.writeheader()
+
+    for row in get_organisation_type_audit_rows():
+        writer.writerow(
+            {
+                "id": row.id,
+                "name": row.name,
+                "nb_organisations": row.nb_organisations,
+                "nb_organisation_requests": row.nb_organisation_requests,
+                "is_canonical": "yes" if row.is_canonical else "no",
+                "target_id": "",
+            }
+        )
+
+
+def parse_merge_mapping_from_csv(input_file: TextIOBase) -> dict[int, int]:
+    reader = csv.DictReader(input_file)
+    if not reader.fieldnames:
+        raise ValueError("Le fichier CSV est vide ou ne contient pas d'en-tête.")
+
+    mapping: dict[int, int] = {}
+
+    for line_number, row in enumerate(reader, start=2):
+        source_id = _read_csv_id(row, ("id", "source_id"), line_number)
+        target_id = _read_csv_id(row, ("target_id",), line_number, required=False)
+
+        if target_id is None:
+            continue
+
+        if source_id == target_id:
+            continue
+
+        if source_id in mapping and mapping[source_id] != target_id:
+            raise ValueError(
+                f"Ligne {line_number} : le type {source_id} a plusieurs cibles "
+                f"({mapping[source_id]} et {target_id})."
+            )
+
+        mapping[source_id] = target_id
+
+    return mapping
+
+
+def preview_organisation_type_merge(
+    mapping: dict[int, int],
+) -> list[OrganisationTypeMergePreview]:
+    previews = []
+
+    for source_id, target_id in sorted(mapping.items()):
+        try:
+            source_type = OrganisationType.objects.get(pk=source_id)
+        except OrganisationType.DoesNotExist as exc:
+            raise ValueError(f"Type source introuvable : id={source_id}.") from exc
+
+        try:
+            target_type = OrganisationType.objects.get(pk=target_id)
+        except OrganisationType.DoesNotExist as exc:
+            raise ValueError(
+                f"Type cible introuvable : id={target_id} (source id={source_id})."
+            ) from exc
+
+        previews.append(
+            OrganisationTypeMergePreview(
+                source_id=source_id,
+                source_name=source_type.name,
+                target_id=target_id,
+                target_name=target_type.name,
+                nb_organisations=Organisation.objects.filter(type_id=source_id).count(),
+                nb_organisation_requests=_count_organisation_requests(source_id),
+            )
+        )
+
+    return previews
+
+
+def apply_organisation_type_merge(
+    mapping: dict[int, int],
+    *,
+    delete_orphans: bool = True,
+) -> ApplyOrganisationTypeMergeResult:
+    previews = preview_organisation_type_merge(mapping)
+
+    for preview in previews:
+        Organisation.objects.filter(type_id=preview.source_id).update(
+            type_id=preview.target_id
+        )
+        _update_organisation_requests(preview.source_id, preview.target_id)
+
+    deleted_orphan_type_ids: tuple[int, ...] = ()
+    if delete_orphans:
+        deleted_orphan_type_ids = delete_unreferenced_organisation_types()
+
+    return ApplyOrganisationTypeMergeResult(
+        previews=tuple(previews),
+        deleted_orphan_type_ids=deleted_orphan_type_ids,
+    )
+
+
+def delete_unreferenced_organisation_types() -> tuple[int, ...]:
+    used_type_ids = (
+        set(
+            Organisation.objects.exclude(type_id=None).values_list("type_id", flat=True)
+        )
+        | _used_organisation_request_type_ids()
+    )
+
+    orphan_type_ids = tuple(
+        OrganisationType.objects.exclude(id__in=used_type_ids)
+        .exclude(id__in=CANONICAL_ORGANISATION_TYPE_IDS)
+        .values_list("id", flat=True)
+    )
+    OrganisationType.objects.filter(id__in=orphan_type_ids).delete()
+    return orphan_type_ids
+
+
+def _read_csv_id(
+    row: dict[str, str | None],
+    field_names: Iterable[str],
+    line_number: int,
+    *,
+    required: bool = True,
+) -> int | None:
+    value = None
+    for field_name in field_names:
+        if row.get(field_name) not in (None, ""):
+            value = row[field_name]
+            break
+
+    if value in (None, ""):
+        if required:
+            raise ValueError(
+                f"Ligne {line_number} : colonne obligatoire manquante "
+                f"({', '.join(field_names)})."
+            )
+        return None
+
+    try:
+        return int(str(value).strip())
+    except ValueError as exc:
+        raise ValueError(
+            f"Ligne {line_number} : identifiant invalide ({value!r})."
+        ) from exc
+
+
+def _count_organisation_requests(type_id: int) -> int:
+    return OrganisationRequest.objects.filter(type_id=type_id).count()
+
+
+def _update_organisation_requests(source_id: int, target_id: int) -> None:
+    OrganisationRequest.objects.filter(type_id=source_id).update(type_id=target_id)
+
+
+def _used_organisation_request_type_ids() -> set[int]:
+    return set(
+        OrganisationRequest.objects.exclude(type_id=None).values_list(
+            "type_id", flat=True
+        )
+    )
+
+
+def iter_merge_summary_lines(
+    previews: list[OrganisationTypeMergePreview],
+    *,
+    deleted_orphan_type_ids: tuple[int, ...] = (),
+) -> Iterator[str]:
+    if not previews:
+        yield "Aucune fusion à appliquer."
+        return
+
+    for preview in previews:
+        yield (
+            f"- {preview.source_id} ({preview.source_name!r}) "
+            f"→ {preview.target_id} ({preview.target_name!r}) : "
+            f"{preview.nb_organisations} organisation(s), "
+            f"{preview.nb_organisation_requests} demande(s)"
+        )
+
+    if deleted_orphan_type_ids:
+        yield (
+            f"Types orphelins supprimés ({len(deleted_orphan_type_ids)}) : "
+            f"{', '.join(str(type_id) for type_id in deleted_orphan_type_ids)}"
+        )

--- a/aidants_connect_web/tests/test_organisation_type_merge.py
+++ b/aidants_connect_web/tests/test_organisation_type_merge.py
@@ -1,0 +1,116 @@
+import csv
+import io
+import tempfile
+
+from django.core.management import call_command
+from django.test import TestCase, tag
+
+from aidants_connect_common.constants import RequestOriginConstants
+from aidants_connect_habilitation.tests.factories import OrganisationRequestFactory
+from aidants_connect_web.models import OrganisationType
+from aidants_connect_web.organisation_type_merge import (
+    apply_organisation_type_merge,
+    parse_merge_mapping_from_csv,
+    preview_organisation_type_merge,
+    write_organisation_types_csv,
+)
+from aidants_connect_web.tests.factories import (
+    OrganisationFactory,
+    OrganisationTypeFactory,
+)
+
+
+@tag("commands")
+class OrganisationTypeMergeTests(TestCase):
+    def test_export_csv_contains_audit_columns(self):
+        source_type = OrganisationTypeFactory(name="Type source")
+        target_type = OrganisationType.objects.get(
+            pk=RequestOriginConstants.ASSOCIATIONS.value
+        )
+        OrganisationFactory(type=source_type)
+        OrganisationRequestFactory(type_id=source_type.id)
+
+        output = io.StringIO()
+        write_organisation_types_csv(output)
+
+        rows = list(csv.DictReader(io.StringIO(output.getvalue())))
+        exported_source = next(row for row in rows if row["id"] == str(source_type.id))
+
+        self.assertEqual(exported_source["name"], "Type source")
+        self.assertEqual(exported_source["nb_organisations"], "1")
+        self.assertEqual(exported_source["nb_organisation_requests"], "1")
+        self.assertEqual(exported_source["is_canonical"], "no")
+        self.assertEqual(exported_source["target_id"], "")
+        self.assertTrue(
+            any(
+                row["id"] == str(target_type.id) and row["is_canonical"] == "yes"
+                for row in rows
+            )
+        )
+
+    def test_parse_mapping_ignores_empty_target_id(self):
+        csv_content = "id,name,target_id\n579,Type custom,13\n580,Autre custom,\n"
+        mapping = parse_merge_mapping_from_csv(io.StringIO(csv_content))
+
+        self.assertEqual(mapping, {579: 13})
+
+    def test_apply_merge_moves_references_and_deletes_orphans(self):
+        source_type = OrganisationTypeFactory(name="Type custom")
+        target_type = OrganisationType.objects.get(
+            pk=RequestOriginConstants.ASSOCIATIONS.value
+        )
+        organisation = OrganisationFactory(type=source_type)
+        organisation_request = OrganisationRequestFactory(type_id=source_type.id)
+
+        previews = preview_organisation_type_merge({source_type.id: target_type.id})
+        self.assertEqual(previews[0].nb_organisations, 1)
+        self.assertEqual(previews[0].nb_organisation_requests, 1)
+
+        result = apply_organisation_type_merge({source_type.id: target_type.id})
+
+        organisation.refresh_from_db()
+        organisation_request.refresh_from_db()
+        self.assertEqual(organisation.type_id, target_type.id)
+        self.assertEqual(organisation_request.type_id, target_type.id)
+        self.assertFalse(OrganisationType.objects.filter(pk=source_type.id).exists())
+        self.assertIn(source_type.id, result.deleted_orphan_type_ids)
+
+    def test_merge_command_dry_run_does_not_update_database(self):
+        source_type = OrganisationTypeFactory(name="Type custom")
+        target_type = OrganisationType.objects.get(
+            pk=RequestOriginConstants.ASSOCIATIONS.value
+        )
+        organisation = OrganisationFactory(type=source_type)
+
+        with tempfile.NamedTemporaryFile(
+            "w+", newline="", encoding="utf-8"
+        ) as csv_file:
+            csv_file.write("id,name,target_id\n")
+            csv_file.write(f"{source_type.id},Type custom,{target_type.id}\n")
+            csv_file.flush()
+
+            call_command("merge_organisation_types", csv_file.name)
+
+        organisation.refresh_from_db()
+        self.assertEqual(organisation.type_id, source_type.id)
+        self.assertTrue(OrganisationType.objects.filter(pk=source_type.id).exists())
+
+    def test_merge_command_apply_updates_database(self):
+        source_type = OrganisationTypeFactory(name="Type custom")
+        target_type = OrganisationType.objects.get(
+            pk=RequestOriginConstants.ASSOCIATIONS.value
+        )
+        organisation = OrganisationFactory(type=source_type)
+
+        with tempfile.NamedTemporaryFile(
+            "w+", newline="", encoding="utf-8"
+        ) as csv_file:
+            csv_file.write("id,name,target_id\n")
+            csv_file.write(f"{source_type.id},Type custom,{target_type.id}\n")
+            csv_file.flush()
+
+            call_command("merge_organisation_types", csv_file.name, "--apply")
+
+        organisation.refresh_from_db()
+        self.assertEqual(organisation.type_id, target_type.id)
+        self.assertFalse(OrganisationType.objects.filter(pk=source_type.id).exists())


### PR DESCRIPTION
## 🌮 Objectif

Assainir la table des types d'organisation en fusionnant ceux qui peuvent l'être

## 🔍 Implémentation

- Migration pour reprendre l'historique suite à la suppression dans l'enum [New Choices for Organisation Type](https://github.com/betagouv/Aidants_Connect/commit/dc5ac4008403a9728c3fd323b280f0c3ca3f5a35)
- Commande d'export
- Commande de merge

## ⚠️ Informations supplémentaires

Export (sort un fichier csv): 

`pipenv run python manage.py merge_organisation_types "export-orga.csv"`

Ajout des ids cible dans le fichier : 

id,name,nb_organisations,nb_organisation_requests,is_canonical,target_id
579,Assoc,1,0,no,13

Merge (dryrun par défaut)

`pipenv run python manage.py merge_organisation_types "export-orga.csv"`

Puis pour de vrai:

`pipenv run python manage.py merge_organisation_types "export-orga.csv" --apply`

